### PR TITLE
Add a benchmark for null hierarchy key creations

### DIFF
--- a/tpm2tools/keys_test.go
+++ b/tpm2tools/keys_test.go
@@ -70,3 +70,19 @@ func BenchmarkStorageRootKeyRSA(b *testing.B) {
 		key.Close()
 	}
 }
+
+func BenchmarkNullSigningKeyRSA(b *testing.B) {
+	b.StopTimer()
+	rwc := internal.GetTPM(b)
+	defer rwc.Close()
+
+	template := AIKTemplateRSA([256]byte{})
+	b.StartTimer()
+	for n := 0; n < b.N; n++ {
+		key, err := NewKey(rwc, tpm2.HandleNull, template)
+		if err != nil {
+			b.Fatal(err)
+		}
+		key.Close()
+	}
+}

--- a/tpm2tools/keys_test.go
+++ b/tpm2tools/keys_test.go
@@ -75,7 +75,6 @@ func BenchmarkNullSigningKeyRSA(b *testing.B) {
 	b.StopTimer()
 	rwc := internal.GetTPM(b)
 	defer rwc.Close()
-
 	template := AIKTemplateRSA([256]byte{})
 	b.StartTimer()
 	for n := 0; n < b.N; n++ {


### PR DESCRIPTION
This will let us compare latency for RSA key creation across the three different hierarchies