### PR TITLE
Refactor of Sealing/Unsealing, expose helper methods

### DIFF
--- a/gotpm/cmd/read.go
+++ b/gotpm/cmd/read.go
@@ -33,19 +33,19 @@ If --pcrs is not provided, all pcrs are read for that hash algorithm.`,
 		}
 		defer rwc.Close()
 
-		hashAlgo, err := getHashAlgo()
+		sel, err := getSelection()
 		if err != nil {
 			return err
 		}
 
-		if pcrs == nil {
-			if pcrs, err = getDefaultPcrs(rwc); err != nil {
+		if len(sel.PCRs) == 0 {
+			if sel.PCRs, err = getDefaultPcrs(rwc); err != nil {
 				return err
 			}
 		}
 
-		fmt.Fprintf(debugOutput(), "Reading pcrs (%v)\n", pcrs)
-		pcrList, err := tpm2tools.ReadPCRs(rwc, pcrs, hashAlgo)
+		fmt.Fprintf(debugOutput(), "Reading pcrs (%v)\n", sel.PCRs)
+		pcrList, err := tpm2tools.ReadPCRs(rwc, sel)
 		if err != nil {
 			return err
 		}

--- a/gotpm/cmd/seal.go
+++ b/gotpm/cmd/seal.go
@@ -45,8 +45,13 @@ state (like Secure Boot).`,
 			return err
 		}
 
-		fmt.Fprintf(debugOutput(), "Sealing to PCRs: %v\n", pcrs)
-		sealed, err := srk.Seal(pcrs, secret)
+		sel, err := getSelection()
+		if err != nil {
+			return err
+		}
+
+		fmt.Fprintf(debugOutput(), "Sealing to PCRs: %v\n", sel.PCRs)
+		sealed, err := srk.Seal(secret, sel)
 		if err != nil {
 			return fmt.Errorf("sealing data: %v", err)
 		}
@@ -55,7 +60,7 @@ state (like Secure Boot).`,
 		if err := pb.MarshalText(dataOutput(), sealed); err != nil {
 			return err
 		}
-		fmt.Fprintf(debugOutput(), "Sealed data to PCRs: %v\n", pcrs)
+		fmt.Fprintf(debugOutput(), "Sealed data to PCRs: %v\n", sel.PCRs)
 		return nil
 	},
 }
@@ -118,7 +123,8 @@ func init() {
 	addInputFlag(unsealCmd)
 	addOutputFlag(sealCmd)
 	addOutputFlag(unsealCmd)
-	// PCRs only used for sealing
+	// PCRs and hash algorithm only used for sealing
 	addPCRsFlag(sealCmd)
+	addHashAlgoFlag(sealCmd)
 	addPublicKeyAlgoFlag(sealCmd)
 }

--- a/gotpm/cmd/utils.go
+++ b/gotpm/cmd/utils.go
@@ -129,6 +129,11 @@ func getHashAlgo() (tpm2.Algorithm, error) {
 	}
 }
 
+func getSelection() (tpm2.PCRSelection, error) {
+	hash, err := getHashAlgo()
+	return tpm2.PCRSelection{Hash: hash, PCRs: pcrs}, err
+}
+
 func getSRKwithAlgo(rwc io.ReadWriter, algo tpm2.Algorithm) (*tpm2tools.Key, error) {
 	switch algo {
 	case tpm2.AlgRSA:

--- a/tpm2tools/keys.go
+++ b/tpm2tools/keys.go
@@ -172,7 +172,7 @@ func (k *Key) Close() {
 // hierarchy using the SHA256 versions of the provided PCRs.
 // The Key k is used as the parent key.
 func (k *Key) Seal(pcrs []int, sensitive []byte) (*proto.SealedBytes, error) {
-	auth, err := getPCRSessionAuth(k.rw, pcrs, tpm2.AlgSHA256)
+	auth, err := getPCRSessionAuth(k.rw, pcrs, tpm2.AlgSHA256, tpm2.AlgSHA256)
 	if err != nil {
 		return nil, fmt.Errorf("could not get pcr session auth: %v", err)
 	}
@@ -216,7 +216,7 @@ func (k *Key) Unseal(in *proto.SealedBytes) ([]byte, error) {
 	for _, pcr := range in.Pcrs {
 		pcrs = append(pcrs, int(pcr))
 	}
-	session, err := createPCRSession(k.rw, pcrs, tpm2.AlgSHA256)
+	session, err := createPCRSession(k.rw, pcrs, tpm2.AlgSHA256, tpm2.AlgSHA256)
 	if err != nil {
 		return nil, fmt.Errorf("failed to unseal: %v", err)
 	}
@@ -250,7 +250,7 @@ func (k *Key) Reseal(pcrs map[int][]byte, in *proto.SealedBytes) (*proto.SealedB
 		pcrsU[uint32(pcr)] = val
 	}
 
-	auth, err := ComputePCRSessionAuth(proto.Pcrs{Hash: proto.HashAlgo_SHA256, Pcrs: pcrsU})
+	auth, err := ComputePCRSessionAuth(&proto.Pcrs{Hash: proto.HashAlgo_SHA256, Pcrs: pcrsU}, tpm2.AlgSHA256)
 	if err != nil {
 		return nil, fmt.Errorf("failed to compute pcr session auth: %v", err)
 	}
@@ -281,8 +281,8 @@ type sessionSummary struct {
 	PcrDigest      tpmutil.RawBytes
 }
 
-func getPCRSessionAuth(rw io.ReadWriter, pcrs []int, hash tpm2.Algorithm) ([]byte, error) {
-	handle, err := createPCRSession(rw, pcrs, hash)
+func getPCRSessionAuth(rw io.ReadWriter, pcrs []int, pcrHash tpm2.Algorithm, sessionHash tpm2.Algorithm) ([]byte, error) {
+	handle, err := createPCRSession(rw, pcrs, pcrHash, sessionHash)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get digest: %v", err)
 	}
@@ -296,7 +296,7 @@ func getPCRSessionAuth(rw io.ReadWriter, pcrs []int, hash tpm2.Algorithm) ([]byt
 	return digest, nil
 }
 
-func createPCRSession(rw io.ReadWriter, pcrs []int, hash tpm2.Algorithm) (tpmutil.Handle, error) {
+func createPCRSession(rw io.ReadWriter, pcrs []int, pcrHash tpm2.Algorithm, sessionHash tpm2.Algorithm) (tpmutil.Handle, error) {
 	nonceIn := make([]byte, 16)
 	/* This session assumes the bus is trusted.  */
 	handle, _, err := tpm2.StartAuthSession(
@@ -307,13 +307,13 @@ func createPCRSession(rw io.ReadWriter, pcrs []int, hash tpm2.Algorithm) (tpmuti
 		/*secret=*/ nil,
 		tpm2.SessionPolicy,
 		tpm2.AlgNull,
-		tpm2.AlgSHA256)
+		sessionHash)
 	if err != nil {
 		return tpm2.HandleNull, fmt.Errorf("failed to start auth session: %v", err)
 	}
 
 	sel := tpm2.PCRSelection{
-		Hash: hash,
+		Hash: pcrHash,
 		PCRs: pcrs,
 	}
 	if err = tpm2.PolicyPCR(rw, handle, nil, sel); err != nil {

--- a/tpm2tools/keys.go
+++ b/tpm2tools/keys.go
@@ -172,7 +172,7 @@ func (k *Key) Close() {
 // hierarchy using the SHA256 versions of the provided PCRs.
 // The Key k is used as the parent key.
 func (k *Key) Seal(pcrs []int, sensitive []byte) (*proto.SealedBytes, error) {
-	auth, err := getPCRSessionAuth(k.rw, pcrs, tpm2.AlgSHA256, tpm2.AlgSHA256)
+	auth, err := getPCRSessionAuth(k.rw, pcrs, tpm2.AlgSHA256)
 	if err != nil {
 		return nil, fmt.Errorf("could not get pcr session auth: %v", err)
 	}
@@ -216,7 +216,7 @@ func (k *Key) Unseal(in *proto.SealedBytes) ([]byte, error) {
 	for _, pcr := range in.Pcrs {
 		pcrs = append(pcrs, int(pcr))
 	}
-	session, err := createPCRSession(k.rw, pcrs, tpm2.AlgSHA256, tpm2.AlgSHA256)
+	session, err := createPCRSession(k.rw, pcrs, tpm2.AlgSHA256)
 	if err != nil {
 		return nil, fmt.Errorf("failed to unseal: %v", err)
 	}
@@ -250,7 +250,7 @@ func (k *Key) Reseal(pcrs map[int][]byte, in *proto.SealedBytes) (*proto.SealedB
 		pcrsU[uint32(pcr)] = val
 	}
 
-	auth, err := ComputePCRSessionAuth(&proto.Pcrs{Hash: proto.HashAlgo_SHA256, Pcrs: pcrsU}, tpm2.AlgSHA256)
+	auth, err := ComputePCRSessionAuth(&proto.Pcrs{Hash: proto.HashAlgo_SHA256, Pcrs: pcrsU})
 	if err != nil {
 		return nil, fmt.Errorf("failed to compute pcr session auth: %v", err)
 	}
@@ -281,8 +281,8 @@ type sessionSummary struct {
 	PcrDigest      tpmutil.RawBytes
 }
 
-func getPCRSessionAuth(rw io.ReadWriter, pcrs []int, pcrHash tpm2.Algorithm, sessionHash tpm2.Algorithm) ([]byte, error) {
-	handle, err := createPCRSession(rw, pcrs, pcrHash, sessionHash)
+func getPCRSessionAuth(rw io.ReadWriter, pcrs []int, pcrHash tpm2.Algorithm) ([]byte, error) {
+	handle, err := createPCRSession(rw, pcrs, pcrHash)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get digest: %v", err)
 	}
@@ -296,7 +296,7 @@ func getPCRSessionAuth(rw io.ReadWriter, pcrs []int, pcrHash tpm2.Algorithm, ses
 	return digest, nil
 }
 
-func createPCRSession(rw io.ReadWriter, pcrs []int, pcrHash tpm2.Algorithm, sessionHash tpm2.Algorithm) (tpmutil.Handle, error) {
+func createPCRSession(rw io.ReadWriter, pcrs []int, pcrHash tpm2.Algorithm) (tpmutil.Handle, error) {
 	nonceIn := make([]byte, 16)
 	/* This session assumes the bus is trusted.  */
 	handle, _, err := tpm2.StartAuthSession(
@@ -307,7 +307,7 @@ func createPCRSession(rw io.ReadWriter, pcrs []int, pcrHash tpm2.Algorithm, sess
 		/*secret=*/ nil,
 		tpm2.SessionPolicy,
 		tpm2.AlgNull,
-		sessionHash)
+		tpm2.AlgSHA256)
 	if err != nil {
 		return tpm2.HandleNull, fmt.Errorf("failed to start auth session: %v", err)
 	}

--- a/tpm2tools/pcr.go
+++ b/tpm2tools/pcr.go
@@ -59,7 +59,7 @@ func ReadPCRs(rw io.ReadWriter, pcrs []int, hash tpm2.Algorithm) (*proto.Pcrs, e
 	return &pl, nil
 }
 
-// ComputePCRSessionAuth calculates the auth value using the SHA256 versions of the provided PCRs.
+// ComputePCRSessionAuth calculates the auth value using the specified hash version of the provided PCRs.
 func ComputePCRSessionAuth(pcrProto proto.Pcrs) ([]byte, error) {
 	var pcrHash tpm2.Algorithm
 	switch pcrProto.Hash {

--- a/tpm2tools/pcr.go
+++ b/tpm2tools/pcr.go
@@ -1,10 +1,10 @@
 package tpm2tools
 
 import (
+	"crypto"
+	"crypto/sha256"
 	"fmt"
 	"io"
-	"crypto/sha256"
-	"crypto"
 
 	"github.com/google/go-tpm-tools/proto"
 	"github.com/google/go-tpm/tpm2"

--- a/tpm2tools/pcr.go
+++ b/tpm2tools/pcr.go
@@ -2,10 +2,12 @@ package tpm2tools
 
 import (
 	"fmt"
+	"hash"
 	"io"
 
 	"github.com/google/go-tpm-tools/proto"
 	"github.com/google/go-tpm/tpm2"
+	"github.com/google/go-tpm/tpmutil"
 )
 
 // GetPCRCount asks the tpm how many PCRs it has.
@@ -54,4 +56,68 @@ func ReadPCRs(rw io.ReadWriter, pcrs []int, hash tpm2.Algorithm) (*proto.Pcrs, e
 	}
 
 	return &pl, nil
+}
+
+// ComputePCRSessionAuth calculates the auth value using the SHA256 versions of the provided PCRs.
+func ComputePCRSessionAuth(pcrProto proto.Pcrs) ([]byte, error) {
+	pcrs := map[int][]byte{}
+	for p, v := range pcrProto.Pcrs {
+		pcrs[int(p)] = v
+	}
+	pcrAlg, err := getHashAlg(pcrProto.Hash)
+	if err != nil {
+		return nil, err
+	}
+	getHash, err := pcrAlg.HashConstructor()
+	if err != nil {
+		return nil, err
+	}
+	var pcrBits [3]byte
+	for pcr := range pcrs {
+		byteNum := pcr / 8
+		bytePos := byte(1 << byte(pcr%8))
+		pcrBits[byteNum] |= bytePos
+	}
+	pcrDigest := digestPCRList(pcrs, getHash())
+
+	summary := sessionSummary{
+		OldDigest:      make([]byte, getHash().Size()),
+		CmdIDPolicyPCR: uint32(tpm2.CmdPolicyPCR),
+		NumPcrSels:     1,
+		Sel: tpmsPCRSelection{
+			Hash: pcrAlg,
+			Size: 3,
+			PCRs: pcrBits[:],
+		},
+		PcrDigest: pcrDigest,
+	}
+	b, err := tpmutil.Pack(summary)
+	if err != nil {
+		return nil, fmt.Errorf("failed to pack for hashing: %v ", err)
+	}
+	digestHash := getHash()
+	digestHash.Write(b)
+	digest := digestHash.Sum(nil)
+
+	return digest[:], nil
+}
+
+func digestPCRList(pcrs map[int][]byte, hash hash.Hash) []byte {
+	for i := 0; i < 24; i++ {
+		if pcrValue, exists := pcrs[i]; exists {
+			hash.Write(pcrValue)
+		}
+	}
+	return hash.Sum(nil)
+}
+
+func getHashAlg(alg proto.HashAlgo) (tpm2.Algorithm, error) {
+	switch alg {
+	case proto.HashAlgo_SHA1:
+		return tpm2.AlgSHA1, nil
+	case proto.HashAlgo_SHA256:
+		return tpm2.AlgSHA256, nil
+	default:
+		return tpm2.AlgNull, fmt.Errorf("Invalid hash alg: %v", alg)
+	}
 }

--- a/tpm2tools/pcr_test.go
+++ b/tpm2tools/pcr_test.go
@@ -66,7 +66,8 @@ func TestReadPCRs(t *testing.T) {
 			testPcrs[test.inAlg] = pcrVal
 		}
 
-		proto, err := ReadPCRs(rwc, []int{0}, test.inAlg)
+		sel := tpm2.PCRSelection{Hash: test.inAlg, PCRs: []int{0}}
+		proto, err := ReadPCRs(rwc, sel)
 		if err != nil {
 			t.Fatalf("failed to read pcrs %v", err)
 		}

--- a/tpm2tools/seal_test.go
+++ b/tpm2tools/seal_test.go
@@ -74,7 +74,7 @@ func TestComputeSessionAuth(t *testing.T) {
 		alg      tpm2.Algorithm
 		protoAlg proto.HashAlgo
 	}{
-		//	{"sha1", tpm2.AlgSHA1, proto.HashAlgo_SHA1},
+		{"sha1", tpm2.AlgSHA1, proto.HashAlgo_SHA1},
 		{"sha256", tpm2.AlgSHA256, proto.HashAlgo_SHA256},
 	}
 	for _, test := range tests {

--- a/tpm2tools/seal_test.go
+++ b/tpm2tools/seal_test.go
@@ -119,14 +119,14 @@ func TestSelfReseal(t *testing.T) {
 	secret := []byte("test")
 
 	pcrList := []int{0, 4, 7}
-	pcrs := map[uint32][]byte{}
+	pcrs := map[int][]byte{}
 	for _, pcrNum := range pcrList {
 		pcrVal, err := tpm2.ReadPCR(rwc, pcrNum, tpm2.AlgSHA256)
 		if err != nil {
 			t.Fatalf("failed to read pcr: %v", err)
 		}
 
-		pcrs[uint32(pcrNum)] = pcrVal
+		pcrs[pcrNum] = pcrVal
 	}
 
 	sealed, err := key.Seal(pcrList, secret)
@@ -142,7 +142,7 @@ func TestSelfReseal(t *testing.T) {
 		t.Fatalf("unsealed (%v) not equal to secret (%v)", unseal, secret)
 	}
 
-	sealed, err = key.Reseal(proto.Pcrs{Hash: proto.HashAlgo_SHA256, Pcrs: pcrs}, sealed)
+	sealed, err = key.Reseal(pcrs, sealed)
 	if err != nil {
 		t.Fatalf("failed to reseal: %v", err)
 	}
@@ -213,14 +213,14 @@ func TestReseal(t *testing.T) {
 
 	pcrToChange := 23
 	pcrList := []int{7, 23}
-	pcrs := map[uint32][]byte{}
+	pcrs := map[int][]byte{}
 	for _, pcrNum := range pcrList {
 		pcrVal, err := tpm2.ReadPCR(rwc, pcrNum, tpm2.AlgSHA256)
 		if err != nil {
 			t.Fatalf("failed to read pcr: %v", err)
 		}
 
-		pcrs[uint32(pcrNum)] = pcrVal
+		pcrs[pcrNum] = pcrVal
 	}
 
 	sealed, err := key.Seal(pcrList, secret)
@@ -241,8 +241,8 @@ func TestReseal(t *testing.T) {
 	}
 
 	// Change pcr value to the predicted future value for resealing
-	pcrs[uint32(pcrToChange)] = computePCRValue(pcrs[uint32(pcrToChange)], extensions)
-	sealed, err = key.Reseal(proto.Pcrs{Hash: proto.HashAlgo_SHA256, Pcrs: pcrs}, sealed)
+	pcrs[pcrToChange] = computePCRValue(pcrs[pcrToChange], extensions)
+	sealed, err = key.Reseal(pcrs, sealed)
 	if err != nil {
 		t.Fatalf("failed to reseal: %v", err)
 	}

--- a/tpm2tools/seal_test.go
+++ b/tpm2tools/seal_test.go
@@ -70,14 +70,11 @@ func TestComputeSessionAuth(t *testing.T) {
 	pcrs := map[uint32][]byte{}
 
 	tests := []struct {
-		name       string
-		pcrHash    tpm2.Algorithm
-		digestHash tpm2.Algorithm
+		name    string
+		pcrHash tpm2.Algorithm
 	}{
-		{"sha1-sha1", tpm2.AlgSHA1, tpm2.AlgSHA1},
-		{"sha1-sha256", tpm2.AlgSHA1, tpm2.AlgSHA256},
-		{"sha256-sha1", tpm2.AlgSHA256, tpm2.AlgSHA1},
-		{"sha256-sha256", tpm2.AlgSHA256, tpm2.AlgSHA256},
+		{"sha1", tpm2.AlgSHA1},
+		{"sha256", tpm2.AlgSHA256},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
@@ -91,12 +88,12 @@ func TestComputeSessionAuth(t *testing.T) {
 				pcrs[uint32(pcrNum)] = pcrVal
 			}
 
-			getAuth, err := getPCRSessionAuth(rwc, pcrList, test.pcrHash, test.digestHash)
+			getAuth, err := getPCRSessionAuth(rwc, pcrList, test.pcrHash)
 			if err != nil {
 				t.Fatalf("failed to get session auth: %v", err)
 			}
 
-			computeAuth, err := ComputePCRSessionAuth(&proto.Pcrs{Hash: proto.HashAlgo(test.pcrHash), Pcrs: pcrs}, test.digestHash)
+			computeAuth, err := ComputePCRSessionAuth(&proto.Pcrs{Hash: proto.HashAlgo(test.pcrHash), Pcrs: pcrs})
 			if err != nil {
 				t.Fatalf("failed to compute session auth: %v", err)
 			}

--- a/tpm2tools/seal_test.go
+++ b/tpm2tools/seal_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/google/go-tpm/tpmutil"
 
 	"github.com/google/go-tpm-tools/internal"
-	"github.com/google/go-tpm-tools/proto"
 )
 
 func TestSeal(t *testing.T) {
@@ -33,10 +32,10 @@ func TestSeal(t *testing.T) {
 			defer srk.Close()
 
 			secret := []byte("test")
-			pcrList := []int{7, 23}
+			sel := tpm2.PCRSelection{Hash: tpm2.AlgSHA256, PCRs: []int{7, 23}}
 			pcrToExtend := tpmutil.Handle(23)
 
-			sealed, err := srk.Seal(pcrList, secret)
+			sealed, err := srk.Seal(secret, sel)
 			if err != nil {
 				t.Fatalf("failed to seal: %v", err)
 			}
@@ -66,8 +65,7 @@ func TestComputeSessionAuth(t *testing.T) {
 	rwc := internal.GetTPM(t)
 	defer CheckedClose(t, rwc)
 
-	pcrList := []int{1, 7}
-	pcrs := map[uint32][]byte{}
+	pcrNums := []int{1, 7}
 
 	tests := []struct {
 		name    string
@@ -78,28 +76,26 @@ func TestComputeSessionAuth(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-
-			for _, pcrNum := range pcrList {
-				pcrVal, err := tpm2.ReadPCR(rwc, pcrNum, test.pcrHash)
-				if err != nil {
-					t.Fatalf("failed to read pcr: %v", err)
-				}
-
-				pcrs[uint32(pcrNum)] = pcrVal
+			sel := tpm2.PCRSelection{Hash: test.pcrHash, PCRs: pcrNums}
+			pcrs, err := ReadPCRs(rwc, sel)
+			if err != nil {
+				t.Fatalf("failed to read PCRs: %v", err)
 			}
+			computeAuth := ComputePCRSessionAuth(pcrs)
 
-			getAuth, err := getPCRSessionAuth(rwc, pcrList, test.pcrHash)
+			session, err := createPCRSession(rwc, sel)
+			if err != nil {
+				t.Fatalf("failed to create PCR session: %v", err)
+			}
+			defer tpm2.FlushContext(rwc, session)
+
+			getAuth, err := tpm2.PolicyGetDigest(rwc, session)
 			if err != nil {
 				t.Fatalf("failed to get session auth: %v", err)
 			}
 
-			computeAuth, err := ComputePCRSessionAuth(&proto.Pcrs{Hash: proto.HashAlgo(test.pcrHash), Pcrs: pcrs})
-			if err != nil {
-				t.Fatalf("failed to compute session auth: %v", err)
-			}
-
 			if !bytes.Equal(computeAuth, getAuth) {
-				t.Fatalf("computed auth (%v) not equal to session auth(%v)", computeAuth, getAuth)
+				t.Errorf("computed auth (%v) not equal to session auth(%v)", computeAuth, getAuth)
 			}
 		})
 	}
@@ -116,19 +112,13 @@ func TestSelfReseal(t *testing.T) {
 	defer key.Close()
 
 	secret := []byte("test")
-
-	pcrList := []int{0, 4, 7}
-	pcrs := map[int][]byte{}
-	for _, pcrNum := range pcrList {
-		pcrVal, err := tpm2.ReadPCR(rwc, pcrNum, tpm2.AlgSHA256)
-		if err != nil {
-			t.Fatalf("failed to read pcr: %v", err)
-		}
-
-		pcrs[pcrNum] = pcrVal
+	sel := tpm2.PCRSelection{Hash: tpm2.AlgSHA256, PCRs: []int{0, 4, 7}}
+	pcrs, err := ReadPCRs(rwc, sel)
+	if err != nil {
+		t.Fatalf("failed to read PCRs: %v", err)
 	}
 
-	sealed, err := key.Seal(pcrList, secret)
+	sealed, err := key.Seal(secret, sel)
 	if err != nil {
 		t.Fatalf("failed to seal: %v", err)
 	}
@@ -138,20 +128,20 @@ func TestSelfReseal(t *testing.T) {
 		t.Fatalf("failed to unseal: %v", err)
 	}
 	if !bytes.Equal(secret, unseal) {
-		t.Fatalf("unsealed (%v) not equal to secret (%v)", unseal, secret)
+		t.Errorf("unsealed (%v) not equal to secret (%v)", unseal, secret)
 	}
 
-	sealed, err = key.Reseal(pcrs, sealed)
+	sealed, err = key.Reseal(sealed, pcrs)
 	if err != nil {
 		t.Fatalf("failed to reseal: %v", err)
 	}
 
 	unseal, err = key.Unseal(sealed)
 	if err != nil {
-		t.Fatalf("unseal failed: %v", err)
+		t.Fatalf("failed to unseal after resealing: %v", err)
 	}
 	if !bytes.Equal(secret, unseal) {
-		t.Fatalf("unsealed (%v) not equal to secret (%v)", unseal, secret)
+		t.Errorf("unsealed (%v) not equal to secret (%v)", unseal, secret)
 	}
 }
 
@@ -209,20 +199,15 @@ func TestReseal(t *testing.T) {
 	defer key.Close()
 
 	secret := []byte("test")
+	pcrToChange := uint32(23)
+	sel := tpm2.PCRSelection{Hash: tpm2.AlgSHA256, PCRs: []int{7, 23}}
 
-	pcrToChange := 23
-	pcrList := []int{7, 23}
-	pcrs := map[int][]byte{}
-	for _, pcrNum := range pcrList {
-		pcrVal, err := tpm2.ReadPCR(rwc, pcrNum, tpm2.AlgSHA256)
-		if err != nil {
-			t.Fatalf("failed to read pcr: %v", err)
-		}
-
-		pcrs[pcrNum] = pcrVal
+	pcrs, err := ReadPCRs(rwc, sel)
+	if err != nil {
+		t.Fatalf("failed to read PCRs: %v", err)
 	}
 
-	sealed, err := key.Seal(pcrList, secret)
+	sealed, err := key.Seal(secret, sel)
 	if err != nil {
 		t.Fatalf("failed to seal: %v", err)
 	}
@@ -235,20 +220,17 @@ func TestReseal(t *testing.T) {
 		t.Fatalf("unsealed (%v) not equal to secret (%v)", unseal, secret)
 	}
 
-	extensions := [][]byte{
-		bytes.Repeat([]byte{0xAA}, sha256.Size),
-	}
+	extensions := [][]byte{bytes.Repeat([]byte{0xAA}, sha256.Size)}
 
 	// Change pcr value to the predicted future value for resealing
-	pcrs[pcrToChange] = computePCRValue(pcrs[pcrToChange], extensions)
-	sealed, err = key.Reseal(pcrs, sealed)
+	pcrs.Pcrs[pcrToChange] = computePCRValue(pcrs.Pcrs[pcrToChange], extensions)
+	sealed, err = key.Reseal(sealed, pcrs)
 	if err != nil {
 		t.Fatalf("failed to reseal: %v", err)
 	}
 
 	// unseal should not succeed since pcr has not been extended.
-	_, err = key.Unseal(sealed)
-	if err == nil {
+	if _, err = key.Unseal(sealed); err == nil {
 		t.Fatalf("unseal should have failed: %v", err)
 	}
 
@@ -261,9 +243,35 @@ func TestReseal(t *testing.T) {
 
 	unseal, err = key.Unseal(sealed)
 	if err != nil {
-		t.Fatalf("failed to unseal: %v", err)
+		t.Fatalf("failed to unseal after resealing: %v", err)
 	}
 	if !bytes.Equal(secret, unseal) {
 		t.Fatalf("unsealed (%v) not equal to secret (%v)", unseal, secret)
+	}
+}
+
+func TestSealingResealingToNilPCRs(t *testing.T) {
+	rwc := internal.GetTPM(t)
+	defer CheckedClose(t, rwc)
+
+	key, err := StorageRootKeyRSA(rwc)
+	if err != nil {
+		t.Fatalf("can't create srk from template: %v", err)
+	}
+	defer key.Close()
+
+	secret := []byte("test")
+	sel := tpm2.PCRSelection{Hash: tpm2.AlgSHA256, PCRs: nil}
+
+	sealed, err := key.Seal(secret, sel)
+	if err != nil {
+		t.Fatalf("failed to seal: %v", err)
+	}
+	unseal, err := key.Unseal(sealed)
+	if err != nil {
+		t.Fatalf("failed to unseal: %v", err)
+	}
+	if !bytes.Equal(secret, unseal) {
+		t.Errorf("unsealed (%v) not equal to secret (%v)", unseal, secret)
 	}
 }


### PR DESCRIPTION
Export ComputePCRSessionAuth and add ComputePCRDigest

ComputePCRSessionAuth was modified to take a proto.Pcrs and the hash algorithm used to create the digest. 
