### PR TITLE
Make `internal` flags consistent with go-tpm

### DIFF
--- a/internal/test_linux.go
+++ b/internal/test_linux.go
@@ -10,7 +10,7 @@ import (
 	"github.com/google/go-tpm-tools/simulator"
 )
 
-var tpmPath = flag.String("tpm_path", "", "Path to Linux TPM character device (i.e. /dev/tpm0 or /dev/tpmrm0). Empty value (default) will run tests against the simulator.")
+var tpmPath = flag.String("tpm-path", "", "Path to Linux TPM character device (i.e. /dev/tpm0 or /dev/tpmrm0). Empty value (default) will run tests against the simulator.")
 
 // GetTPM is a cross-platform testing helper function that retrives the
 // appropriate TPM device from the flags passed into "go test".

--- a/internal/test_windows.go
+++ b/internal/test_windows.go
@@ -10,7 +10,7 @@ import (
 	"github.com/google/go-tpm-tools/simulator"
 )
 
-var useTBS = flag.Bool("use_tbs", false, "Run the tests against the Windows TBS. Value of false (default) will run tests against the simulator.")
+var useTBS = flag.Bool("use-tbs", false, "Run the tests against the Windows TBS. Value of false (default) will run tests against the simulator.")
 
 // GetTPM is a cross-platform testing helper function that retrives the
 // appropriate TPM device from the flags passed into "go test".


### PR DESCRIPTION
The flags in github.com/google/go-tpm all use dashes, as the flags in
the `internal` package are supposed to match, they should use dashes
as well.

For example:
  - in [go-tpm-tools](https://github.com/google/go-tpm-tools/blob/f38bf7b6e5c01f2820c5ae2017ef13c639e1546e/cmd/flush_handles/flush_handles.go#L13-L19) 
  - in [go-tpm](https://github.com/google/go-tpm/blob/612987aec54bad657671bbabd215093f123d8248/examples/tpm2-ekcert/main.go#L19-L23)

Related: https://github.com/google/go-tpm/pull/69