### PR TITLE
Package gotpm for Arch Linux

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,8 @@
 gotpm
 !gotpm/
 gotpm.exe
+files/pkg
+files/src
+files/go-tpm-tools
+*.pkg.tar.xz
 .vscode*

--- a/files/PKGBUILD
+++ b/files/PKGBUILD
@@ -1,0 +1,35 @@
+# Maintainer: Joe Richey <joerichey@google.com>
+pkgname=gotpm
+pkgver=0.1.2
+pkgrel=1
+pkgdesc='TPM2 command-line utility'
+arch=('x86_64')
+_reponame=go-tpm-tools
+url="https://github.com/google/${_reponame}"
+license=('APACHE')
+depends=('glibc') # go-pie requires CGO, so we have to link against libc
+makedepends=('go-pie')
+source=("git+${url}.git#tag=v${pkgver}?signed")
+validpgpkeys=('19CE40CEB581BCD81E1FB2371DD6D05AA306C53F')
+sha256sums=('SKIP')
+
+build() {
+  cd ${_reponame}
+  go build \
+    -trimpath \
+    -ldflags "-extldflags $LDFLAGS" \
+    ./cmd/${pkgname}
+}
+
+package() {
+  cd ${_reponame}
+
+  install -Dm755 $pkgname "${pkgdir}/usr/bin/${pkgname}"
+  install -Dm755 files/boot-unseal.sh "${pkgdir}/etc/${pkgname}/boot-unseal.sh"
+
+  initcpio_name='encrypt-gotpm'
+  install -Dm644 files/initcpio.hooks "${pkgdir}/usr/lib/initcpio/hooks/${initcpio_name}"
+  install -Dm644 files/initcpio.install "${pkgdir}/usr/lib/initcpio/install/${initcpio_name}"
+
+  install -Dm644 LICENSE "${pkgdir}/usr/share/licenses/${pkgname}/LICENSE"
+}

--- a/files/boot-unseal.sh
+++ b/files/boot-unseal.sh
@@ -16,21 +16,24 @@ for device in $(blkid -o device); do
     # the key is unsealed by the TPM, does not mean it will unlock the disk. We
     # write the unsealed key to the in-memory rootfs, it is not written to disk.
     for f in /mnt/esp/*/disk_unlock_keys/*.sealed; do
-        if [ -f "$f" ] && gotpm unseal --input "$f" --output "/crypto_keyfile.bin" ; then
-            echo "gotpm: Unsealed $f"
-            key_found=1
-            break
+        if [ -f "$f" ]; then
+            if gotpm unseal --input "$f" --output "/crypto_keyfile.bin" ; then
+                echo "Unsealed ${f#/mnt/esp}"
+                key_found=1
+                break
+            else
+                echo "Failed to unseal ${f#/mnt/esp}"
+            fi
         fi
     done
     umount $device
 
     if [ $key_found -ne 0 ]; then
-        break
+        exit 0
     fi
 done
 
-if [ $key_found -eq 0 ]; then
-    echo "gotpm: Unable to unseal any TPM disk unlock key"
-fi
+echo "Unable to unseal any TPM disk unlock key"
+exit 1
 
 # vim: set ft=sh ts=4 sw=4 et:

--- a/files/boot-unseal.sh
+++ b/files/boot-unseal.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/ash
 
-unlocked=0
+key_found=0
 # Loop through all devices to find the ESP
 for device in $(blkid -o device); do
     part_type=$(blkid -p $device -s PART_ENTRY_TYPE -o value)
@@ -12,23 +12,25 @@ for device in $(blkid -o device); do
     mkdir -p /mnt/esp
     mount -t vfat $device /mnt/esp
 
-    # Try all of the keys in the appropriate folder
+    # Attempt to unseal each sealed keyfile on the ESP. Note that just becasue
+    # the key is unsealed by the TPM, does not mean it will unlock the disk. We
+    # write the unsealed key to the in-memory rootfs, it is not written to disk.
     for f in /mnt/esp/*/disk_unlock_keys/*.sealed; do
-        if gotpm unseal --input "$f" --output "/crypto_keyfile.bin" ; then
+        if [ -f "$f" ] && gotpm unseal --input "$f" --output "/crypto_keyfile.bin" ; then
             echo "gotpm: Unsealed $f"
-            unlocked=1
+            key_found=1
             break
         fi
     done
     umount $device
 
-    if [ $unlocked -ne 0 ]; then
+    if [ $key_found -ne 0 ]; then
         break
     fi
 done
 
-if [ $unlocked -eq 0 ]; then
-    echo "gotpm: Unable to unseal TPM disk unlock key"
+if [ $key_found -eq 0 ]; then
+    echo "gotpm: Unable to unseal any TPM disk unlock key"
 fi
 
 # vim: set ft=sh ts=4 sw=4 et:

--- a/files/boot-unseal.sh
+++ b/files/boot-unseal.sh
@@ -10,7 +10,7 @@ for device in $(blkid -o device); do
 
     # Temporarily mount the ESP to read disk unlock keys
     mkdir -p /mnt/esp
-    mount -t vfat $device /mnt/esp
+    mount -t vfat -o ro $device /mnt/esp
 
     # Attempt to unseal each sealed keyfile on the ESP. Note that just becasue
     # the key is unsealed by the TPM, does not mean it will unlock the disk. We

--- a/files/boot-unseal.sh
+++ b/files/boot-unseal.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/ash
+
+# Loop through all devices to find the ESP
+for device in $(blkid -o device); do
+    part_type=$(blkid -p $device -s PART_ENTRY_TYPE -o value)
+    if [[ "$part_type" != "c12a7328-f81f-11d2-ba4b-00a0c93ec93b" ]]; then
+        continue
+    fi
+
+    # Temporarily mount the ESP to read disk unlock keys
+    mkdir -p /mnt/esp
+    mount -t vfat $device /mnt/esp
+
+    # Try all of the keys in the appropriate folder
+    for f in /mnt/esp/*/disk_unlock_keys/*.sealed; do
+        if gotpm unseal --input "$f" --output "/crypto_keyfile.bin" ; then
+            echo "gotpm: Unsealed $f"
+        fi
+    done
+    umount $device
+done
+
+# vim: set ft=sh ts=4 sw=4 et:

--- a/files/boot-unseal.sh
+++ b/files/boot-unseal.sh
@@ -1,9 +1,10 @@
 #!/usr/bin/ash
 
+unlocked=0
 # Loop through all devices to find the ESP
 for device in $(blkid -o device); do
     part_type=$(blkid -p $device -s PART_ENTRY_TYPE -o value)
-    if [[ "$part_type" != "c12a7328-f81f-11d2-ba4b-00a0c93ec93b" ]]; then
+    if [ "$part_type" != "c12a7328-f81f-11d2-ba4b-00a0c93ec93b" ]; then
         continue
     fi
 
@@ -15,9 +16,19 @@ for device in $(blkid -o device); do
     for f in /mnt/esp/*/disk_unlock_keys/*.sealed; do
         if gotpm unseal --input "$f" --output "/crypto_keyfile.bin" ; then
             echo "gotpm: Unsealed $f"
+            unlocked=1
+            break
         fi
     done
     umount $device
+
+    if [ $unlocked -ne 0 ]; then
+        break
+    fi
 done
+
+if [ $unlocked -eq 0 ]; then
+    echo "gotpm: Unable to unseal TPM disk unlock key"
+fi
 
 # vim: set ft=sh ts=4 sw=4 et:

--- a/files/initcpio.hooks
+++ b/files/initcpio.hooks
@@ -1,0 +1,7 @@
+#!/usr/bin/ash
+
+run_hook() {
+    /etc/gotpm/boot-unseal.sh
+}
+
+# vim: set ft=sh ts=4 sw=4 et:

--- a/files/initcpio.install
+++ b/files/initcpio.install
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+build() {
+    # Allows us to mount the ESP
+    add_module vfat
+    # Allows us to use the TPM (through either hardware interface).
+    add_module tpm_crb
+    add_module tpm_tis
+
+    add_binary gotpm
+    add_file /etc/gotpm/boot-unseal.sh
+
+    add_runscript
+}
+
+help() {
+    cat <<HELPEOF
+This hook enables unlocking TPM-bound encrypted disks with gotpm. This hook
+should be placed before the "encrypt" hook.
+HELPEOF
+}
+
+# vim: set ft=sh ts=4 sw=4 et:


### PR DESCRIPTION
This adds Arch Linux support.

We now support installing the binary as well as adding initramfs hooks for unlocking TPM secrets at boot time. This process has some Arch Linux specific components.

Note that incorporating Debian configs is not yet ready (as Debian packaging is much more complex. 

Note that (right now) we use my work PGP key for verifying the package. This allows us to avoid updating sha256 sums every time we bump the package. 