### PR TITLE
Add ECC support to tpmSigner

### DIFF
--- a/tpm2tools/signer.go
+++ b/tpm2tools/signer.go
@@ -83,10 +83,10 @@ func (k *Key) GetSigner() (crypto.Signer, error) {
 		return nil, fmt.Errorf("unsupported key type: %v", k.pubArea.Type)
 	}
 	if sigScheme == nil {
-		return nil, fmt.Errorf("GetSigner called on key missing a signing scheme.")
+		return nil, fmt.Errorf("key missing required signing scheme")
 	}
 	if sigScheme.Alg != tpm2.AlgRSASSA && sigScheme.Alg != tpm2.AlgECDSA {
-		return nil, fmt.Errorf("unsupported signing algorithm: %v.", sigScheme.Alg)
+		return nil, fmt.Errorf("unsupported signing algorithm: %v", sigScheme.Alg)
 	}
 	hash, err := sigScheme.Hash.Hash()
 	if err != nil {

--- a/tpm2tools/signer.go
+++ b/tpm2tools/signer.go
@@ -56,7 +56,7 @@ func (signer *tpmSigner) Sign(_ io.Reader, digest []byte, opts crypto.SignerOpts
 		sigStruct := struct{ R, S *big.Int }{sig.ECC.R, sig.ECC.S}
 		return asn1.Marshal(sigStruct)
 	default:
-		return nil, fmt.Errorf("unsupported signing algorithm: %v", sig.Alg)
+		panic("unsupported signing algorithm")
 	}
 }
 

--- a/tpm2tools/signer.go
+++ b/tpm2tools/signer.go
@@ -3,10 +3,10 @@ package tpm2tools
 import (
 	"crypto"
 	"crypto/rsa"
-	"math/big"
 	"encoding/asn1"
 	"fmt"
 	"io"
+	"math/big"
 	"sync"
 
 	"github.com/google/go-tpm/tpm2"
@@ -52,7 +52,7 @@ func (signer *tpmSigner) Sign(_ io.Reader, digest []byte, opts crypto.SignerOpts
 	if sig.RSA != nil {
 		return sig.RSA.Signature, nil
 	} else {
-		sigStruct := struct{R *big.Int; S *big.Int}{sig.ECC.R, sig.ECC.S}
+		sigStruct := struct{ R, S *big.Int }{sig.ECC.R, sig.ECC.S}
 		return asn1.Marshal(sigStruct)
 	}
 }

--- a/tpm2tools/signer_test.go
+++ b/tpm2tools/signer_test.go
@@ -2,13 +2,13 @@ package tpm2tools
 
 import (
 	"crypto"
-	"math/big"
 	"crypto/ecdsa"
 	"crypto/rsa"
 	"crypto/sha1"
 	"crypto/sha256"
-	"testing"
 	"encoding/asn1"
+	"math/big"
+	"testing"
 
 	"github.com/google/go-tpm-tools/internal"
 	"github.com/google/go-tpm/tpm2"
@@ -29,7 +29,7 @@ func templateECC(hash tpm2.Algorithm) tpm2.Public {
 	template.RSAParameters = nil
 	template.ECCParameters = &tpm2.ECCParams{
 		Sign: &tpm2.SigScheme{
-			Alg: tpm2.AlgECDSA,
+			Alg:  tpm2.AlgECDSA,
 			Hash: hash,
 		},
 		CurveID: tpm2.CurveNISTP256,
@@ -42,7 +42,7 @@ func verifyRSA(pubKey crypto.PublicKey, hash crypto.Hash, digest, sig []byte) bo
 }
 
 func verifyECC(pubKey crypto.PublicKey, _ crypto.Hash, digest, sig []byte) bool {
-	var sigStruct struct{R *big.Int; S *big.Int}
+	var sigStruct struct{ R, S *big.Int }
 	asn1.Unmarshal(sig, &sigStruct)
 	return ecdsa.Verify(pubKey.(*ecdsa.PublicKey), digest, sigStruct.R, sigStruct.S)
 }


### PR DESCRIPTION
As per the crypto.Signer spec, ecdsa signatures are returned in a DER-serialised, ASN.1 signature structure (and is done the same way used in the ecdsa lib).