### PR TITLE
Introduce CheckedClose

### DIFF
--- a/gotpm/tests/flush_test.go
+++ b/gotpm/tests/flush_test.go
@@ -12,7 +12,7 @@ import (
 
 func TestFlushNothing(t *testing.T) {
 	rwc := internal.GetTPM(t)
-	defer rwc.Close()
+	defer tpm2tools.CheckedClose(t, rwc)
 	cmd.ExternalTPM = rwc
 
 	cmd.RootCmd.SetArgs([]string{"flush", "all", "--quiet"})
@@ -23,7 +23,7 @@ func TestFlushNothing(t *testing.T) {
 
 func TestFlush(t *testing.T) {
 	rwc := internal.GetTPM(t)
-	defer rwc.Close()
+	defer tpm2tools.CheckedClose(t, rwc)
 	cmd.ExternalTPM = rwc
 
 	cmd.RootCmd.SetArgs([]string{"flush", "transient", "--quiet"})

--- a/simulator/simulator_test.go
+++ b/simulator/simulator_test.go
@@ -48,7 +48,7 @@ func getEKModulus(t *testing.T, rwc io.ReadWriteCloser) *big.Int {
 
 func TestResetDoesntChangeEK(t *testing.T) {
 	s := getSimulator(t)
-	defer s.Close()
+	defer tpm2tools.CheckedClose(t, s)
 
 	modulus1 := getEKModulus(t, s)
 	if err := s.Reset(); err != nil {
@@ -62,7 +62,7 @@ func TestResetDoesntChangeEK(t *testing.T) {
 }
 func TestManufactureResetChangesEK(t *testing.T) {
 	s := getSimulator(t)
-	defer s.Close()
+	defer tpm2tools.CheckedClose(t, s)
 
 	modulus1 := getEKModulus(t, s)
 	if err := s.ManufactureReset(); err != nil {
@@ -77,7 +77,7 @@ func TestManufactureResetChangesEK(t *testing.T) {
 
 func TestGetRandom(t *testing.T) {
 	s := getSimulator(t)
-	defer s.Close()
+	defer tpm2tools.CheckedClose(t, s)
 	result, err := tpm2.GetRandom(s, 10)
 	if err != nil {
 		t.Fatalf("GetRandom: %v", err)
@@ -97,7 +97,7 @@ func TestFixedSeedExpectedModulus(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer s.Close()
+	defer tpm2tools.CheckedClose(t, s)
 
 	modulus := getEKModulus(t, s)
 	if modulus.Cmp(zeroSeedModulus()) != 0 {
@@ -110,7 +110,7 @@ func TestDifferentSeedDifferentModulus(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer s.Close()
+	defer tpm2tools.CheckedClose(t, s)
 
 	modulus := getEKModulus(t, s)
 	if modulus.Cmp(zeroSeedModulus()) == 0 {

--- a/tpm2tools/close.go
+++ b/tpm2tools/close.go
@@ -1,0 +1,29 @@
+package tpm2tools
+
+import (
+	"io"
+	"testing"
+
+	"github.com/google/go-tpm/tpm2"
+)
+
+// CheckedClose closes the simluator and asserts that there were no leaked handles.
+func CheckedClose(tb testing.TB, rwc io.ReadWriteCloser) {
+	for _, t := range []tpm2.HandleType{
+		tpm2.HandleTypeLoadedSession,
+		tpm2.HandleTypeSavedSession,
+		tpm2.HandleTypeTransient,
+	} {
+		handles, err := Handles(rwc, t)
+		if err != nil {
+			tb.Fatalf("failed to fetch handles of type %v: %v", t, err)
+		}
+		if len(handles) != 0 {
+			tb.Errorf("tests leaked handles: %v", handles)
+		}
+	}
+
+	if err := rwc.Close(); err != nil {
+		tb.Errorf("failed to close simulator: %v", err)
+	}
+}

--- a/tpm2tools/keys_test.go
+++ b/tpm2tools/keys_test.go
@@ -11,7 +11,7 @@ import (
 
 func TestNameMatchesPublicArea(t *testing.T) {
 	rwc := internal.GetTPM(t)
-	defer rwc.Close()
+	defer CheckedClose(t, rwc)
 	ek, err := EndorsementKeyRSA(rwc)
 	if err != nil {
 		t.Fatal(err)
@@ -29,7 +29,7 @@ func TestNameMatchesPublicArea(t *testing.T) {
 
 func TestCreateSigningKeysInHierarchies(t *testing.T) {
 	rwc := internal.GetTPM(t)
-	defer rwc.Close()
+	defer CheckedClose(t, rwc)
 	template := AIKTemplateRSA([256]byte{})
 
 	// We are not authorized to create keys in the Platform Hierarchy
@@ -46,7 +46,7 @@ func TestCreateSigningKeysInHierarchies(t *testing.T) {
 func BenchmarkEndorsementKeyRSA(b *testing.B) {
 	b.StopTimer()
 	rwc := internal.GetTPM(b)
-	defer rwc.Close()
+	defer CheckedClose(b, rwc)
 	b.StartTimer()
 	for n := 0; n < b.N; n++ {
 		key, err := EndorsementKeyRSA(rwc)
@@ -60,7 +60,7 @@ func BenchmarkEndorsementKeyRSA(b *testing.B) {
 func BenchmarkStorageRootKeyRSA(b *testing.B) {
 	b.StopTimer()
 	rwc := internal.GetTPM(b)
-	defer rwc.Close()
+	defer CheckedClose(b, rwc)
 	b.StartTimer()
 	for n := 0; n < b.N; n++ {
 		key, err := StorageRootKeyRSA(rwc)
@@ -74,7 +74,7 @@ func BenchmarkStorageRootKeyRSA(b *testing.B) {
 func BenchmarkNullSigningKeyRSA(b *testing.B) {
 	b.StopTimer()
 	rwc := internal.GetTPM(b)
-	defer rwc.Close()
+	defer CheckedClose(b, rwc)
 	template := AIKTemplateRSA([256]byte{})
 	b.StartTimer()
 	for n := 0; n < b.N; n++ {

--- a/tpm2tools/seal_test.go
+++ b/tpm2tools/seal_test.go
@@ -13,7 +13,7 @@ import (
 
 func TestSeal(t *testing.T) {
 	rwc := internal.GetTPM(t)
-	defer rwc.Close()
+	defer CheckedClose(t, rwc)
 
 	key, err := StorageRootKeyRSA(rwc)
 	if err != nil {
@@ -53,7 +53,7 @@ func TestSeal(t *testing.T) {
 
 func TestComputeSessionAuth(t *testing.T) {
 	rwc := internal.GetTPM(t)
-	defer rwc.Close()
+	defer CheckedClose(t, rwc)
 
 	pcrList := []int{1, 7}
 
@@ -85,7 +85,7 @@ func TestComputeSessionAuth(t *testing.T) {
 
 func TestSelfReseal(t *testing.T) {
 	rwc := internal.GetTPM(t)
-	defer rwc.Close()
+	defer CheckedClose(t, rwc)
 
 	key, err := StorageRootKeyRSA(rwc)
 	if err != nil {
@@ -143,7 +143,7 @@ func computePCRValue(base []byte, extensions [][]byte) []byte {
 
 func TestComputePCRValue(t *testing.T) {
 	rwc := internal.GetTPM(t)
-	defer rwc.Close()
+	defer CheckedClose(t, rwc)
 
 	pcrNum := 23
 	extensions := [][]byte{
@@ -178,7 +178,7 @@ func TestComputePCRValue(t *testing.T) {
 
 func TestReseal(t *testing.T) {
 	rwc := internal.GetTPM(t)
-	defer rwc.Close()
+	defer CheckedClose(t, rwc)
 
 	key, err := StorageRootKeyRSA(rwc)
 	if err != nil {


### PR DESCRIPTION
Based off of https://github.com/google/go-tpm-tools/pull/15, but we make the helper public so that the `cmd` tests will also be able to use it.

Tests can now enforce error checking on tpm close.
Tests can now fail if they leak TPM Handles.

Introducing this actually found a bug in [tpm2tools.TestHandles](https://github.com/google/go-tpm-tools/blob/ebf984d5e19b25a44323df04356caf1908a95cd6/tpm2tools/handles_test.go#L17-L40). This bug has been fixed to properly clear the handles.

We also fixed an issue in NewKey that was sometimes not clearing a key.