### PR TITLE
Add support for importing using ECC EKs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,10 +2,8 @@ module github.com/google/go-tpm-tools
 
 go 1.12
 
-replace github.com/google/go-tpm => ../go-tpm
-
 require (
 	github.com/golang/protobuf v1.3.2
-	github.com/google/go-tpm v0.2.1-0.20190910203116-33a9c3f38379
+	github.com/google/go-tpm v0.2.1-0.20190926184827-9f71d680f4ab
 	github.com/spf13/cobra v0.0.5
 )

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,8 @@ module github.com/google/go-tpm-tools
 
 go 1.12
 
+replace github.com/google/go-tpm => ../go-tpm
+
 require (
 	github.com/golang/protobuf v1.3.2
 	github.com/google/go-tpm v0.2.1-0.20190910203116-33a9c3f38379

--- a/go.sum
+++ b/go.sum
@@ -34,7 +34,16 @@ github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXf
 github.com/ugorji/go/codec v0.0.0-20181204163529-d75b2dcb6bc8/go.mod h1:VFNgLljTbGfSG7qAOspJ7OScBnGdDN/yBr0sguwnwf0=
 github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77/go.mod h1:aYKd//L2LvnjZzWKhF00oedf4jCCReLcmhLdhm1A27Q=
 golang.org/x/crypto v0.0.0-20181203042331-505ab145d0a9/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
+golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
+golang.org/x/lint v0.0.0-20190909230951-414d861bb4ac/go.mod h1:6SW0HCj/g11FgYtHlgUYUwCkIfeOF89ocIRzGO/8vkc=
+golang.org/x/net v0.0.0-20190311183353-d8887717615a/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
+golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
+golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20181205085412-a5c9d58dba9a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
+golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
+golang.org/x/tools v0.0.0-20190311212946-11955173bddd/go.mod h1:LCzVGOaR6xXOjkQ3onu1FJEFr0SW1gC7cKk1uF8kGRs=
+golang.org/x/tools v0.0.0-20190917162342-3b4f30a44f3b/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
+golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/go.sum
+++ b/go.sum
@@ -13,6 +13,8 @@ github.com/google/go-tpm v0.1.2-0.20190725015402-ae6dd98980d4 h1:GNNkIb6NSjYfw+K
 github.com/google/go-tpm v0.1.2-0.20190725015402-ae6dd98980d4/go.mod h1:H9HbmUG2YgV/PHITkO7p6wxEEj/v5nlsVWIwumwH2NI=
 github.com/google/go-tpm v0.2.1-0.20190910203116-33a9c3f38379 h1:spUrNOxKZPzgPd/K9rAXoJ1BfHXTnuI2vT7zUkonnZM=
 github.com/google/go-tpm v0.2.1-0.20190910203116-33a9c3f38379/go.mod h1:gTv8GNuqS7CI+tQWrpt5BMMaD5W3G+dZULQLhhAKT5c=
+github.com/google/go-tpm v0.2.1-0.20190926184827-9f71d680f4ab h1:n0a1xd4IaX8uK/HK5C18vIAog4AJF0WEx39keoHAu8M=
+github.com/google/go-tpm v0.2.1-0.20190926184827-9f71d680f4ab/go.mod h1:gTv8GNuqS7CI+tQWrpt5BMMaD5W3G+dZULQLhhAKT5c=
 github.com/google/go-tpm-tools v0.0.0-20190906225433-1614c142f845/go.mod h1:AVfHadzbdzHo54inR2x1v640jdi1YSi3NauM2DUsxk0=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=

--- a/server/import.go
+++ b/server/import.go
@@ -182,7 +182,7 @@ func encryptSecret(secret, seed, nameEncoded []byte, hashAlg tpm2.Algorithm) ([]
 		"STORAGE",
 		nameEncoded,
 		/*contextV=*/ nil,
-		len(seed)*8)
+		len(seed)*4)
 	if err != nil {
 		return nil, err
 	}

--- a/server/import.go
+++ b/server/import.go
@@ -120,19 +120,19 @@ func createECCSeed(ek tpm2.Public) (seed, encryptedSeed []byte, err error) {
 	}
 	ekPoint := ek.ECCParameters.Point
 	z, _ := curve.ScalarMult(ekPoint.X(), ekPoint.Y(), priv)
-	xBytes := eccIntToBytes(x, curve)
+	xBytes := eccIntToBytes(curve, x)
 
 	seed, err = tpm2.KDFe(
 		ek.NameAlg,
-		eccIntToBytes(z, curve),
+		eccIntToBytes(curve, z),
 		"DUPLICATE",
 		xBytes,
-		eccIntToBytes(ekPoint.X(), curve),
+		eccIntToBytes(curve, ekPoint.X()),
 		getHash(ek.NameAlg).Size()*8)
 	if err != nil {
 		return nil, nil, err
 	}
-	encryptedSeed, err = tpmutil.Pack(tpmutil.U16Bytes(xBytes), tpmutil.U16Bytes(eccIntToBytes(y, curve)))
+	encryptedSeed, err = tpmutil.Pack(tpmutil.U16Bytes(xBytes), tpmutil.U16Bytes(eccIntToBytes(curve, y)))
 	return seed, encryptedSeed, err
 }
 

--- a/server/import.go
+++ b/server/import.go
@@ -139,7 +139,7 @@ func createECCSeed(ek tpm2.Public) (seed, encryptedSeed []byte, err error) {
 		"DUPLICATE",
 		xPad,
 		eccIntToBytes(ekPoint.X(), curve),
-		getHash(ek.NameAlg).Size())
+		getHash(ek.NameAlg).Size()*8)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/server/import.go
+++ b/server/import.go
@@ -35,7 +35,19 @@ func CreateImportBlob(ekPub crypto.PublicKey, sensitive []byte) (*proto.ImportBl
 			return nil, err
 		}
 	} else if ek.Type == tpm2.AlgECC {
-		curve := elliptic.P256() // TODO Get from ek.
+		var curve elliptic.Curve
+		switch ek.ECCParameters.CurveID {
+		case tpm2.CurveNISTP224:
+			curve = elliptic.P224()
+		case tpm2.CurveNISTP256:
+			curve = elliptic.P256()
+		case tpm2.CurveNISTP384:
+			curve = elliptic.P384()
+		case tpm2.CurveNISTP521:
+			curve = elliptic.P521()
+		default:
+			return nil, fmt.Errorf("unsupported elliptic curve: %v", ek.ECCParameters.CurveID)
+		}
 		priv, x, y, err := elliptic.GenerateKey(curve, rand.Reader)
 		if err != nil {
 			return nil, err

--- a/server/import.go
+++ b/server/import.go
@@ -61,19 +61,13 @@ func CreateImportBlob(ekPub crypto.PublicKey, sensitive []byte) (*proto.ImportBl
 			"DUPLICATE",
 			x.Bytes(),
 			ekPoint.X().Bytes(),
-			256)
-//			int(ek.ECCParameters.Symmetric.KeyBits))
+			getHash(ek.NameAlg).Size() * 8)
 		if err != nil {
 			return nil, err
 		}
 		encryptedSeed, err = tpmutil.Pack(tpmutil.U16Bytes(x.Bytes()), tpmutil.U16Bytes(y.Bytes()))
 		if err != nil {
 			return nil, fmt.Errorf("err: %v", err)
-		}
-		if len(encryptedSeed) != 128 {
-	//		encryptedSeed = append(make([]byte, 128-len(encryptedSeed)), encryptedSeed...)
-	//		encryptedSeed = append(encryptedSeed, make([]byte, 128-len(encryptedSeed))...)
-		//	return nil, fmt.Errorf("size %v", len(encryptedSeed))
 		}
 	}
 	duplicate, err := createDuplicate(private, seed, public, ek.NameAlg)

--- a/server/import.go
+++ b/server/import.go
@@ -178,6 +178,8 @@ func encryptSecret(secret, seed, nameEncoded []byte, ek tpm2.Public) ([]byte, er
 		symSize = int(ek.RSAParameters.Symmetric.KeyBits)
 	case tpm2.AlgECC:
 		symSize = int(ek.ECCParameters.Symmetric.KeyBits)
+	default:
+		return nil, fmt.Errorf("unsupported EK type: %v", ek.Type)
 	}
 
 	symmetricKey, err := tpm2.KDFa(

--- a/server/import_test.go
+++ b/server/import_test.go
@@ -9,14 +9,6 @@ import (
 	"github.com/google/go-tpm/tpm2"
 )
 
-func getECCTemplate(curve tpm2.EllipticCurve) tpm2.Public {
-	public := tpm2tools.DefaultEKTemplateECC()
-	public.ECCParameters.CurveID = curve
-	public.ECCParameters.Point.XRaw = nil
-	public.ECCParameters.Point.YRaw = nil
-	return public
-}
-
 func TestImport(t *testing.T) {
 	rwc := internal.GetTPM(t)
 	defer tpm2tools.CheckedClose(t, rwc)

--- a/server/import_test.go
+++ b/server/import_test.go
@@ -6,29 +6,52 @@ import (
 
 	"github.com/google/go-tpm-tools/internal"
 	"github.com/google/go-tpm-tools/tpm2tools"
+	"github.com/google/go-tpm/tpm2"
 )
+
+func getECCTemplate(curve tpm2.EllipticCurve) tpm2.Public {
+	public := tpm2tools.DefaultEKTemplateECC()
+	public.ECCParameters.CurveID = curve
+	public.ECCParameters.Point.XRaw = nil
+	public.ECCParameters.Point.YRaw = nil
+	return public
+}
 
 func TestImport(t *testing.T) {
 	rwc := internal.GetTPM(t)
 	defer tpm2tools.CheckedClose(t, rwc)
+	tests := []struct {
+		name     string
+		template tpm2.Public
+	}{
+		{"RSA", tpm2tools.DefaultEKTemplateRSA()},
+		{"ECC", tpm2tools.DefaultEKTemplateECC()},
+		{"ECC-P224", getECCTemplate(tpm2.CurveNISTP224)},
+		{"ECC-P256", getECCTemplate(tpm2.CurveNISTP256)},
+		{"ECC-P384", getECCTemplate(tpm2.CurveNISTP384)},
+		{"ECC-P521", getECCTemplate(tpm2.CurveNISTP521)},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			ek, err := tpm2tools.NewKey(rwc, tpm2.HandleEndorsement, test.template)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer ek.Close()
+			pub := ek.PublicKey()
+			secret := []byte("super secret code")
+			blob, err := CreateImportBlob(pub, secret)
+			if err != nil {
+				t.Fatalf("creating import blob failed: %v", err)
+			}
 
-	ek, err := tpm2tools.EndorsementKeyRSA(rwc)
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer ek.Close()
-	pub := ek.PublicKey()
-	secret := []byte("super secret code")
-	blob, err := CreateImportBlob(pub, secret)
-	if err != nil {
-		t.Fatalf("creating import blob failed: %v", err)
-	}
-
-	output, err := ek.Import(rwc, blob)
-	if err != nil {
-		t.Fatalf("import failed: %v", err)
-	}
-	if !bytes.Equal(output, secret) {
-		t.Errorf("got %X, expected %X", output, secret)
+			output, err := ek.Import(rwc, blob)
+			if err != nil {
+				t.Fatalf("import failed: %v", err)
+			}
+			if !bytes.Equal(output, secret) {
+				t.Errorf("got %X, expected %X", output, secret)
+			}
+		})
 	}
 }

--- a/server/key_conversion_test.go
+++ b/server/key_conversion_test.go
@@ -7,7 +7,6 @@ import (
 	"crypto/rand"
 	"crypto/rsa"
 	"testing"
-	"fmt"
 
 	"github.com/google/go-tpm-tools/internal"
 	"github.com/google/go-tpm-tools/tpm2tools"
@@ -101,29 +100,4 @@ func TestCreateEKPublicAreaFromKeyTPMKey(t *testing.T) {
 			}
 		})
 	}
-}
-
-// TODO THIS TEST FAILS SOMETIMES. DO NOT SUBMIT.
-func TestCreateEKPublicAreaFromKeyTPMKeyECC(t *testing.T) {
-	fmt.Println("running ECC")
-	rwc := internal.GetTPM(t)
-	defer tpm2tools.CheckedClose(t, rwc)
-    public := tpm2tools.DefaultEKTemplateECC()
-    public.ECCParameters.CurveID = tpm2.CurveNISTP521
-    public.ECCParameters.Point.XRaw = nil
-    public.ECCParameters.Point.YRaw = nil
-	ek, err := tpm2tools.NewKey(rwc, tpm2.HandleEndorsement, public)
-
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer ek.Close()
-	newArea, err := CreateEKPublicAreaFromKey(ek.PublicKey())
-	if err != nil {
-		t.Fatalf("failed to create public area from public key: %v", err)
-	}
-	if matches, err := ek.Name().MatchesPublic(newArea); !matches || err != nil {
-		t.Error("public areas did not match or match check failed.")
-	}
-
 }


### PR DESCRIPTION
This change adds support for importing using an ECC EK.

Supports NIST-P224, NIST-P256, NIST-P384, and NIST-P521. 