### PR TITLE
Add tpm2tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,11 @@ This repository contains various tools designed for use with
 [Go-TPM](https://github.com/google/go-tpm):
   - [simulator](https://godoc.org/github.com/google/go-tpm-tools/simulator):
     Allows the [IBM TPM2 simulator](https://sourceforge.net/projects/ibmswtpm2/)
-    to be used with Go-TPM
+    to be used with Go-TPM.
+  - [tpm2tools](https://godoc.org/github.com/google/go-tpm-tools/tpm2tools):
+    Useful abstractions and utility functions for using TPM2. The goal of this
+    package is to handle complex TPM functionality (sessions, authorization,
+    activating credentials, etc...) for the user, presenting a simplified API.
 
 ## Legal
 

--- a/simulator/simulator_test.go
+++ b/simulator/simulator_test.go
@@ -27,6 +27,7 @@ import (
 )
 
 func getSimulator(t *testing.T) *Simulator {
+	t.Helper()
 	simulator, err := Get()
 	if err != nil {
 		t.Fatal(err)
@@ -35,6 +36,7 @@ func getSimulator(t *testing.T) *Simulator {
 }
 
 func getEKModulus(t *testing.T, rwc io.ReadWriteCloser) *big.Int {
+	t.Helper()
 	ek, err := tpm2tools.EndorsementKeyRSA(rwc)
 	if err != nil {
 		t.Fatal(err)

--- a/tpm2tools/keys.go
+++ b/tpm2tools/keys.go
@@ -1,0 +1,127 @@
+package tpm2tools
+
+import (
+	"crypto"
+	"crypto/rsa"
+	"fmt"
+	"io"
+
+	"github.com/google/go-tpm/tpm2"
+	"github.com/google/go-tpm/tpmutil"
+)
+
+// Key wraps an active TPM2 key. Users of Key should be sure to call Close()
+// when finished using the Key, so that the underlying TPM handle can be freed.
+type Key struct {
+	rw           io.ReadWriter
+	handle       tpmutil.Handle
+	pubArea      tpm2.Public
+	pubKey       crypto.PublicKey
+	creationData *tpm2.CreationData
+	creationHash []byte
+	ticket       *tpm2.Ticket
+	name         *tpm2.HashValue
+}
+
+// EndorsementKeyRSA returns the key created from DefaultEKTemplateRSA.
+func EndorsementKeyRSA(rw io.ReadWriter) (*Key, error) {
+	return EndorsementKeyFromTemplate(rw, DefaultEKTemplateRSA())
+}
+
+// EndorsementKeyFromNvIndex loads an endorsement key using the template
+// stored at the provided nvdata index. This is usefull for TPMs which have a
+// preinstalled AIK template.
+func EndorsementKeyFromNvIndex(rw io.ReadWriter, idx uint32) (*Key, error) {
+	data, err := tpm2.NVRead(rw, tpmutil.Handle(idx))
+	if err != nil {
+		return nil, fmt.Errorf("read error at index %d: %v", idx, err)
+	}
+	template, err := tpm2.DecodePublic(data)
+	if err != nil {
+		return nil, fmt.Errorf("index %d data was not a TPM key template: %v", idx, err)
+	}
+	return EndorsementKeyFromTemplate(rw, template)
+}
+
+// EndorsementKeyFromTemplate loads a primary key in the endorsement hierarchy
+// using the provided template. This function assumes that the desired key:
+//   - Does not have its usage locked to specific PCR values
+//   - Usable with empty authorization sessions (i.e. doesn't need a password)
+func EndorsementKeyFromTemplate(rw io.ReadWriter, template tpm2.Public) (*Key, error) {
+	return newPrimaryKey(rw, tpm2.HandleEndorsement, template)
+}
+
+// StorageKeyFromTemplate loads a primary key in the owner hierarchy
+// using the provided template. This function assumes that the desired key:
+//   - Does not have its usage locked to specific PCR values
+//   - Usable with empty authorization sessions (i.e. doesn't need a password)
+func StorageKeyFromTemplate(rw io.ReadWriter, template tpm2.Public) (*Key, error) {
+	return newPrimaryKey(rw, tpm2.HandleOwner, template)
+}
+
+// Wrapper around CreatePrimary used to load a key which does not need to be
+// locked to any PCRs or use any authorization sessions.
+func newPrimaryKey(rw io.ReadWriter, owner tpmutil.Handle, template tpm2.Public) (*Key, error) {
+	key := &Key{rw: rw}
+
+	var err error
+	var pubArea, creationData, name []byte
+	key.handle, pubArea, creationData, key.creationHash, key.ticket, name, err =
+		tpm2.CreatePrimaryEx(rw, owner, tpm2.PCRSelection{}, "", "", template)
+	if err != nil {
+		return nil, err
+	}
+
+	if key.pubArea, err = tpm2.DecodePublic(pubArea); err != nil {
+		return nil, err
+	}
+	if key.pubArea.Type != tpm2.AlgRSA {
+		return nil, fmt.Errorf("Keys of type %v are not yet supported", key.pubArea.Type)
+	}
+	key.pubKey = &rsa.PublicKey{
+		N: key.pubArea.RSAParameters.Modulus,
+		E: int(key.pubArea.RSAParameters.Exponent),
+	}
+	if key.creationData, err = tpm2.DecodeCreationData(creationData); err != nil {
+		return nil, err
+	}
+
+	key.name = &tpm2.HashValue{}
+	n, err := tpmutil.Unpack(name, &key.name.Alg)
+	if err != nil {
+		return nil, err
+	}
+	key.name.Value = name[n:]
+
+	hashFn, err := key.name.Alg.HashConstructor()
+	if err != nil {
+		return nil, err
+	}
+	if hashFn().Size() != len(key.name.Value) {
+		return nil, fmt.Errorf("expected name buffer of length %d, got %d", hashFn().Size(), len(key.name.Value))
+	}
+
+	return key, nil
+}
+
+// Handle allows this key to be used directly with other go-tpm commands.
+func (k *Key) Handle() tpmutil.Handle {
+	return k.handle
+}
+
+// Name is hash of this key's public area. It is useful for various TPM
+// commands related to authorization.
+func (k *Key) Name() *tpm2.HashValue {
+	return k.name
+}
+
+// PublicKey provides a go interface to the loaded key's public area.
+func (k *Key) PublicKey() crypto.PublicKey {
+	return k.pubKey
+}
+
+// Close should be called when the key is no longer needed. This is important to
+// do as most TPMs can only have a small number of key simultaneously loaded.
+func (k *Key) Close() {
+	tpm2.FlushContext(k.rw, k.handle)
+}

--- a/tpm2tools/keys.go
+++ b/tpm2tools/keys.go
@@ -20,17 +20,17 @@ type Key struct {
 	creationData *tpm2.CreationData
 	creationHash []byte
 	ticket       *tpm2.Ticket
-	name         *tpm2.HashValue
+	name         tpm2.Name
 }
 
-// EndorsementKeyRSA returns the key created from DefaultEKTemplateRSA.
+// EndorsementKeyRSA generates and loads a key from DefaultEKTemplateRSA.
 func EndorsementKeyRSA(rw io.ReadWriter) (*Key, error) {
-	return EndorsementKeyFromTemplate(rw, DefaultEKTemplateRSA())
+	return NewKey(rw, tpm2.HandleEndorsement, DefaultEKTemplateRSA())
 }
 
-// EndorsementKeyFromNvIndex loads an endorsement key using the template
-// stored at the provided nvdata index. This is usefull for TPMs which have a
-// preinstalled AIK template.
+// EndorsementKeyFromNvIndex generates and loads an endorsement key using the
+// template stored at the provided nvdata index. This is useful for TPMs which
+// have a preinstalled AIK template.
 func EndorsementKeyFromNvIndex(rw io.ReadWriter, idx uint32) (*Key, error) {
 	data, err := tpm2.NVRead(rw, tpmutil.Handle(idx))
 	if err != nil {
@@ -40,68 +40,71 @@ func EndorsementKeyFromNvIndex(rw io.ReadWriter, idx uint32) (*Key, error) {
 	if err != nil {
 		return nil, fmt.Errorf("index %d data was not a TPM key template: %v", idx, err)
 	}
-	return EndorsementKeyFromTemplate(rw, template)
+	return NewKey(rw, tpm2.HandleEndorsement, template)
 }
 
-// EndorsementKeyFromTemplate loads a primary key in the endorsement hierarchy
-// using the provided template. This function assumes that the desired key:
+// NewKey generates a key from the template and loads that key into the TPM
+// under the specified parent. NewKey can call many different TPM commands:
+//   - If parent is tpm2.Handle{Owner|Endorsement|Platform|Null} a primary key
+//     is created in the specified hierarchy (using CreatePrimary).
+//   - If parent is a valid key handle, a normal key object is created under
+//     that parent (using Create and Load). NOTE: Not yet supported.
+// This function also assumes that the desired key:
 //   - Does not have its usage locked to specific PCR values
 //   - Usable with empty authorization sessions (i.e. doesn't need a password)
-func EndorsementKeyFromTemplate(rw io.ReadWriter, template tpm2.Public) (*Key, error) {
-	return newPrimaryKey(rw, tpm2.HandleEndorsement, template)
-}
-
-// StorageKeyFromTemplate loads a primary key in the owner hierarchy
-// using the provided template. This function assumes that the desired key:
-//   - Does not have its usage locked to specific PCR values
-//   - Usable with empty authorization sessions (i.e. doesn't need a password)
-func StorageKeyFromTemplate(rw io.ReadWriter, template tpm2.Public) (*Key, error) {
-	return newPrimaryKey(rw, tpm2.HandleOwner, template)
-}
-
-// Wrapper around CreatePrimary used to load a key which does not need to be
-// locked to any PCRs or use any authorization sessions.
-func newPrimaryKey(rw io.ReadWriter, owner tpmutil.Handle, template tpm2.Public) (*Key, error) {
-	key := &Key{rw: rw}
-
-	var err error
+func NewKey(rw io.ReadWriter, parent tpmutil.Handle, template tpm2.Public) (key *Key, err error) {
+	key = &Key{rw: rw}
 	var pubArea, creationData, name []byte
-	key.handle, pubArea, creationData, key.creationHash, key.ticket, name, err =
-		tpm2.CreatePrimaryEx(rw, owner, tpm2.PCRSelection{}, "", "", template)
-	if err != nil {
-		return nil, err
+
+	if parent == tpm2.HandleOwner || parent == tpm2.HandleEndorsement ||
+		parent == tpm2.HandlePlatform || parent == tpm2.HandleNull {
+		key.handle, pubArea, creationData, key.creationHash, key.ticket, name, err =
+			tpm2.CreatePrimaryEx(rw, parent, tpm2.PCRSelection{}, "", "", template)
+		if err != nil {
+			return
+		}
+	} else {
+		// TODO add support for normal objects with Create() and Load()
+		return nil, fmt.Errorf("unsupported parent handle: %x", parent)
 	}
+
+	// Prevent leaking the handle on failure
+	defer func() {
+		if err != nil {
+			key.Close()
+		}
+	}()
 
 	if key.pubArea, err = tpm2.DecodePublic(pubArea); err != nil {
-		return nil, err
+		return
 	}
 	if key.pubArea.Type != tpm2.AlgRSA {
-		return nil, fmt.Errorf("Keys of type %v are not yet supported", key.pubArea.Type)
+		return nil, fmt.Errorf("keys of type %v are not yet supported", key.pubArea.Type)
 	}
 	key.pubKey = &rsa.PublicKey{
 		N: key.pubArea.RSAParameters.Modulus,
 		E: int(key.pubArea.RSAParameters.Exponent),
 	}
 	if key.creationData, err = tpm2.DecodeCreationData(creationData); err != nil {
-		return nil, err
+		return
 	}
 
-	key.name = &tpm2.HashValue{}
-	n, err := tpmutil.Unpack(name, &key.name.Alg)
+	key.name = tpm2.Name{Digest: &tpm2.HashValue{}}
+	n, err := tpmutil.Unpack(name, &key.name.Digest.Alg)
 	if err != nil {
-		return nil, err
+		return
 	}
-	key.name.Value = name[n:]
+	key.name.Digest.Value = name[n:]
 
-	hashFn, err := key.name.Alg.HashConstructor()
+	hashFn, err := key.name.Digest.Alg.HashConstructor()
 	if err != nil {
-		return nil, err
+		return
 	}
-	if hashFn().Size() != len(key.name.Value) {
-		return nil, fmt.Errorf("expected name buffer of length %d, got %d", hashFn().Size(), len(key.name.Value))
+	if hashFn().Size() != len(key.name.Digest.Value) {
+		return nil, fmt.Errorf("expected name buffer of length %d, got %d",
+			hashFn().Size(), len(key.name.Digest.Value))
 	}
-
-	return key, nil
+	return
 }
 
 // Handle allows this key to be used directly with other go-tpm commands.
@@ -109,9 +112,9 @@ func (k *Key) Handle() tpmutil.Handle {
 	return k.handle
 }
 
-// Name is hash of this key's public area. It is useful for various TPM
-// commands related to authorization.
-func (k *Key) Name() *tpm2.HashValue {
+// Name is hash of this key's public area. Only the Digest field will ever be
+// populated. It is useful for various TPM commands related to authorization.
+func (k *Key) Name() tpm2.Name {
 	return k.name
 }
 

--- a/tpm2tools/keys_test.go
+++ b/tpm2tools/keys_test.go
@@ -10,6 +10,7 @@ import (
 )
 
 func getEK(t *testing.T) (*simulator.Simulator, *Key) {
+	t.Helper()
 	simulator, err := simulator.Get()
 	if err != nil {
 		t.Fatal(err)

--- a/tpm2tools/keys_test.go
+++ b/tpm2tools/keys_test.go
@@ -3,6 +3,9 @@ package tpm2tools
 import (
 	"testing"
 
+	"github.com/google/go-tpm/tpm2"
+	"github.com/google/go-tpm/tpmutil"
+
 	"github.com/google/go-tpm-tools/simulator"
 )
 
@@ -30,5 +33,22 @@ func TestNameMatchesPublicArea(t *testing.T) {
 	}
 	if !matches {
 		t.Fatal("Returned name and computed name do not match")
+	}
+}
+
+func TestCreateSigningKeysInAllHierarchies(t *testing.T) {
+	simulator, err := simulator.Get()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	template := AIKTemplateRSA([256]byte{})
+	for _, hierarchy := range []tpmutil.Handle{tpm2.HandleOwner, tpm2.HandleEndorsement, tpm2.HandlePlatform, tpm2.HandleNull} {
+		key, err := NewKey(simulator, hierarchy, template)
+		if err != nil {
+			t.Errorf("Hierarchy %+v: %s", hierarchy, err)
+		} else {
+			key.Close()
+		}
 	}
 }

--- a/tpm2tools/keys_test.go
+++ b/tpm2tools/keys_test.go
@@ -1,0 +1,43 @@
+package tpm2tools
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/google/go-tpm-tools/simulator"
+)
+
+func getEK(t *testing.T) (*simulator.Simulator, *Key) {
+	simulator, err := simulator.Get()
+	if err != nil {
+		t.Fatal(err)
+	}
+	key, err := EndorsementKeyRSA(simulator)
+	if err != nil {
+		simulator.Close()
+		t.Fatal(err)
+	}
+	return simulator, key
+}
+
+func TestNameMatchesPublicArea(t *testing.T) {
+	s, ek := getEK(t)
+	defer s.Close()
+	defer ek.Close()
+
+	pubEncoded, err := ek.pubArea.Encode()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	hashFn, err := ek.pubArea.NameAlg.HashConstructor()
+	if err != nil {
+		t.Fatal(err)
+	}
+	hash := hashFn()
+
+	hash.Write(pubEncoded)
+	if !bytes.Equal(hash.Sum(nil), ek.Name().Value) {
+		t.Fatal("Returned name and computed name do not match")
+	}
+}

--- a/tpm2tools/keys_test.go
+++ b/tpm2tools/keys_test.go
@@ -1,7 +1,6 @@
 package tpm2tools
 
 import (
-	"bytes"
 	"testing"
 
 	"github.com/google/go-tpm-tools/simulator"
@@ -25,19 +24,11 @@ func TestNameMatchesPublicArea(t *testing.T) {
 	defer s.Close()
 	defer ek.Close()
 
-	pubEncoded, err := ek.pubArea.Encode()
+	matches, err := ek.Name().MatchesPublic(ek.pubArea)
 	if err != nil {
 		t.Fatal(err)
 	}
-
-	hashFn, err := ek.pubArea.NameAlg.HashConstructor()
-	if err != nil {
-		t.Fatal(err)
-	}
-	hash := hashFn()
-
-	hash.Write(pubEncoded)
-	if !bytes.Equal(hash.Sum(nil), ek.Name().Value) {
+	if !matches {
 		t.Fatal("Returned name and computed name do not match")
 	}
 }

--- a/tpm2tools/template.go
+++ b/tpm2tools/template.go
@@ -38,7 +38,7 @@ func DefaultEKTemplateRSA() tpm2.Public {
 			},
 			KeyBits:    2048,
 			Exponent:   0,
-			ModulusRaw: make([]byte, 256),
+			ModulusRaw: make([]byte, 256), // public.unique must be all zeros
 		},
 	}
 }
@@ -59,7 +59,7 @@ func AIKTemplateRSA(nonce [256]byte) tpm2.Public {
 			},
 			KeyBits:    2048,
 			Exponent:   0,
-			ModulusRaw: nonce[:],
+			ModulusRaw: nonce[:], // Use public.unique to generate distinct keys
 		},
 	}
 }

--- a/tpm2tools/template.go
+++ b/tpm2tools/template.go
@@ -1,0 +1,65 @@
+package tpm2tools
+
+import (
+	"crypto/sha256"
+
+	"github.com/google/go-tpm/tpm2"
+	"github.com/google/go-tpm/tpmutil"
+)
+
+// Calculations from Credential_Profile_EK_V2.0, section 2.1.5.3 - authPolicy
+func defaultAuthPolicy() []byte {
+	buf, err := tpmutil.Pack(tpm2.CmdPolicySecret, tpm2.HandleEndorsement)
+	if err != nil {
+		panic(err)
+	}
+	digest1 := sha256.Sum256(append(make([]byte, 32), buf...))
+	// We would normally append the policy buffer to digest1, but the
+	// policy buffer is empty for the deafult Auth Policy.
+	digest2 := sha256.Sum256(digest1[:])
+	return digest2[:]
+}
+
+// DefaultEKTemplateRSA returns the default Endorsement Key (EK) template as
+// specified in Credential_Profile_EK_V2.0, section 2.1.5.1 - authPolicy.
+// https://trustedcomputinggroup.org/wp-content/uploads/Credential_Profile_EK_V2.0_R14_published.pdf
+func DefaultEKTemplateRSA() tpm2.Public {
+	return tpm2.Public{
+		Type:    tpm2.AlgRSA,
+		NameAlg: tpm2.AlgSHA256,
+		Attributes: tpm2.FlagFixedTPM | tpm2.FlagFixedParent | tpm2.FlagSensitiveDataOrigin |
+			tpm2.FlagAdminWithPolicy | tpm2.FlagRestricted | tpm2.FlagDecrypt,
+		AuthPolicy: defaultAuthPolicy(),
+		RSAParameters: &tpm2.RSAParams{
+			Symmetric: &tpm2.SymScheme{
+				Alg:     tpm2.AlgAES,
+				KeyBits: 128,
+				Mode:    tpm2.AlgCFB,
+			},
+			KeyBits:    2048,
+			Exponent:   0,
+			ModulusRaw: make([]byte, 256),
+		},
+	}
+}
+
+// AIKTemplateRSA returns a potential Attestation Identity Key (AIK) template.
+// This is very similar to DefaultEKTemplateRSA, except that this will be a
+// signing key instead of an encrypting key. The random nonce provided allows
+// for multiple AIKs to easily cooexist on the same TPM (which only has 1 EK).
+func AIKTemplateRSA(nonce [256]byte) tpm2.Public {
+	return tpm2.Public{
+		Type:       tpm2.AlgRSA,
+		NameAlg:    tpm2.AlgSHA256,
+		Attributes: tpm2.FlagSignerDefault,
+		RSAParameters: &tpm2.RSAParams{
+			Sign: &tpm2.SigScheme{
+				Alg:  tpm2.AlgRSASSA,
+				Hash: tpm2.AlgSHA256,
+			},
+			KeyBits:    2048,
+			Exponent:   0,
+			ModulusRaw: nonce[:],
+		},
+	}
+}


### PR DESCRIPTION
This package is designed to provide helper methods to make dealing with primary keys easier.

We also update our tests to use these helper functions.