### PR TITLE
Add PSS support for Signer

### DIFF
--- a/simulator/ms-tpm-20-ref/TPMCmd/tpm/include/TpmProfile.h
+++ b/simulator/ms-tpm-20-ref/TPMCmd/tpm/include/TpmProfile.h
@@ -171,7 +171,7 @@
 #define NUM_AUTHVALUE_PCR_GROUP         1
 #endif
 #ifndef MAX_CONTEXT_SIZE
-#define MAX_CONTEXT_SIZE                1360
+#define MAX_CONTEXT_SIZE                1264
 #endif
 #ifndef MAX_DIGEST_BUFFER
 #define MAX_DIGEST_BUFFER               1024
@@ -356,7 +356,7 @@
 #define ALG_SHA3_512                    ALG_NO      /* Not specified by vendor */
 #endif
 #ifndef ALG_SHA512
-#define ALG_SHA512                      ALG_YES
+#define ALG_SHA512                      ALG_NO
 #endif
 #ifndef ALG_SM2
 #define ALG_SM2                         (ALG_NO && ALG_ECC)

--- a/simulator/ms-tpm-20-ref/TPMCmd/tpm/include/TpmProfile.h
+++ b/simulator/ms-tpm-20-ref/TPMCmd/tpm/include/TpmProfile.h
@@ -171,7 +171,7 @@
 #define NUM_AUTHVALUE_PCR_GROUP         1
 #endif
 #ifndef MAX_CONTEXT_SIZE
-#define MAX_CONTEXT_SIZE                1264
+#define MAX_CONTEXT_SIZE                1360
 #endif
 #ifndef MAX_DIGEST_BUFFER
 #define MAX_DIGEST_BUFFER               1024
@@ -356,7 +356,7 @@
 #define ALG_SHA3_512                    ALG_NO      /* Not specified by vendor */
 #endif
 #ifndef ALG_SHA512
-#define ALG_SHA512                      ALG_NO
+#define ALG_SHA512                      ALG_YES
 #endif
 #ifndef ALG_SM2
 #define ALG_SM2                         (ALG_NO && ALG_ECC)

--- a/tpm2tools/signer.go
+++ b/tpm2tools/signer.go
@@ -3,7 +3,6 @@ package tpm2tools
 import (
 	"crypto"
 	"crypto/rsa"
-<<<<<<< HEAD
 	"encoding/asn1"
 	"fmt"
 	"io"
@@ -19,25 +18,6 @@ var signerMutex sync.Mutex
 type tpmSigner struct {
 	Key  *Key
 	Hash crypto.Hash
-=======
-	"fmt"
-	"io"
-	"sync"
-
-	"github.com/google/go-tpm/tpm2"
-)
-
-var (
-	// Global mutex to protect against concurrent TPM read/writes.
-	signerMutex = &sync.Mutex{}
-)
-
-// TpmSigner implements the crypto.Signer interface for TPM Keys.
-// Concurrent use of one or more TpmSigners is thread safe, but it is not safe
-// to read/write to the TPM from other sources while using a TpmSigner.
-type TpmSigner struct {
-	key *Key
->>>>>>> 81cb72b... Format and change comments
 }
 
 // Public returns the tpmSigners public key.
@@ -45,21 +25,12 @@ func (signer *tpmSigner) Public() crypto.PublicKey {
 	return signer.Key.PublicKey()
 }
 
-<<<<<<< HEAD
 // Sign uses the TPM key to sign the digest.
 // The digest must be hashed from the same hash algorithm as the keys scheme.
 // The opts hash function must also match the keys scheme.
 // Concurrent use of Sign is thread safe, but it is not safe to access the TPM
 // from other sources while Sign is executing.
 func (signer *tpmSigner) Sign(_ io.Reader, digest []byte, opts crypto.SignerOpts) (signature []byte, err error) {
-=======
-// Sign uses the TPM key to  sign the digest.
-// The digest must be hashed from the same hash algorithm as the keys scheme.
-// The opts hash function must also match the keys scheme.
-// Concurrent use of Sign is thread safe, but it is not safe to read/write to
-// the TPM from other sources while Sign is executing.
-func (signer TpmSigner) Sign(_ io.Reader, digest []byte, opts crypto.SignerOpts) (signature []byte, err error) {
->>>>>>> 81cb72b... Format and change comments
 	if _, ok := opts.(*rsa.PSSOptions); ok {
 		return nil, fmt.Errorf("signing with PSS not supported")
 	}
@@ -78,7 +49,6 @@ func (signer TpmSigner) Sign(_ io.Reader, digest []byte, opts crypto.SignerOpts)
 		return nil, err
 	}
 
-<<<<<<< HEAD
 	switch sig.Alg {
 	case tpm2.AlgRSASSA:
 		return sig.RSA.Signature, nil
@@ -89,15 +59,6 @@ func (signer TpmSigner) Sign(_ io.Reader, digest []byte, opts crypto.SignerOpts)
 		panic("unsupported signing algorithm")
 	}
 }
-=======
-	public := signer.key.pubArea
-
-	switch public.Type {
-	case tpm2.AlgRSA:
-		if hash != public.RSAParameters.Sign.Hash {
-			return nil, fmt.Errorf("opts hash: %v does not match the keys signing hash: %v", hash, public.RSAParameters.Sign.Hash)
-		}
->>>>>>> 81cb72b... Format and change comments
 
 // GetSigner returns a crypto.Signer wrapping the loaded TPM Key.
 // Concurrent use of one or more Signers is thread safe, but it is not safe to
@@ -115,20 +76,8 @@ func (k *Key) GetSigner() (crypto.Signer, error) {
 		return nil, fmt.Errorf("non-signing key used with GetSigner()")
 	}
 
-<<<<<<< HEAD
 	var sigScheme *tpm2.SigScheme
 	var sigAlg tpm2.Algorithm
-=======
-		sig, err := tpm2.Sign(signer.key.rw, signer.key.handle, "", digest, nil)
-		if err != nil {
-			return nil, err
-		}
-		return sig.RSA.Signature, nil
-	default:
-		return nil, fmt.Errorf("unsupported key type: %v", public.Type)
-	}
-}
->>>>>>> 81cb72b... Format and change comments
 
 	switch k.pubArea.Type {
 	case tpm2.AlgRSA:

--- a/tpm2tools/signer_test.go
+++ b/tpm2tools/signer_test.go
@@ -151,11 +151,11 @@ func TestSignPSS(t *testing.T) {
 		{"RSA-SHA384", crypto.SHA384, templatePSS(tpm2.AlgSHA384), 1024, 48},
 		{"RSA-SHA512", crypto.SHA512, templatePSS(tpm2.AlgSHA512), 1024, 62},
 		{"RSA-SHA512", crypto.SHA512, templatePSS(tpm2.AlgSHA512), 2048, 64},
-		{"RSA-SHA1", &rsa.PSSOptions{rsa.PSSSaltLengthAuto, crypto.SHA1}, templatePSS(tpm2.AlgSHA1), 1024, 20},
-		{"RSA-SHA256", &rsa.PSSOptions{rsa.PSSSaltLengthAuto, crypto.SHA256}, templatePSS(tpm2.AlgSHA256), 1024, 32},
-		{"RSA-SHA384", &rsa.PSSOptions{rsa.PSSSaltLengthAuto, crypto.SHA384}, templatePSS(tpm2.AlgSHA384), 1024, 48},
-		{"RSA-SHA512", &rsa.PSSOptions{rsa.PSSSaltLengthAuto, crypto.SHA512}, templatePSS(tpm2.AlgSHA512), 1024, 62},
-		{"RSA-SHA512", &rsa.PSSOptions{rsa.PSSSaltLengthAuto, crypto.SHA512}, templatePSS(tpm2.AlgSHA512), 2048, 64},
+		{"RSA-SHA1", &rsa.PSSOptions{SaltLength: rsa.PSSSaltLengthAuto, Hash: crypto.SHA1}, templatePSS(tpm2.AlgSHA1), 1024, 20},
+		{"RSA-SHA256", &rsa.PSSOptions{SaltLength: rsa.PSSSaltLengthAuto, Hash: crypto.SHA256}, templatePSS(tpm2.AlgSHA256), 1024, 32},
+		{"RSA-SHA384", &rsa.PSSOptions{SaltLength: rsa.PSSSaltLengthAuto, Hash: crypto.SHA384}, templatePSS(tpm2.AlgSHA384), 1024, 48},
+		{"RSA-SHA512", &rsa.PSSOptions{SaltLength: rsa.PSSSaltLengthAuto, Hash: crypto.SHA512}, templatePSS(tpm2.AlgSHA512), 1024, 62},
+		{"RSA-SHA512", &rsa.PSSOptions{SaltLength: rsa.PSSSaltLengthAuto, Hash: crypto.SHA512}, templatePSS(tpm2.AlgSHA512), 2048, 64},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
This change is mostly just writing test code to verify RSAPSS signing works as expected, particularly for salt lengths.