### PR TITLE
Add testing helpers and benchmarks

### DIFF
--- a/internal/test_linux.go
+++ b/internal/test_linux.go
@@ -1,0 +1,32 @@
+package internal
+
+import (
+	"flag"
+	"io"
+	"testing"
+
+	"github.com/google/go-tpm/tpm2"
+
+	"github.com/google/go-tpm-tools/simulator"
+)
+
+var tpmPath = flag.String("tpm-path", "", "Path to Linux TPM character device (i.e. /dev/tpm0 or /dev/tpmrm0). Empty value (default) will run tests against the simulator.")
+
+// GetTPM is a cross-platform testing helper function that retrives the
+// appropriate TPM device from the flags passed into "go test".
+func GetTPM(tb testing.TB) io.ReadWriteCloser {
+	tb.Helper()
+	if *tpmPath != "" {
+		rwc, err := tpm2.OpenTPM(*tpmPath)
+		if err != nil {
+			tb.Fatalf("Opening TPM at %s failed: %v", *tpmPath, err)
+		}
+		return rwc
+	}
+
+	simulator, err := simulator.Get()
+	if err != nil {
+		tb.Fatalf("Initializing simulator failed: %v", err)
+	}
+	return simulator
+}

--- a/internal/test_linux.go
+++ b/internal/test_linux.go
@@ -10,7 +10,7 @@ import (
 	"github.com/google/go-tpm-tools/simulator"
 )
 
-var tpmPath = flag.String("tpm-path", "", "Path to Linux TPM character device (i.e. /dev/tpm0 or /dev/tpmrm0). Empty value (default) will run tests against the simulator.")
+var tpmPath = flag.String("tpm_path", "", "Path to Linux TPM character device (i.e. /dev/tpm0 or /dev/tpmrm0). Empty value (default) will run tests against the simulator.")
 
 // GetTPM is a cross-platform testing helper function that retrives the
 // appropriate TPM device from the flags passed into "go test".
@@ -26,7 +26,7 @@ func GetTPM(tb testing.TB) io.ReadWriteCloser {
 
 	simulator, err := simulator.Get()
 	if err != nil {
-		tb.Fatalf("Initializing simulator failed: %v", err)
+		tb.Fatalf("Simulator initialization failed: %v", err)
 	}
 	return simulator
 }

--- a/internal/test_windows.go
+++ b/internal/test_windows.go
@@ -1,0 +1,32 @@
+package internal
+
+import (
+	"flag"
+	"io"
+	"testing"
+
+	"github.com/google/go-tpm/tpm2"
+
+	"github.com/google/go-tpm-tools/simulator"
+)
+
+var useTBS = flag.Bool("use-tbs", false, "Run the tests against the Windows TBS. Value of false (default) will run tests against the simulator.")
+
+// GetTPM is a cross-platform testing helper function that retrives the
+// appropriate TPM device from the flags passed into "go test".
+func GetTPM(tb testing.TB) io.ReadWriteCloser {
+	tb.Helper()
+	if useTBS {
+		rwc, err := tpm2.OpenTPM()
+		if err != nil {
+			tb.Fatalf("Initializing Windows TBS failed: %v", err)
+		}
+		return rwc
+	}
+
+	simulator, err := simulator.Get()
+	if err != nil {
+		tb.Fatalf("Initializing simulator failed: %v", err)
+	}
+	return simulator
+}

--- a/internal/test_windows.go
+++ b/internal/test_windows.go
@@ -10,7 +10,7 @@ import (
 	"github.com/google/go-tpm-tools/simulator"
 )
 
-var useTBS = flag.Bool("use-tbs", false, "Run the tests against the Windows TBS. Value of false (default) will run tests against the simulator.")
+var useTBS = flag.Bool("use_tbs", false, "Run the tests against the Windows TBS. Value of false (default) will run tests against the simulator.")
 
 // GetTPM is a cross-platform testing helper function that retrives the
 // appropriate TPM device from the flags passed into "go test".
@@ -19,14 +19,14 @@ func GetTPM(tb testing.TB) io.ReadWriteCloser {
 	if useTBS {
 		rwc, err := tpm2.OpenTPM()
 		if err != nil {
-			tb.Fatalf("Initializing Windows TBS failed: %v", err)
+			tb.Fatalf("Windows TBS initialization failed: %v", err)
 		}
 		return rwc
 	}
 
 	simulator, err := simulator.Get()
 	if err != nil {
-		tb.Fatalf("Initializing simulator failed: %v", err)
+		tb.Fatalf("Simulator initialization failed: %v", err)
 	}
 	return simulator
 }

--- a/tpm2tools/keys_test.go
+++ b/tpm2tools/keys_test.go
@@ -47,10 +47,9 @@ func BenchmarkEndorsementKeyRSA(b *testing.B) {
 	b.StopTimer()
 	rwc := internal.GetTPM(b)
 	defer rwc.Close()
+	b.StartTimer()
 	for n := 0; n < b.N; n++ {
-		b.StartTimer()
 		key, err := EndorsementKeyRSA(rwc)
-		b.StartTimer()
 		if err != nil {
 			b.Fatal(err)
 		}
@@ -62,10 +61,9 @@ func BenchmarkStorageRootKeyRSA(b *testing.B) {
 	b.StopTimer()
 	rwc := internal.GetTPM(b)
 	defer rwc.Close()
+	b.StartTimer()
 	for n := 0; n < b.N; n++ {
-		b.StartTimer()
 		key, err := StorageRootKeyRSA(rwc)
-		b.StopTimer()
 		if err != nil {
 			b.Fatal(err)
 		}

--- a/tpm2tools/keys_test.go
+++ b/tpm2tools/keys_test.go
@@ -42,3 +42,33 @@ func TestCreateSigningKeysInHierarchies(t *testing.T) {
 		}
 	}
 }
+
+func BenchmarkEndorsementKeyRSA(b *testing.B) {
+	b.StopTimer()
+	rwc := internal.GetTPM(b)
+	defer rwc.Close()
+	for n := 0; n < b.N; n++ {
+		b.StartTimer()
+		key, err := EndorsementKeyRSA(rwc)
+		b.StartTimer()
+		if err != nil {
+			b.Fatal(err)
+		}
+		key.Close()
+	}
+}
+
+func BenchmarkStorageRootKeyRSA(b *testing.B) {
+	b.StopTimer()
+	rwc := internal.GetTPM(b)
+	defer rwc.Close()
+	for n := 0; n < b.N; n++ {
+		b.StartTimer()
+		key, err := StorageRootKeyRSA(rwc)
+		b.StopTimer()
+		if err != nil {
+			b.Fatal(err)
+		}
+		key.Close()
+	}
+}


### PR DESCRIPTION
When testing go-tpm-tools on real hardware, I noticed that some operations take much more time to complete than others. There is also a great difference in the amount of time needed between real hardware and virtualized hardware on Google cloud. This PR should make getting performance numbers much easier.

First, a new package called `internal` is added to contain testing helper code (so that we can use it with multiple packages in go-tpm-tools, but external users can't inadvertently bring it in). Then the testing code is cleaned up to use the internal package and benchmarks.

This allows very easy benchmark testing. For example (on Linux):
```bash
# Compile the benchmarking code
-> go test ./tpm2tools -c

# Run against the simulator
-> ../tpm2tools.test -test.bench=. -test.run=^$
goos: linux
goarch: amd64
pkg: github.com/google/go-tpm-tools/tpm2tools
BenchmarkEndorsementKeyRSA-8   	     200	  14541982 ns/op
BenchmarkStorageRootKeyRSA-8   	      50	  29673783 ns/op
PASS

# Run against real hardware
-> sudo ./tpm2tools.test -test.bench=. -test.run=^$ -tpm-path=/dev/tpm0
goos: linux
goarch: amd64
pkg: github.com/google/go-tpm-tools/tpm2tools
BenchmarkEndorsementKeyRSA-8   	       1	3318950780 ns/op
BenchmarkStorageRootKeyRSA-8   	       1	7106487932 ns/op
PASS
```