### PR TITLE
Support persisting defualt EK-RSA and SRK-RSA

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 gotpm/gotpm*
 gotpm/tests/tests.test*
+tpm2tools/tpm2tools.test*
 .vscode*

--- a/tpm2tools/handles.go
+++ b/tpm2tools/handles.go
@@ -9,6 +9,17 @@ import (
 	"github.com/google/go-tpm/tpmutil"
 )
 
+// Reserved Handles from "TCG TPM v2.0 Provisioning Guidance" - v1r1 - Table 2
+const (
+	EKReservedHandle  = tpmutil.Handle(0x81010001)
+	SRKReservedHandle = tpmutil.Handle(0x81000001)
+)
+
+func isHierarchy(h tpmutil.Handle) bool {
+	return h == tpm2.HandleOwner || h == tpm2.HandleEndorsement ||
+		h == tpm2.HandlePlatform || h == tpm2.HandleNull
+}
+
 // Handles returns a slice of tpmutil.Handle objects of all handles within
 // the TPM rw of type handleType.
 func Handles(rw io.ReadWriter, handleType tpm2.HandleType) ([]tpmutil.Handle, error) {


### PR DESCRIPTION
Addresses some of the performance concerns in #24 

The `EndorsementKeyRSA` and `StorageRootKeyRSA` command will now look in the standard locations for a persisted handle, creating one if it does not exist.

The tests all pass against the simulator and a real TPM. I also confirmed that the commands correctly picked up the cached keys on a machine that already had the SRK/EK provisioned. 

This massively improves the time to get an EK or an SRK on a wide variety of platforms:

## 8 CPU Real Machine - Simulator
```
BenchmarkRSAKeyCreation/SRK-Cached-8         	  200000	     11849 ns/op
BenchmarkRSAKeyCreation/EK-Cached-8          	  100000	     13871 ns/op
BenchmarkRSAKeyCreation/SRK-Uncached-8       	     100	  23866486 ns/op
BenchmarkRSAKeyCreation/EK-Uncached-8        	     100	  10798069 ns/op
BenchmarkRSAKeyCreation/Null-Uncached-8      	     100	  16286958 ns/op
```

## 8 CPU Real Machine - Real TPM
```
BenchmarkRSAKeyCreation/SRK-Cached-8         	     500	   3089347 ns/op
BenchmarkRSAKeyCreation/EK-Cached-8          	     500	   3140839 ns/op
BenchmarkRSAKeyCreation/SRK-Uncached-8       	       1	2324773609 ns/op
BenchmarkRSAKeyCreation/EK-Uncached-8        	       1	3047484460 ns/op
BenchmarkRSAKeyCreation/Null-Uncached-8      	       1	2881086590 ns/op
```

## 1 vCPU GCE VM - vTPM
```
BenchmarkRSAKeyCreation/SRK-Cached         	     200	   8122555 ns/op
BenchmarkRSAKeyCreation/EK-Cached          	     200	   8098916 ns/op
BenchmarkRSAKeyCreation/SRK-Uncached       	     100	 153429721 ns/op
BenchmarkRSAKeyCreation/EK-Uncached        	     100	 131092148 ns/op
BenchmarkRSAKeyCreation/Null-Uncached      	      20	  67895521 ns/op
```