### PR TITLE
Prevent simulator from returning TPM_RC_RETRY

### DIFF
--- a/simulator/simulator.go
+++ b/simulator/simulator.go
@@ -21,7 +21,7 @@ package simulator
 // building with cgo: -Wno-unused-variable is to work around a cgo bug and
 // -Wno-strict-aliasing is due to unsafe pointer math in the TPM simulator.
 
-// #cgo CFLAGS: -DTPM_POSIX -DVTPM=NO -DUSE_BIT_FIELD_STRUCTURES=NO -Wall -Wno-expansion-to-defined -Wno-self-assign -Wno-unused-variable -Wno-strict-aliasing -Wnested-externs -Wsign-compare
+// #cgo CFLAGS: -DTPM_POSIX -DVTPM=NO -DUSE_BIT_FIELD_STRUCTURES=NO -DUSE_DA_USED=NO -Wall -Wno-expansion-to-defined -Wno-self-assign -Wno-unused-variable -Wno-strict-aliasing -Wnested-externs -Wsign-compare
 // #cgo LDFLAGS: -lcrypto -lpthread -lrt
 //
 // #include <stdlib.h>


### PR DESCRIPTION
For certain TPM2 commands like ActivateCredential or PolicySecret, the
TPM is allowed to return TPM_RC_RETRY. In this simulator, this occurs
when dictionary attack prevention mechanisms are used. Specifically,
when checking to see if the maximum number of tries has been exceeded,
the simulator returns TPM_RC_RETRY to let certain values sync to nvdata.

While this can occur on real TPMs as well, it tends not to, and g[o-tpm
does not automatically handle this case](https://github.com/google/go-tpm/issues/59). So we simply remove the above
feature.