### PR TITLE
Add ECC EK conversion

### DIFF
--- a/server/ecc_utils.go
+++ b/server/ecc_utils.go
@@ -1,0 +1,54 @@
+package server
+
+import (
+	"crypto/elliptic"
+	"fmt"
+	"math/big"
+
+	"github.com/google/go-tpm-tools/tpm2tools"
+	"github.com/google/go-tpm/tpm2"
+)
+
+// ECC coordinates need to maintain a specific size based on the curve, so we pad the front with zeros.
+func eccIntToBytes(key *big.Int, curve elliptic.Curve) []byte {
+	bytes := key.Bytes()
+	return append(make([]byte, (curve.Params().BitSize+7)/8-len(bytes)), bytes...)
+}
+
+func curveIDToGoCurve(curve tpm2.EllipticCurve) (elliptic.Curve, error) {
+	switch curve {
+	case tpm2.CurveNISTP224:
+		return elliptic.P224(), nil
+	case tpm2.CurveNISTP256:
+		return elliptic.P256(), nil
+	case tpm2.CurveNISTP384:
+		return elliptic.P384(), nil
+	case tpm2.CurveNISTP521:
+		return elliptic.P521(), nil
+	default:
+		return nil, fmt.Errorf("unsupported curve: %v", curve)
+	}
+}
+
+func goCurveToCurveID(curve elliptic.Curve) (tpm2.EllipticCurve, error) {
+	switch curve.Params().Name {
+	case "P-224":
+		return tpm2.CurveNISTP224, nil
+	case "P-256":
+		return tpm2.CurveNISTP256, nil
+	case "P-384":
+		return tpm2.CurveNISTP384, nil
+	case "P-521":
+		return tpm2.CurveNISTP521, nil
+	default:
+		return 0, fmt.Errorf("unsupported curve: %v", curve.Params().Name)
+	}
+}
+
+func getECCTemplate(curve tpm2.EllipticCurve) tpm2.Public {
+	public := tpm2tools.DefaultEKTemplateECC()
+	public.ECCParameters.CurveID = curve
+	public.ECCParameters.Point.XRaw = nil
+	public.ECCParameters.Point.YRaw = nil
+	return public
+}

--- a/server/ecc_utils.go
+++ b/server/ecc_utils.go
@@ -10,9 +10,10 @@ import (
 
 // ECC coordinates need to maintain a specific size based on the curve, so we pad the front with zeros.
 // This is particularly an issue for NIST-P521 coordinates, as they are frequently missing their first byte.
-func eccIntToBytes(key *big.Int, curve elliptic.Curve) []byte {
-	bytes := key.Bytes()
-	return append(make([]byte, (curve.Params().BitSize+7)/8-len(bytes)), bytes...)
+func eccIntToBytes(curve elliptic.Curve, i *big.Int) []byte {
+	bytes := i.Bytes()
+	curveBytes := (curve.Params().BitSize + 7) / 8
+	return append(make([]byte, curveBytes-len(bytes)), bytes...)
 }
 
 func curveIDToGoCurve(curve tpm2.EllipticCurve) (elliptic.Curve, error) {
@@ -26,7 +27,7 @@ func curveIDToGoCurve(curve tpm2.EllipticCurve) (elliptic.Curve, error) {
 	case tpm2.CurveNISTP521:
 		return elliptic.P521(), nil
 	default:
-		return nil, fmt.Errorf("unsupported curve: %v", curve)
+		return nil, fmt.Errorf("unsupported TPM2 curve: %v", curve)
 	}
 }
 
@@ -41,6 +42,6 @@ func goCurveToCurveID(curve elliptic.Curve) (tpm2.EllipticCurve, error) {
 	case elliptic.P521().Params().Name:
 		return tpm2.CurveNISTP521, nil
 	default:
-		return 0, fmt.Errorf("unsupported curve: %v", curve.Params().Name)
+		return 0, fmt.Errorf("unsupported Go curve: %v", curve.Params().Name)
 	}
 }

--- a/server/key_conversion.go
+++ b/server/key_conversion.go
@@ -11,7 +11,7 @@ import (
 )
 
 // CreateEKPublicAreaFromKey creates a public area from a go interface PublicKey.
-// Currently only supports RSA keys.
+// Supports RSA and ECC keys.
 func CreateEKPublicAreaFromKey(k crypto.PublicKey) (tpm2.Public, error) {
 	switch key := k.(type) {
 	case *rsa.PublicKey:

--- a/server/key_conversion.go
+++ b/server/key_conversion.go
@@ -37,14 +37,10 @@ func createEKPublicRSA(rsaKey *rsa.PublicKey) (tpm2.Public, error) {
 
 func createEKPublicECC(eccKey *ecdsa.PublicKey) (public tpm2.Public, err error) {
 	public = tpm2tools.DefaultEKTemplateECC()
-	public.ECCParameters.CurveID, err = goCurveToCurveID(eccKey)
-	if err != nil {
-		return tpm2.Public{}, err
-	}
-
 	public.ECCParameters.Point = tpm2.ECPoint{
-		XRaw: eccIntToBytes(eccKey.X, eccKey),
-		YRaw: eccIntToBytes(eccKey.Y, eccKey),
+		XRaw: eccIntToBytes(eccKey.Curve, eccKey.X),
+		YRaw: eccIntToBytes(eccKey.Curve, eccKey.Y),
 	}
-	return public, nil
+	public.ECCParameters.CurveID, err = goCurveToCurveID(eccKey.Curve)
+	return public, err
 }

--- a/server/key_conversion_test.go
+++ b/server/key_conversion_test.go
@@ -22,14 +22,13 @@ func getECCTemplate(curve tpm2.EllipticCurve) tpm2.Public {
 }
 
 func TestCreateEKPublicAreaFromKeyGeneratedKey(t *testing.T) {
-	template := tpm2tools.DefaultEKTemplateRSA()
 	tests := []struct {
 		name        string
 		template    tpm2.Public
 		generateKey func() (crypto.PublicKey, error)
 	}{
 		{"RSA", tpm2tools.DefaultEKTemplateRSA(), func() (crypto.PublicKey, error) {
-			priv, err := rsa.GenerateKey(rand.Reader, int(template.RSAParameters.KeyBits))
+			priv, err := rsa.GenerateKey(rand.Reader, 2048)
 			return priv.Public(), err
 		}},
 		{"ECC", tpm2tools.DefaultEKTemplateECC(), func() (crypto.PublicKey, error) {
@@ -64,7 +63,7 @@ func TestCreateEKPublicAreaFromKeyGeneratedKey(t *testing.T) {
 				t.Fatalf("failed to create public area from public key: %v", err)
 			}
 			if !newArea.MatchesTemplate(test.template) {
-				t.Errorf("public areas did not match. got: %+v want: %+v", newArea, template)
+				t.Errorf("public areas did not match. got: %+v want: %+v", newArea, test.template)
 			}
 		})
 	}
@@ -96,7 +95,7 @@ func TestCreateEKPublicAreaFromKeyTPMKey(t *testing.T) {
 			if err != nil {
 				t.Fatalf("failed to create public area from public key: %v", err)
 			}
-			if matches, err := ek.Name().MatchesPublic(newArea); !matches || err != nil {
+			if matches, err := ek.Name().MatchesPublic(newArea); err != nil || !matches {
 				t.Error("public areas did not match or match check failed.")
 			}
 		})

--- a/server/key_conversion_test.go
+++ b/server/key_conversion_test.go
@@ -13,6 +13,14 @@ import (
 	"github.com/google/go-tpm/tpm2"
 )
 
+func getECCTemplate(curve tpm2.EllipticCurve) tpm2.Public {
+	public := tpm2tools.DefaultEKTemplateECC()
+	public.ECCParameters.CurveID = curve
+	public.ECCParameters.Point.XRaw = nil
+	public.ECCParameters.Point.YRaw = nil
+	return public
+}
+
 func TestCreateEKPublicAreaFromKeyGeneratedKey(t *testing.T) {
 	template := tpm2tools.DefaultEKTemplateRSA()
 	tests := []struct {

--- a/server/key_conversion_test.go
+++ b/server/key_conversion_test.go
@@ -1,26 +1,64 @@
 package server
 
 import (
+	"crypto"
+	"crypto/ecdsa"
+	"crypto/elliptic"
 	"crypto/rand"
 	"crypto/rsa"
 	"testing"
 
 	"github.com/google/go-tpm-tools/internal"
 	"github.com/google/go-tpm-tools/tpm2tools"
+	"github.com/google/go-tpm/tpm2"
 )
 
 func TestCreateEKPublicAreaFromKeyGeneratedKey(t *testing.T) {
 	template := tpm2tools.DefaultEKTemplateRSA()
-	key, err := rsa.GenerateKey(rand.Reader, int(template.RSAParameters.KeyBits))
-	if err != nil {
-		t.Fatal(err)
+	tests := []struct {
+		name        string
+		template    tpm2.Public
+		generateKey func() (crypto.PublicKey, error)
+	}{
+		{"RSA", tpm2tools.DefaultEKTemplateRSA(), func() (crypto.PublicKey, error) {
+			priv, err := rsa.GenerateKey(rand.Reader, int(template.RSAParameters.KeyBits))
+			return priv.Public(), err
+		}},
+		{"ECC", tpm2tools.DefaultEKTemplateECC(), func() (crypto.PublicKey, error) {
+			priv, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+			return priv.Public(), err
+		}},
+		{"ECC-P224", getECCTemplate(tpm2.CurveNISTP224), func() (crypto.PublicKey, error) {
+			priv, err := ecdsa.GenerateKey(elliptic.P224(), rand.Reader)
+			return priv.Public(), err
+		}},
+		{"ECC-P256", getECCTemplate(tpm2.CurveNISTP256), func() (crypto.PublicKey, error) {
+			priv, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+			return priv.Public(), err
+		}},
+		{"ECC-P384", getECCTemplate(tpm2.CurveNISTP384), func() (crypto.PublicKey, error) {
+			priv, err := ecdsa.GenerateKey(elliptic.P384(), rand.Reader)
+			return priv.Public(), err
+		}},
+		{"ECC-P521", getECCTemplate(tpm2.CurveNISTP521), func() (crypto.PublicKey, error) {
+			priv, err := ecdsa.GenerateKey(elliptic.P521(), rand.Reader)
+			return priv.Public(), err
+		}},
 	}
-	newArea, err := CreateEKPublicAreaFromKey(key.Public())
-	if err != nil {
-		t.Fatalf("failed to create public area from public key: %v", err)
-	}
-	if !newArea.MatchesTemplate(template) {
-		t.Errorf("public areas did not match. got: %+v want: %+v", newArea, template)
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			key, err := test.generateKey()
+			if err != nil {
+				t.Fatal(err)
+			}
+			newArea, err := CreateEKPublicAreaFromKey(key)
+			if err != nil {
+				t.Fatalf("failed to create public area from public key: %v", err)
+			}
+			if !newArea.MatchesTemplate(test.template) {
+				t.Errorf("public areas did not match. got: %+v want: %+v", newArea, template)
+			}
+		})
 	}
 }
 
@@ -28,17 +66,31 @@ func TestCreateEKPublicAreaFromKeyTPMKey(t *testing.T) {
 	rwc := internal.GetTPM(t)
 	defer tpm2tools.CheckedClose(t, rwc)
 
-	ek, err := tpm2tools.EndorsementKeyRSA(rwc)
-	if err != nil {
-		t.Fatal(err)
+	tests := []struct {
+		name     string
+		template tpm2.Public
+	}{
+		{"RSA", tpm2tools.DefaultEKTemplateRSA()},
+		{"ECC", tpm2tools.DefaultEKTemplateECC()},
+		{"ECC-P224", getECCTemplate(tpm2.CurveNISTP224)},
+		{"ECC-P256", getECCTemplate(tpm2.CurveNISTP256)},
+		{"ECC-P384", getECCTemplate(tpm2.CurveNISTP384)},
+		{"ECC-P521", getECCTemplate(tpm2.CurveNISTP521)},
 	}
-	defer ek.Close()
-	newArea, err := CreateEKPublicAreaFromKey(ek.PublicKey())
-	if err != nil {
-		t.Fatalf("failed to create public area from public key: %v", err)
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			ek, err := tpm2tools.NewKey(rwc, tpm2.HandleEndorsement, test.template)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer ek.Close()
+			newArea, err := CreateEKPublicAreaFromKey(ek.PublicKey())
+			if err != nil {
+				t.Fatalf("failed to create public area from public key: %v", err)
+			}
+			if matches, err := ek.Name().MatchesPublic(newArea); !matches || err != nil {
+				t.Error("public areas did not match or match check failed.")
+			}
+		})
 	}
-	if matches, err := ek.Name().MatchesPublic(newArea); !matches || err != nil {
-		t.Error("public areas did not match or match check failed.")
-	}
-
 }


### PR DESCRIPTION
Expands CreateEkPublicAreaFromKey to support ECC EKs.
Also adds some ECC utility functions.

These changes will be needed to add support for Importing using an ECC EK.