### PR TITLE
Import RSA signing keys with PCR policies

### DIFF
--- a/server/import_test.go
+++ b/server/import_test.go
@@ -2,6 +2,9 @@ package server
 
 import (
 	"bytes"
+	"crypto"
+	"crypto/rand"
+	"crypto/rsa"
 	"testing"
 
 	"github.com/google/go-tpm-tools/internal"
@@ -84,7 +87,6 @@ func TestImportPCRs(t *testing.T) {
 			if err != nil {
 				t.Fatalf("creating import blob failed: %v", err)
 			}
-
 			output, err := ek.Import(rwc, blob)
 			if test.expectSuccess {
 				if err != nil {
@@ -93,6 +95,70 @@ func TestImportPCRs(t *testing.T) {
 				if !bytes.Equal(output, secret) {
 					t.Errorf("got %X, expected %X", output, secret)
 				}
+			} else if err == nil {
+				t.Error("expected Import to fail but it did not")
+			}
+		})
+	}
+}
+
+func TestSigningKeyImport(t *testing.T) {
+	rwc := internal.GetTPM(t)
+	defer tpm2tools.CheckedClose(t, rwc)
+
+	ek, err := tpm2tools.EndorsementKeyRSA(rwc)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ek.Close()
+	signingKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatal(err)
+	}
+	pcr0, err := tpm2.ReadPCR(rwc, 0, tpm2.AlgSHA256)
+	if err != nil {
+		t.Fatal(err)
+	}
+	badPCR := append(make([]byte, 0), pcr0...)
+	// badPCR increments first value so it doesn't match.
+	badPCR[0]++
+	tests := []struct {
+		name          string
+		pcrs          *proto.Pcrs
+		expectSuccess bool
+	}{
+		{"No-PCR-nil", nil, true},
+		{"No-PCR-empty", &proto.Pcrs{Hash: proto.HashAlgo_SHA256}, true},
+		{"Good-PCR", &proto.Pcrs{Hash: proto.HashAlgo_SHA256, Pcrs: map[uint32][]byte{0: pcr0}}, true},
+		{"Bad-PCR", &proto.Pcrs{Hash: proto.HashAlgo_SHA256, Pcrs: map[uint32][]byte{0: badPCR}}, false},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			blob, err := CreateSigningKeyImportBlob(ek.PublicKey(), signingKey, test.pcrs)
+			if err != nil {
+				t.Fatalf("creating import blob failed: %v", err)
+			}
+
+			importedKey, err := ek.ImportSigningKey(blob)
+			if err != nil {
+				t.Fatalf("import failed: %v", err)
+			}
+			defer importedKey.Close()
+			signer, err := importedKey.GetSigner()
+			if err != nil {
+				t.Fatalf("could not create signer: %v", err)
+			}
+			var digest [32]byte
+
+			sig, err := signer.Sign(nil, digest[:], crypto.SHA256)
+			if test.expectSuccess {
+				if err != nil {
+					t.Fatalf("import failed: %v", err)
+				}
+				if err = rsa.VerifyPKCS1v15(&signingKey.PublicKey, crypto.SHA256, digest[:], sig); err != nil {
+					t.Error(err)
+				}
+				return
 			} else if err == nil {
 				t.Error("expected Import to fail but it did not")
 			}

--- a/server/key_conversion.go
+++ b/server/key_conversion.go
@@ -3,9 +3,12 @@ package server
 import (
 	"crypto"
 	"crypto/ecdsa"
+	"crypto/rand"
 	"crypto/rsa"
 	"fmt"
+	"io"
 
+	tpmpb "github.com/google/go-tpm-tools/proto"
 	"github.com/google/go-tpm-tools/tpm2tools"
 	"github.com/google/go-tpm/tpm2"
 )
@@ -43,4 +46,40 @@ func createEKPublicECC(eccKey *ecdsa.PublicKey) (public tpm2.Public, err error) 
 	}
 	public.ECCParameters.CurveID, err = goCurveToCurveID(eccKey.Curve)
 	return public, err
+}
+
+func createPublic(private tpm2.Private, hashAlg tpm2.Algorithm, pcrs *tpmpb.Pcrs) tpm2.Public {
+	publicHash := getHash(hashAlg)
+	publicHash.Write(private.SeedValue)
+	publicHash.Write(private.Sensitive)
+	public := tpm2.Public{
+		Type:    tpm2.AlgKeyedHash,
+		NameAlg: hashAlg,
+		KeyedHashParameters: &tpm2.KeyedHashParams{
+			Alg:    tpm2.AlgNull,
+			Unique: publicHash.Sum(nil),
+		},
+	}
+	if len(pcrs.GetPcrs()) == 0 {
+		// Allow password authorization so we can use a nil AuthPolicy.
+		public.AuthPolicy = nil
+		public.Attributes |= tpm2.FlagUserWithAuth
+	} else {
+		public.AuthPolicy = tpm2tools.ComputePCRSessionAuth(pcrs)
+		public.Attributes |= tpm2.FlagAdminWithPolicy
+	}
+	return public
+}
+
+func createPrivate(sensitive []byte, hashAlg tpm2.Algorithm) tpm2.Private {
+	private := tpm2.Private{
+		Type:      tpm2.AlgKeyedHash,
+		AuthValue: nil,
+		SeedValue: make([]byte, getHash(hashAlg).Size()),
+		Sensitive: sensitive,
+	}
+	if _, err := io.ReadFull(rand.Reader, private.SeedValue); err != nil {
+		panic(err)
+	}
+	return private
 }


### PR DESCRIPTION
Add importing for RSA signing keys.

The import flow returns a *Key to the user, which can be used to get a tpmSigner to sign digests.
