### PR TITLE
Add ECC AIK template and cache; Work around for CertifyCreation

### DIFF
--- a/tpm2tools/handles.go
+++ b/tpm2tools/handles.go
@@ -9,10 +9,17 @@ import (
 	"github.com/google/go-tpm/tpmutil"
 )
 
-// Reserved Handles from "TCG TPM v2.0 Provisioning Guidance" - v1r1 - Table 2
 const (
-	EKReservedHandle  = tpmutil.Handle(0x81010001)
-	SRKReservedHandle = tpmutil.Handle(0x81000001)
+	// Reserved Handles from "TCG TPM v2.0 Provisioning Guidance" - v1r1 - Table 2
+	EKReservedHandle     = tpmutil.Handle(0x81010001)
+	EKECCReservedHandle  = tpmutil.Handle(0x81010002)
+	SRKReservedHandle    = tpmutil.Handle(0x81000001)
+	SRKECCReservedHandle = tpmutil.Handle(0x81000002)
+
+	// Picked available handles from TPM 2.0 Handles and Localities 2.3.1 - Table 11
+	// go-tpm-tools will use handles in the range from 0x81008F00 to 0x81008FFF
+	DefaultAIKECCHandle = tpmutil.Handle(0x81008F00)
+	DefaultAIKRSAHandle = tpmutil.Handle(0x81008F01)
 )
 
 func isHierarchy(h tpmutil.Handle) bool {

--- a/tpm2tools/keys.go
+++ b/tpm2tools/keys.go
@@ -29,7 +29,7 @@ func EndorsementKeyRSA(rw io.ReadWriter) (*Key, error) {
 
 // EndorsementKeyECC generates and loads a key from DefaultEKTemplateECC.
 func EndorsementKeyECC(rw io.ReadWriter) (*Key, error) {
-	return NewKey(rw, tpm2.HandleEndorsement, DefaultEKTemplateECC())
+	return NewCachedKey(rw, tpm2.HandleEndorsement, DefaultEKTemplateECC(), EKECCReservedHandle)
 }
 
 // StorageRootKeyRSA generates and loads a key from SRKTemplateRSA.
@@ -37,14 +37,24 @@ func StorageRootKeyRSA(rw io.ReadWriter) (*Key, error) {
 	return NewCachedKey(rw, tpm2.HandleOwner, SRKTemplateRSA(), SRKReservedHandle)
 }
 
-// AttestationIdentityKeyRSA generates and loads a key from AIKTemplateRSA
-func AttestationIdentityKeyRSA(rw io.ReadWriter, nonces []byte) (*Key, error) {
-	return NewKey(rw, tpm2.HandleOwner, AIKTemplateRSA(nonces))
-}
-
 // StorageRootKeyECC generates and loads a key from SRKTemplateECC.
 func StorageRootKeyECC(rw io.ReadWriter) (*Key, error) {
-	return NewKey(rw, tpm2.HandleOwner, SRKTemplateECC())
+	return NewCachedKey(rw, tpm2.HandleOwner, SRKTemplateECC(), SRKECCReservedHandle)
+}
+
+// AttestationIdentityKeyRSA generates and loads a key from AIKTemplateRSA
+func AttestationIdentityKeyRSA(rw io.ReadWriter, nonces []byte) (*Key, error) {
+	// If nonce is null, then try to use the cached key
+	if nonces == nil {
+		return NewCachedKey(rw, tpm2.HandleOwner, AIKTemplateRSA(nonces), DefaultAIKRSAHandle)
+	} else {
+		return NewKey(rw, tpm2.HandleOwner, AIKTemplateRSA(nonces))
+	}
+}
+
+// AttestationIdentityKeyECC generates and loads a key from AIKTemplateECC
+func AttestationIdentityKeyECC(rw io.ReadWriter) (*Key, error) {
+	return NewCachedKey(rw, tpm2.HandleOwner, AIKTemplateECC(), DefaultAIKECCHandle)
 }
 
 // EndorsementKeyFromNvIndex generates and loads an endorsement key using the

--- a/tpm2tools/keys_test.go
+++ b/tpm2tools/keys_test.go
@@ -1,6 +1,7 @@
 package tpm2tools
 
 import (
+	"crypto/rand"
 	"io"
 	"reflect"
 	"testing"
@@ -102,8 +103,17 @@ func TestKeyCreation(t *testing.T) {
 	}{
 		{"SRK-ECC", StorageRootKeyECC},
 		{"EK-ECC", EndorsementKeyECC},
+		{"AIK-ECC", AttestationIdentityKeyECC},
 		{"SRK-RSA", StorageRootKeyRSA},
 		{"EK-RSA", EndorsementKeyRSA},
+		{"AIK-RSA-Default", func(rw io.ReadWriter) (*Key, error) {
+			return AttestationIdentityKeyRSA(rw, nil)
+		}},
+		{"AIK-RSA-Nonce", func(rw io.ReadWriter) (*Key, error) {
+			nonce := make([]byte, 16)
+			rand.Read(nonce)
+			return AttestationIdentityKeyRSA(rw, nonce)
+		}},
 	}
 
 	for _, test := range tests {

--- a/tpm2tools/keys_test.go
+++ b/tpm2tools/keys_test.go
@@ -135,19 +135,36 @@ func BenchmarkKeyCreation(b *testing.B) {
 		name   string
 		getKey func(io.ReadWriter) (*Key, error)
 	}{
-		{"SRK-ECC", StorageRootKeyECC},
-		{"EK-ECC", EndorsementKeyECC},
+		{"SRK-ECC-Cached", StorageRootKeyECC},
+		{"EK-ECC-Cached", EndorsementKeyECC},
+		{"AIK-ECC-Default-Cached", AttestationIdentityKeyECC},
+
+		{"SRK-ECC", func(rw io.ReadWriter) (*Key, error) {
+			return NewKey(rw, tpm2.HandleOwner, SRKTemplateECC())
+		}},
+		{"EK-ECC", func(rw io.ReadWriter) (*Key, error) {
+			return NewKey(rw, tpm2.HandleEndorsement, DefaultEKTemplateECC())
+		}},
+		{"AIK-ECC-Default", func(rw io.ReadWriter) (*Key, error) {
+			return NewKey(rw, tpm2.HandleOwner, AIKTemplateECC())
+		}},
+
 		{"SRK-RSA-Cached", StorageRootKeyRSA},
 		{"EK-RSA-Cached", EndorsementKeyRSA},
+		{"AIK-RSA-Default-Cached", func(rw io.ReadWriter) (*Key, error) {
+			return AttestationIdentityKeyRSA(rw, nil)
+		}},
+
 		{"SRK-RSA", func(rw io.ReadWriter) (*Key, error) {
 			return NewKey(rw, tpm2.HandleEndorsement, SRKTemplateRSA())
 		}},
 		{"EK-RSA", func(rw io.ReadWriter) (*Key, error) {
 			return NewKey(rw, tpm2.HandleOwner, DefaultEKTemplateRSA())
 		}},
-		{"AIK-RSA-Null", func(rw io.ReadWriter) (*Key, error) {
-			template := AIKTemplateRSA(nil)
-			return NewKey(rw, tpm2.HandleNull, template)
+		{"AIK-RSA", func(rw io.ReadWriter) (*Key, error) {
+			nonce := make([]byte, 16)
+			rand.Read(nonce)
+			return AttestationIdentityKeyRSA(rw, nonce)
 		}},
 	}
 

--- a/tpm2tools/template.go
+++ b/tpm2tools/template.go
@@ -104,6 +104,29 @@ func AIKTemplateRSA(nonce []byte) tpm2.Public {
 	}
 }
 
+// AIKTemplateRSA returns a potential Attestation Identity Key (AIK) template.
+// This is very similar to DefaultEKTemplateECC, except that this will be a
+// signing key instead of an encrypting key. Unlike AIKTemplateRSA, this ECC
+// template doesn't accept a nonce.
+func AIKTemplateECC() tpm2.Public {
+	return tpm2.Public{
+		Type:       tpm2.AlgECC,
+		NameAlg:    tpm2.AlgSHA256,
+		Attributes: tpm2.FlagSignerDefault,
+		ECCParameters: &tpm2.ECCParams{
+			Sign: &tpm2.SigScheme{
+				Alg:  tpm2.AlgECDSA,
+				Hash: tpm2.AlgSHA256,
+			},
+			CurveID: tpm2.CurveNISTP256,
+			Point: tpm2.ECPoint{
+				XRaw: make([]byte, 32),
+				YRaw: make([]byte, 32),
+			},
+		},
+	}
+}
+
 // SRKTemplateRSA returns a standard Storage Root Key (SRK) template.
 // This is based upon the advice in the TCG's TPM v2.0 Provisioning Guidance.
 func SRKTemplateRSA() tpm2.Public {


### PR DESCRIPTION
Certain TPM (the one on my Lenovo X1 carbon) cannot handle CeritfyCreation with a null signing handle correctly. It will throw a TPM_RC_INSUFFICIENT error when we trying to do that.

One work around is that we pass in a non-null signing handle into CertifyCreation.
This PR implement this work around as well as add a ECC AIK template.

AIK ECC key will be cached for performance concerns.
I picked the handle 0x81008FFF (I picked randomly from "Storage -> Available" from Table 11 from  https://trustedcomputinggroup.org/wp-content/uploads/RegistryOfReservedTPM2HandlesAndLocalities_v1p1_pub.pdf