### PR TITLE
Add TpmSigner 

### DIFF
--- a/simulator/internal/internal.go
+++ b/simulator/internal/internal.go
@@ -39,6 +39,8 @@ package internal
 // #cgo CFLAGS: -DCERTIFYX509_DEBUG=NO
 // #cgo CFLAGS: -DECC_NIST_P224=YES
 // #cgo CFLAGS: -DECC_NIST_P521=YES
+// #cgo CFLAGS: -DALG_SHA512=ALG_YES
+// #cgo CFLAGS: -DMAX_CONTEXT_SIZE=1360
 // #cgo LDFLAGS: -lcrypto
 //
 // #include <stdlib.h>

--- a/tpm2tools/keys.go
+++ b/tpm2tools/keys.go
@@ -276,3 +276,7 @@ func (k *Key) Reseal(in *proto.SealedBytes, pcrs *proto.Pcrs) (*proto.SealedByte
 	sb.Srk = in.Srk
 	return sb, nil
 }
+
+func (k *Key) hasAttribute(attr tpm2.KeyProp) bool {
+	return k.pubArea.Attributes&attr != 0
+}

--- a/tpm2tools/signer.go
+++ b/tpm2tools/signer.go
@@ -1,0 +1,77 @@
+package tpm2tools
+
+import (
+	"crypto"
+	"fmt"
+	"io"
+	"sync"
+
+	"github.com/google/go-tpm/tpm2"
+)
+
+// Global mutex to protect against concurrent TPM access.
+var signerMutex sync.Mutex
+
+type tpmSigner struct {
+	Key  *Key
+	Hash crypto.Hash
+}
+
+// Public returns the tpmSigners public key.
+func (signer *tpmSigner) Public() crypto.PublicKey {
+	return signer.Key.PublicKey()
+}
+
+// Sign uses the TPM key to  sign the digest.
+// The digest must be hashed from the same hash algorithm as the keys scheme.
+// The opts hash function must also match the keys scheme.
+// Concurrent use of Sign is thread safe, but it is not safe to access the TPM
+// from other sources while Sign is executing.
+func (signer *tpmSigner) Sign(_ io.Reader, digest []byte, opts crypto.SignerOpts) (signature []byte, err error) {
+	if opts.HashFunc() != signer.Hash {
+		return nil, fmt.Errorf("opts hash: %v does not match the keys signing hash: %v", opts.HashFunc(), signer.Hash)
+	}
+	if len(digest) != signer.Hash.Size() {
+		return nil, fmt.Errorf("digest length: %d does not match hash size: %d", digest, signer.Hash.Size())
+	}
+
+	signerMutex.Lock()
+	defer signerMutex.Unlock()
+
+	sig, err := tpm2.Sign(signer.Key.rw, signer.Key.handle, "", digest, nil)
+	if err != nil {
+		return nil, err
+	}
+	return sig.RSA.Signature, nil
+}
+
+// GetSigner returns a crypto.Signer wrapping the loaded TPM Key.
+// Concurrent use of one or more Signers is thread safe, but it is not safe to
+// access the TPM from other sources while using a Signer.
+// The returned Signer lasts the lifetime of the Key, and will no longer work
+// once the Key has been closed.
+func (k *Key) GetSigner() (crypto.Signer, error) {
+	if k.pubArea.Type != tpm2.AlgRSA {
+		return nil, fmt.Errorf("unsupported key type: %v", k.pubArea.Type)
+	}
+	if k.pubArea.AuthPolicy != nil {
+		return nil, fmt.Errorf("GetSigner does not support keys with an auth policy.")
+	}
+	if k.hasAttribute(tpm2.FlagRestricted) {
+		return nil, fmt.Errorf("GetSigner does not support restricted keys.")
+	}
+	if !k.hasAttribute(tpm2.FlagSign) {
+		return nil, fmt.Errorf("GetSigner called on non-signing key.")
+	}
+	if k.pubArea.RSAParameters.Sign == nil {
+		return nil, fmt.Errorf("GetSigner called on key missing a signing scheme.")
+	}
+	if k.pubArea.RSAParameters.Sign.Alg != tpm2.AlgRSASSA {
+		return nil, fmt.Errorf("GetSigner only supports RSASSA signing keys.")
+	}
+	hash, err := k.pubArea.RSAParameters.Sign.Hash.Hash()
+	if err != nil {
+		return nil, err
+	}
+	return &tpmSigner{k, hash}, nil
+}

--- a/tpm2tools/signer_test.go
+++ b/tpm2tools/signer_test.go
@@ -1,0 +1,95 @@
+package tpm2tools
+
+import (
+	"crypto"
+	"crypto/rsa"
+	"crypto/sha1"
+	"crypto/sha256"
+	"testing"
+
+	"github.com/google/go-tpm-tools/internal"
+	"github.com/google/go-tpm/tpm2"
+)
+
+func templateSSA(hash tpm2.Algorithm) tpm2.Public {
+	template := AIKTemplateRSA(nil)
+	// Can't sign arbitrary data if restricted.
+	template.Attributes &= ^tpm2.FlagRestricted
+	template.RSAParameters.Sign.Hash = hash
+	return template
+}
+
+func TestSign(t *testing.T) {
+	rwc := internal.GetTPM(t)
+	defer CheckedClose(t, rwc)
+
+	tests := []struct {
+		name     string
+		hash     crypto.Hash
+		template tpm2.Public
+	}{
+		{"RSA-SHA1", crypto.SHA1, templateSSA(tpm2.AlgSHA1)},
+		{"RSA-SHA256", crypto.SHA256, templateSSA(tpm2.AlgSHA256)},
+		{"RSA-SHA384", crypto.SHA384, templateSSA(tpm2.AlgSHA384)},
+		{"RSA-SHA512", crypto.SHA512, templateSSA(tpm2.AlgSHA512)},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			key, err := NewKey(rwc, tpm2.HandleEndorsement, test.template)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer key.Close()
+
+			hash := test.hash.New()
+			hash.Write([]byte("authenticated message"))
+			digest := hash.Sum(nil)
+
+			signer, err := key.GetSigner()
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			sig, err := signer.Sign(nil, digest, test.hash)
+			if err != nil {
+				t.Fatal(err)
+			}
+			pubKey := signer.Public().(*rsa.PublicKey)
+			if err := rsa.VerifyPKCS1v15(pubKey, test.hash, digest, sig); err != nil {
+				t.Error(err)
+			}
+		})
+	}
+}
+
+func TestSignIncorrectHash(t *testing.T) {
+	rwc := internal.GetTPM(t)
+	defer CheckedClose(t, rwc)
+
+	key, err := NewKey(rwc, tpm2.HandleEndorsement, templateSSA(tpm2.AlgSHA256))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer key.Close()
+
+	signer, err := key.GetSigner()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	digestSHA1 := sha1.Sum([]byte("authenticated message"))
+	digestSHA256 := sha256.Sum256([]byte("authenticated message"))
+
+	if _, err := signer.Sign(nil, digestSHA1[:], crypto.SHA1); err == nil {
+		t.Error("expected failure for digest and hash not matching keys sigScheme.")
+	}
+
+	if _, err := signer.Sign(nil, digestSHA1[:], crypto.SHA256); err == nil {
+		t.Error("expected failure for correct hash, but incorrect digest.")
+	}
+
+	if _, err := signer.Sign(nil, digestSHA256[:], crypto.SHA1); err == nil {
+		t.Error("expected failure for correct digest, but incorrect hash.")
+	}
+}


### PR DESCRIPTION
TpmSigner only supports RSA PKCS#1 v1.5 signing. Subsequent PRs will add PSS and ECC support.

There will also be a PR for adding a (k *Key) GetSigner function, which will check that the Key is appropriate to be used as a Signer.

Also enables SHA512 in the simulator. The simulator told me to set MAX_CONTENT_SIZE to 1360 when I tried to run it after enabling SHA512.