### PR TITLE
tpm2tools: Consolidate session handling

### DIFF
--- a/server/import_test.go
+++ b/server/import_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/google/go-tpm/tpm2"
 )
 
-func TestImportEKs(t *testing.T) {
+func TestImport(t *testing.T) {
 	rwc := internal.GetTPM(t)
 	defer tpm2tools.CheckedClose(t, rwc)
 	tests := []struct {
@@ -19,6 +19,8 @@ func TestImportEKs(t *testing.T) {
 	}{
 		{"RSA", tpm2tools.DefaultEKTemplateRSA()},
 		{"ECC", tpm2tools.DefaultEKTemplateECC()},
+		{"SRK-RSA", tpm2tools.SRKTemplateRSA()},
+		{"SRK-ECC", tpm2tools.SRKTemplateECC()},
 		{"ECC-P224", getECCTemplate(tpm2.CurveNISTP224)},
 		{"ECC-P256", getECCTemplate(tpm2.CurveNISTP256)},
 		{"ECC-P384", getECCTemplate(tpm2.CurveNISTP384)},

--- a/tpm2tools/import.go
+++ b/tpm2tools/import.go
@@ -6,39 +6,14 @@ import (
 
 	tpmpb "github.com/google/go-tpm-tools/proto"
 	"github.com/google/go-tpm/tpm2"
-	"github.com/google/go-tpm/tpmutil"
 )
 
 // Import decrypts the secret contained in an encoded import request.
-// This method only works if the Key is a standard (low address) EK.
+// The key used must be an encryption key (signing keys cannot be used).
 // The req parameter should come from server.CreateImportBlob.
 func (k *Key) Import(rw io.ReadWriter, blob *tpmpb.ImportBlob) ([]byte, error) {
-	session, _, err := tpm2.StartAuthSession(
-		rw,
-		tpm2.HandleNull,  /*tpmKey*/
-		tpm2.HandleNull,  /*bindKey*/
-		make([]byte, 16), /*nonceCaller*/
-		nil,              /*secret*/
-		tpm2.SessionPolicy,
-		tpm2.AlgNull,
-		tpm2.AlgSHA256)
+	auth, err := k.session.Auth()
 	if err != nil {
-		return nil, err
-	}
-	defer tpm2.FlushContext(rw, session)
-
-	// Authorization w/ EK has to use Policy Secret sessions. Call
-	// refreshSession, before each use of the EK using auth.
-	refreshSession := func() error {
-		nullAuth := tpm2.AuthCommand{Session: tpm2.HandlePasswordSession, Attributes: tpm2.AttrContinueSession}
-		if _, err := tpm2.PolicySecret(rw, tpm2.HandleEndorsement, nullAuth, session, nil, nil, nil, 0); err != nil {
-			return fmt.Errorf("authorizing policy failed: %s", err)
-		}
-		return nil
-	}
-	auth := tpm2.AuthCommand{Session: session, Attributes: tpm2.AttrContinueSession}
-
-	if err = refreshSession(); err != nil {
 		return nil, err
 	}
 	private, err := tpm2.Import(rw, k.Handle(), auth, blob.PublicArea, blob.Duplicate, blob.EncryptedSeed, nil, nil)
@@ -46,7 +21,8 @@ func (k *Key) Import(rw io.ReadWriter, blob *tpmpb.ImportBlob) ([]byte, error) {
 		return nil, fmt.Errorf("import failed: %s", err)
 	}
 
-	if err = refreshSession(); err != nil {
+	auth, err = k.session.Auth()
+	if err != nil {
 		return nil, err
 	}
 	handle, _, err := tpm2.LoadUsingAuth(rw, k.Handle(), auth, blob.PublicArea, private)
@@ -55,23 +31,17 @@ func (k *Key) Import(rw io.ReadWriter, blob *tpmpb.ImportBlob) ([]byte, error) {
 	}
 	defer tpm2.FlushContext(rw, handle)
 
-	var out []byte
-	if len(blob.Pcrs.GetPcrs()) == 0 {
-		// The object to be imported does not have a PCR policy.
-		out, err = tpm2.Unseal(rw, handle, "")
-	} else {
-		// The object to be imported has a PCR policy.
-		pcrSel := PCRSelection(blob.Pcrs)
-
-		var unsealSession tpmutil.Handle
-		unsealSession, err = createPCRSession(rw, pcrSel)
-		if err != nil {
-			return nil, err
-		}
-		defer tpm2.FlushContext(rw, unsealSession)
-
-		out, err = tpm2.UnsealWithSession(rw, unsealSession, handle, "")
+	unsealSession, err := newPCRSession(rw, PCRSelection(blob.Pcrs))
+	if err != nil {
+		return nil, err
 	}
+	defer unsealSession.Close()
+
+	auth, err = unsealSession.Auth()
+	if err != nil {
+		return nil, err
+	}
+	out, err := tpm2.UnsealWithSession(rw, auth.Session, handle, "")
 	if err != nil {
 		return nil, fmt.Errorf("unseal failed: %s", err)
 	}

--- a/tpm2tools/keys_test.go
+++ b/tpm2tools/keys_test.go
@@ -64,6 +64,8 @@ func TestCachedRSAKeys(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
+			defer srk.Close()
+
 			pub := srk.PublicKey()
 			if tpm2.FlushContext(rwc, srk.Handle()) == nil {
 				t.Error("Trying to flush persistent keys should fail.")
@@ -74,6 +76,8 @@ func TestCachedRSAKeys(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
+			defer srk.Close()
+
 			if !reflect.DeepEqual(srk.PublicKey(), pub) {
 				t.Errorf("Expected pub key: %v got: %v", pub, srk.PublicKey())
 			}
@@ -86,6 +90,8 @@ func TestCachedRSAKeys(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
+			defer srk.Close()
+
 			if !reflect.DeepEqual(srk.PublicKey(), pub) {
 				t.Errorf("Expected pub key: %v got: %v", pub, srk.PublicKey())
 			}

--- a/tpm2tools/session.go
+++ b/tpm2tools/session.go
@@ -1,0 +1,89 @@
+package tpm2tools
+
+import (
+	"io"
+
+	"github.com/google/go-tpm/tpm2"
+	"github.com/google/go-tpm/tpmutil"
+)
+
+type session interface {
+	io.Closer
+	Auth() (tpm2.AuthCommand, error)
+}
+
+func startAuthSesssion(rw io.ReadWriter) (session tpmutil.Handle, err error) {
+	// This session assumes the bus is trusted, so we:
+	// - use nil for tpmkey, encrypted salt, and symmetric
+	// - use and all-zeros caller nonce, and ignore the returned nonce
+	// As we are creating a plain TPM session, we:
+	// - setup a policy session
+	// - don't bind the session to any particular key
+	session, _, err = tpm2.StartAuthSession(
+		rw,
+		/*tpmkey=*/ tpm2.HandleNull,
+		/*bindkey=*/ tpm2.HandleNull,
+		/*nonceCaller=*/ make([]byte, sessionHashAlg.Size()),
+		/*encryptedSalt=*/ nil,
+		/*sessionType=*/ tpm2.SessionPolicy,
+		/*symmetric=*/ tpm2.AlgNull,
+		/*authHash=*/ sessionHashAlgTpm)
+	return
+}
+
+type pcrSession struct {
+	rw      io.ReadWriter
+	session tpmutil.Handle
+	sel     tpm2.PCRSelection
+}
+
+func newPCRSession(rw io.ReadWriter, sel tpm2.PCRSelection) (session, error) {
+	if len(sel.PCRs) == 0 {
+		return nullSession{}, nil
+	}
+	session, err := startAuthSesssion(rw)
+	return pcrSession{rw, session, sel}, err
+}
+
+func (p pcrSession) Auth() (auth tpm2.AuthCommand, err error) {
+	if err = tpm2.PolicyPCR(p.rw, p.session, nil, p.sel); err != nil {
+		return
+	}
+	return tpm2.AuthCommand{Session: p.session, Attributes: tpm2.AttrContinueSession}, nil
+}
+
+func (p pcrSession) Close() error {
+	return tpm2.FlushContext(p.rw, p.session)
+}
+
+type ekSession struct {
+	rw      io.ReadWriter
+	session tpmutil.Handle
+}
+
+func newEKSession(rw io.ReadWriter) (session, error) {
+	session, err := startAuthSesssion(rw)
+	return ekSession{rw, session}, err
+}
+
+func (e ekSession) Auth() (auth tpm2.AuthCommand, err error) {
+	nullAuth := tpm2.AuthCommand{Session: tpm2.HandlePasswordSession, Attributes: tpm2.AttrContinueSession}
+	if _, err = tpm2.PolicySecret(e.rw, tpm2.HandleEndorsement, nullAuth, e.session, nil, nil, nil, 0); err != nil {
+		return
+	}
+	return tpm2.AuthCommand{Session: e.session, Attributes: tpm2.AttrContinueSession}, nil
+}
+
+func (e ekSession) Close() error {
+	return tpm2.FlushContext(e.rw, e.session)
+}
+
+type nullSession struct{}
+
+func (n nullSession) Auth() (auth tpm2.AuthCommand, err error) {
+	return tpm2.AuthCommand{Session: tpm2.HandlePasswordSession, Attributes: tpm2.AttrContinueSession}, nil
+}
+
+func (n nullSession) Close() error {
+	return nil
+}

--- a/tpm2tools/template.go
+++ b/tpm2tools/template.go
@@ -109,21 +109,17 @@ func AIKTemplateRSA(nonce []byte) tpm2.Public {
 // signing key instead of an encrypting key. Unlike AIKTemplateRSA, this ECC
 // template doesn't accept a nonce.
 func AIKTemplateECC() tpm2.Public {
+	params := defaultECCParams()
+	params.Symmetric = nil
+	params.Sign = &tpm2.SigScheme{
+		Alg:  tpm2.AlgECDSA,
+		Hash: tpm2.AlgSHA256,
+	}
 	return tpm2.Public{
-		Type:       tpm2.AlgECC,
-		NameAlg:    tpm2.AlgSHA256,
-		Attributes: tpm2.FlagSignerDefault,
-		ECCParameters: &tpm2.ECCParams{
-			Sign: &tpm2.SigScheme{
-				Alg:  tpm2.AlgECDSA,
-				Hash: tpm2.AlgSHA256,
-			},
-			CurveID: tpm2.CurveNISTP256,
-			Point: tpm2.ECPoint{
-				XRaw: make([]byte, 32),
-				YRaw: make([]byte, 32),
-			},
-		},
+		Type:          tpm2.AlgECC,
+		NameAlg:       tpm2.AlgSHA256,
+		Attributes:    tpm2.FlagSignerDefault,
+		ECCParameters: params,
 	}
 }
 


### PR DESCRIPTION
This PR cleans up session handling to make different types of key
authorization easier to use. Refreshing a key's authorization is
now part of each key operation.

We can now sign with keys that need authorization and can Import under
parent keys that don't need authorization.

Tests/comments are updated accordingly.

Signed-off-by: Joe Richey <joerichey@google.com>