### PR TITLE
Add get_key helper command

### DIFF
--- a/cmd/get_key/get_key.go
+++ b/cmd/get_key/get_key.go
@@ -1,0 +1,74 @@
+package main
+
+import (
+	"crypto"
+	"crypto/x509"
+	"encoding/pem"
+	"flag"
+	"fmt"
+	"io"
+	"log"
+	"os"
+
+	"github.com/google/go-tpm-tools/tpm2tools"
+	"github.com/google/go-tpm/tpm2"
+)
+
+var (
+	tpmPath   = flag.String("tpm-path", "/dev/tpm0", "Path to a TPM character device or socket.")
+	hierarchy = flag.String("hierarchy", "endorsement", "Hierarchy to use for the key. Valid options are endorsement, platform, owner, and null.")
+	index     = flag.Uint("template-index", 0, "NVRAM index of the key template; if zero, the default RSA EK/SRK template is used")
+)
+
+func main() {
+	flag.Parse()
+
+	rwc, err := tpm2.OpenTPM(*tpmPath)
+	if err != nil {
+		log.Fatalf("Failed to open TPM: %v", err)
+	}
+	defer rwc.Close()
+
+	key, err := getKey(rwc, *hierarchy, uint32(*index))
+	if err != nil {
+		log.Fatalf("Failed to read public key: %v", err)
+	}
+	defer key.Close()
+
+	if err := writeKey(key.PublicKey()); err != nil {
+		log.Fatalf("Failed to write public key: %v", err)
+	}
+}
+
+func getKey(rw io.ReadWriter, name string, idx uint32) (*tpm2tools.Key, error) {
+	switch name {
+	case "endorsement":
+		if idx == 0 {
+			return tpm2tools.EndorsementKeyRSA(rw)
+		}
+		return tpm2tools.EndorsementKeyFromNvIndex(rw, idx)
+	case "owner":
+		if idx == 0 {
+			return tpm2tools.StorageRootKeyRSA(rw)
+		}
+		return tpm2tools.KeyFromNvIndex(rw, tpm2.HandleOwner, idx)
+	case "platform":
+		return tpm2tools.KeyFromNvIndex(rw, tpm2.HandlePlatform, idx)
+	case "null":
+		return tpm2tools.KeyFromNvIndex(rw, tpm2.HandleNull, idx)
+	default:
+		return nil, fmt.Errorf("invalid hierarchy %s", name)
+	}
+}
+
+func writeKey(pubKey crypto.PublicKey) error {
+	asn1Bytes, err := x509.MarshalPKIXPublicKey(pubKey)
+	if err != nil {
+		return err
+	}
+
+	return pem.Encode(os.Stdout, &pem.Block{
+		Type:  "PUBLIC KEY",
+		Bytes: asn1Bytes,
+	})
+}

--- a/tpm2tools/keys.go
+++ b/tpm2tools/keys.go
@@ -38,6 +38,13 @@ func StorageRootKeyRSA(rw io.ReadWriter) (*Key, error) {
 // template stored at the provided nvdata index. This is useful for TPMs which
 // have a preinstalled AIK template.
 func EndorsementKeyFromNvIndex(rw io.ReadWriter, idx uint32) (*Key, error) {
+	return KeyFromNvIndex(rw, tpm2.HandleEndorsement, idx)
+}
+
+// KeyFromNvIndex generates and loads a key under the provided parent
+// (possibly a hierarchy root tpm2.Handle{Owner|Endorsement|Platform|Null})
+// using the template stored at the provided nvdata index.
+func KeyFromNvIndex(rw io.ReadWriter, parent tpmutil.Handle, idx uint32) (*Key, error) {
 	data, err := tpm2.NVRead(rw, tpmutil.Handle(idx))
 	if err != nil {
 		return nil, fmt.Errorf("read error at index %d: %v", idx, err)
@@ -46,7 +53,7 @@ func EndorsementKeyFromNvIndex(rw io.ReadWriter, idx uint32) (*Key, error) {
 	if err != nil {
 		return nil, fmt.Errorf("index %d data was not a TPM key template: %v", idx, err)
 	}
-	return NewKey(rw, tpm2.HandleEndorsement, template)
+	return NewKey(rw, parent, template)
 }
 
 // NewKey generates a key from the template and loads that key into the TPM


### PR DESCRIPTION
This makes it much more simple to get PEM formatted public keys from a
TPM without changing the TPM's state.

A KeyFromNvIndex method is also added which generalizes
EndorsementKeyFromNvIndex to other hierarchies.