### PR TITLE
internal: Only open the physical TPM once

### DIFF
--- a/internal/test_other.go
+++ b/internal/test_other.go
@@ -5,32 +5,18 @@ package internal
 import (
 	"flag"
 	"io"
-	"testing"
 
 	"github.com/google/go-tpm/tpm2"
-
-	"github.com/google/go-tpm-tools/simulator"
 )
 
 // As this package is only included in tests, this flag will not conflict with
 // the --tpm-path flag in gotpm/cmd
 var tpmPath = flag.String("tpm-path", "", "Path to Linux TPM character device (i.e. /dev/tpm0 or /dev/tpmrm0). Empty value (default) will run tests against the simulator.")
 
-// GetTPM is a cross-platform testing helper function that retrives the
-// appropriate TPM device from the flags passed into "go test".
-func GetTPM(tb testing.TB) io.ReadWriteCloser {
-	tb.Helper()
-	if *tpmPath != "" {
-		rwc, err := tpm2.OpenTPM(*tpmPath)
-		if err != nil {
-			tb.Fatalf("Opening TPM failed: %v", err)
-		}
-		return rwc
-	}
+func useRealTPM() bool {
+	return *tpmPath != ""
+}
 
-	simulator, err := simulator.Get()
-	if err != nil {
-		tb.Fatalf("Simulator initialization failed: %v", err)
-	}
-	return simulator
+func getRealTPM() (io.ReadWriteCloser, error) {
+	return tpm2.OpenTPM(*tpmPath)
 }

--- a/internal/test_tpm.go
+++ b/internal/test_tpm.go
@@ -1,0 +1,46 @@
+package internal
+
+import (
+	"io"
+	"sync"
+	"testing"
+
+	"github.com/google/go-tpm-tools/simulator"
+)
+
+// Only open the TPM device once. Reopening the device causes issues on Linux.
+var (
+	tpm  io.ReadWriteCloser
+	lock sync.Mutex
+)
+
+type NoClose struct {
+	io.ReadWriter
+}
+
+func (n NoClose) Close() error {
+	return nil
+}
+
+// GetTPM is a cross-platform testing helper function that retrives the
+// appropriate TPM device from the flags passed into "go test".
+func GetTPM(tb testing.TB) io.ReadWriteCloser {
+	tb.Helper()
+	if useRealTPM() {
+		lock.Lock()
+		defer lock.Unlock()
+		if tpm == nil {
+			var err error
+			if tpm, err = getRealTPM(); err != nil {
+				tb.Fatalf("Failed to open TPM: %v", err)
+			}
+		}
+		return NoClose{tpm}
+	}
+
+	simulator, err := simulator.Get()
+	if err != nil {
+		tb.Fatalf("Simulator initialization failed: %v", err)
+	}
+	return simulator
+}

--- a/internal/test_windows.go
+++ b/internal/test_windows.go
@@ -3,30 +3,16 @@ package internal
 import (
 	"flag"
 	"io"
-	"testing"
 
 	"github.com/google/go-tpm/tpm2"
-
-	"github.com/google/go-tpm-tools/simulator"
 )
 
 var useTBS = flag.Bool("use-tbs", false, "Run the tests against the Windows TBS. Value of false (default) will run tests against the simulator.")
 
-// GetTPM is a cross-platform testing helper function that retrives the
-// appropriate TPM device from the flags passed into "go test".
-func GetTPM(tb testing.TB) io.ReadWriteCloser {
-	tb.Helper()
-	if *useTBS {
-		rwc, err := tpm2.OpenTPM()
-		if err != nil {
-			tb.Fatalf("Windows TBS initialization failed: %v", err)
-		}
-		return rwc
-	}
+func useRealTPM() bool {
+	return *useTBS
+}
 
-	simulator, err := simulator.Get()
-	if err != nil {
-		tb.Fatalf("Simulator initialization failed: %v", err)
-	}
-	return simulator
+func getRealTPM() (io.ReadWriteCloser, error) {
+	return tpm2.OpenTPM()
 }


### PR DESCRIPTION
This prevents some flakes we've seen on Linux

Signed-off-by: Joe Richey <joerichey@google.com>