### PR TITLE
Add additional documentation for the command line tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ use with [Go-TPM](https://github.com/google/go-tpm):
     with this tool allows users to address this problem with out rebooting
     their machine.
   - `get_key`: a command line tool for querying TPM2 public keys. This tool can
-    use either the default key template or a template in NVRAM to retrive PEM
+    use either the default key template or a template in NVRAM to retrieve PEM
     formatted public keys specific to a user's TPM.
 
 ## Legal

--- a/README.md
+++ b/README.md
@@ -1,14 +1,25 @@
 # Go-TPM tools
 
-This repository contains various tools designed for use with
-[Go-TPM](https://github.com/google/go-tpm):
+This repository contains various libraries and command line tools designed for
+use with [Go-TPM](https://github.com/google/go-tpm):
   - [simulator](https://godoc.org/github.com/google/go-tpm-tools/simulator):
-    Allows the [IBM TPM2 simulator](https://sourceforge.net/projects/ibmswtpm2/)
+    a Go library allowing the
+    [IBM TPM2 simulator](https://sourceforge.net/projects/ibmswtpm2/)
     to be used with Go-TPM.
   - [tpm2tools](https://godoc.org/github.com/google/go-tpm-tools/tpm2tools):
-    Useful abstractions and utility functions for using TPM2. The goal of this
-    package is to handle complex TPM functionality (sessions, authorization,
-    activating credentials, etc...) for the user, presenting a simplified API.
+    a Go library providing useful abstractions and utility functions for using a
+    TPM2. The goal of this library is to handle complex TPM functionality
+    (sessions, authorization, activating credentials, etc...), providing users
+    with a simplified API.
+  - `flush_handles`: a command line tool that flushes active TPM2 handles.
+    Sometimes, TPM commands will leave handles active after they have completed.
+    This can cause subsequent TPM commands to fail as only a fixed number
+    (usually three) of handles can be active at a given time. Flushing handles
+    with this tool allows users to address this problem with out rebooting
+    their machine.
+  - `get_key`: a command line tool for querying TPM2 public keys. This tool can
+    use either the default key template or a template in NVRAM to retrive PEM
+    formatted public keys specific to a user's TPM.
 
 ## Legal
 

--- a/cmd/flush_handles/flush_handles.go
+++ b/cmd/flush_handles/flush_handles.go
@@ -31,7 +31,7 @@ func main() {
 	if err != nil {
 		log.Fatalf("%v", err)
 	}
-	fmt.Println("%d handles successfully flushed", n)
+	fmt.Printf("%d handles successfully flushed\n", n)
 }
 
 // handleTypeFromFlags parses flag values and returns a slice of

--- a/cmd/flush_handles/flush_handles_test.go
+++ b/cmd/flush_handles/flush_handles_test.go
@@ -55,8 +55,12 @@ func TestFlush(t *testing.T) {
 		for j := 0; j < i; j++ {
 			internal.LoadRandomExternalKey(t, rwc)
 		}
-		if err := flush(rwc, tpm2.HandleTypeTransient); err != nil {
+		n, err := flush(rwc, tpm2.HandleTypeTransient)
+		if err != nil {
 			t.Fatal(err)
+		}
+		if n != i {
+			t.Errorf("Flushed %d handles, expected %d", n, i)
 		}
 	}
 

--- a/cmd/get_key/get_key.go
+++ b/cmd/get_key/get_key.go
@@ -16,11 +16,15 @@ import (
 
 var (
 	tpmPath   = flag.String("tpm-path", "/dev/tpm0", "Path to a TPM character device or socket.")
-	hierarchy = flag.String("hierarchy", "endorsement", "Hierarchy to use for the key. Valid options are endorsement, platform, owner, and null.")
-	index     = flag.Uint("template-index", 0, "NVRAM index of the key template; if zero, the default RSA EK/SRK template is used")
+	hierarchy = flag.String("hierarchy", "endorsement", "Hierarchy of the requested key. Valid options are endorsement,\nplatform, owner, and null.")
+	index     = flag.Uint("template-index", 0, "NVRAM index of the key template. If this flag is not given,\nthe default RSA EK/SRK template is used.")
 )
 
 func main() {
+	flag.Usage = func() {
+		fmt.Fprintf(flag.CommandLine.Output(), "%s - Write PEM formatted TPM public keys to stdout\n\n", os.Args[0])
+		flag.PrintDefaults()
+	}
 	flag.Parse()
 
 	rwc, err := tpm2.OpenTPM(*tpmPath)
@@ -38,6 +42,10 @@ func main() {
 	if err := writeKey(key.PublicKey()); err != nil {
 		log.Fatalf("Failed to write public key: %v", err)
 	}
+}
+
+func usage() {
+
 }
 
 func getKey(rw io.ReadWriter, name string, idx uint32) (*tpm2tools.Key, error) {

--- a/tpm2tools/template_test.go
+++ b/tpm2tools/template_test.go
@@ -1,0 +1,102 @@
+package tpm2tools
+
+import (
+	"crypto/sha256"
+	"encoding/binary"
+	"io"
+	"testing"
+
+	"github.com/google/go-tpm/tpmutil"
+
+	"github.com/google/go-tpm-tools/internal"
+	"github.com/google/go-tpm/tpm2"
+)
+
+func TestPolicyTemplate(t *testing.T) {
+	rwc := internal.GetTPM(t)
+	defer rwc.Close()
+
+	// This is just an empty/default session for appling policies
+	session, _, err := tpm2.StartAuthSession(
+		rwc,
+		tpm2.HandleNull,
+		tpm2.HandleNull,
+		make([]byte, 16),
+		/*secret=*/ nil,
+		tpm2.SessionPolicy,
+		tpm2.AlgNull,
+		tpm2.AlgSHA256)
+	if err != nil {
+		t.Fatalf("Failed to start auth session: %v", err)
+	}
+	defer tpm2.FlushContext(rwc, session)
+
+	childTemplate := DefaultEKTemplateRSA()
+	childTemplateBytes, err := childTemplate.Encode()
+	if err != nil {
+		t.Fatalf("Failed to encode child template: %v", err)
+	}
+
+	childTemplateDigest := sha256.Sum256(childTemplateBytes)
+	if err := tpm2.PolicyTemplate(rwc, session, childTemplateDigest[:]); err != nil {
+		t.Fatalf("Failed to call PolicyTemplate: %v", err)
+	}
+
+	parentTemplate := DefaultEKTemplateRSA()
+	parentTemplate.AuthPolicy = computeTemplateSessionAuth(childTemplateDigest[:])
+	parent, err := NewKey(rwc, tpm2.HandleEndorsement, parentTemplate)
+	if err != nil {
+		t.Fatalf("Failed to create parent key: %v", err)
+	}
+	defer parent.Close()
+
+	if err := createWithSessionAuth(rwc, parent, session, childTemplate); err != nil {
+		t.Fatalf("Failed to create child key: %v", err)
+	}
+}
+
+func computeTemplateSessionAuth(digest []byte) []byte {
+	hash := sha256.New()
+
+	hash.Write(make([]byte, sha256.Size))
+	binary.Write(hash, binary.BigEndian, tpm2.CmdPolicyTemplate)
+	hash.Write(digest)
+
+	return hash.Sum(nil)
+}
+
+func createWithSessionAuth(rw io.ReadWriter, parent *Key, session tpmutil.Handle, childTemplate tpm2.Public) error {
+	// authBuf, err := tpmutil.Pack(tpm2.AuthCommand{Session: session, Attributes: tpm2.AttrContinueSession})
+	// if err != nil {
+	// 	return fmt.Errorf("encoding authorization buffer: %v", err)
+	// }
+
+	// resp, code, err := tpmutil.RunCommand(
+	// 	rw, tpm2.TagSessions, tpm2.CmdCreate,
+	// 	parent.Handle(),
+	// 	uint32(len(authBuf)), tpmutil.RawBytes(authBuf),
+	// 	make([]byte, 4), // Empty sensitive area
+	// 	childTemplate,
+	// 	[]byte(nil),     // Empty outside info
+	// 	uint32(0),       // Empty PCR list
+	// )
+	// if err != nil {
+	// 	return err
+	// }
+	// if code != tpmutil.RCSuccess {
+	// 	return fmt.Errorf("response status 0x%x", code)
+	// }
+
+	// var childHandle tpmutil.Handle
+	// if _, err := tpmutil.Unpack(resp, &childHandle); err != nil {
+	// 	return fmt.Errorf("decoding handle: %v", err)
+	// }
+
+	// return tpm2.FlushContext(rw, childHandle)
+
+	handle, _, _, _, _, _, err := tpm2.CreateWithSession(rw, parent.Handle(), session, childTemplate)
+	if err != nil {
+		return err
+	}
+	return tpm2.FlushContext(rw, handle)
+}


### PR DESCRIPTION
The `README` now discusses the two tools that live in `cmd`. It also make the `--help` output for these commands more informative and readable. Specifically:

```bash
> get_key --help
get_key - Write PEM formatted TPM public keys to stdout

  -hierarchy string
    	Hierarchy of the requested key. Valid options are endorsement,
    	platform, owner, and null. (default "endorsement")
  -template-index uint
    	NVRAM index of the key template. If this flag is not given,
    	the default RSA EK/SRK template is used.
  -tpm-path string
    	Path to a TPM character device or socket. (default "/dev/tpm0")
```

```bash
> flush_handles --help
flush_handles - Flush active TPM handles from the device

  -flush-all-types
    	Flush handles of all handle types. If enabled,
    	settings for other handle types are ignored.
  -flush-loaded-session
    	Flush all loaded session handles.
  -flush-saved-session
    	Flush all saved session handles.
  -flush-transient
    	Flush all transient handles. (default true)
  -tpm-path string
    	Path to a TPM character device or socket. (default "/dev/tpm0")
```