### PR TITLE
Fix handle leak in TestHandles

### DIFF
--- a/tpm2tools/handles_test.go
+++ b/tpm2tools/handles_test.go
@@ -15,6 +15,16 @@ const (
 func TestHandles(t *testing.T) {
 	rwc := internal.GetTPM(t)
 	defer rwc.Close()
+	// Cleanup the transient handles before exiting the test
+	defer func() {
+		h, err := Handles(rwc, tpm2.HandleTypeTransient)
+		if err != nil {
+			t.Fatal(err)
+		}
+		for _, handle := range h {
+			tpm2.FlushContext(rwc, handle)
+		}
+	}()
 
 	for i := 0; i <= maxHandles; i++ {
 		h, err := Handles(rwc, tpm2.HandleTypeTransient)


### PR DESCRIPTION
This test (when run on real hardware) would not properly free handles.