### PR TITLE
Enable NIST P-224 and P-521

### DIFF
--- a/simulator/internal/internal.go
+++ b/simulator/internal/internal.go
@@ -37,6 +37,8 @@ package internal
 // #cgo CFLAGS: -DRUNTIME_SIZE_CHECKS=DEBUG
 // #cgo CFLAGS: -DUSE_DA_USED=NO
 // #cgo CFLAGS: -DCERTIFYX509_DEBUG=NO
+// #cgo CFLAGS: -DECC_NIST_P224=YES
+// #cgo CFLAGS: -DECC_NIST_P521=YES
 // #cgo LDFLAGS: -lcrypto
 //
 // #include <stdlib.h>


### PR DESCRIPTION
These ECC curves are implemented in the standard library, so we should enable them.