### PR TITLE
cmd: Set SilenceUsage in PersistentPreRunE

### DIFF
--- a/cmd/flush.go
+++ b/cmd/flush.go
@@ -49,7 +49,6 @@ Which handles are flushed depends on the argument passed:
 	}(),
 	Args: cobra.ExactValidArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		cmd.SilenceUsage = true
 		rwc, err := openTpm()
 		if err != nil {
 			return err

--- a/cmd/pubkey.go
+++ b/cmd/pubkey.go
@@ -46,8 +46,6 @@ NVDATA instead (and --algo is ignored).`,
 	}(),
 	Args: cobra.ExactValidArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		cmd.SilenceUsage = true
-
 		rwc, err := openTpm()
 		if err != nil {
 			return err

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -21,6 +21,7 @@ See the per-command documentation for more information.`,
 		if quiet && verbose {
 			return fmt.Errorf("cannot specify both --quiet and --verbose")
 		}
+		cmd.SilenceUsage = true
 		return nil
 	},
 }


### PR DESCRIPTION
This avoids dumping usage on errors unrelated to usage.