### PR TITLE
tpm2tools: Stop using nonce for AIKTemplateRSA

### DIFF
--- a/tpm2tools/keys.go
+++ b/tpm2tools/keys.go
@@ -46,13 +46,8 @@ func StorageRootKeyECC(rw io.ReadWriter) (*Key, error) {
 }
 
 // AttestationIdentityKeyRSA generates and loads a key from AIKTemplateRSA
-func AttestationIdentityKeyRSA(rw io.ReadWriter, nonces []byte) (*Key, error) {
-	// If nonce is null, then try to use the cached key
-	if nonces == nil {
-		return NewCachedKey(rw, tpm2.HandleOwner, AIKTemplateRSA(nonces), DefaultAIKRSAHandle)
-	} else {
-		return NewKey(rw, tpm2.HandleOwner, AIKTemplateRSA(nonces))
-	}
+func AttestationIdentityKeyRSA(rw io.ReadWriter) (*Key, error) {
+	return NewCachedKey(rw, tpm2.HandleOwner, AIKTemplateRSA(), DefaultAIKRSAHandle)
 }
 
 // AttestationIdentityKeyECC generates and loads a key from AIKTemplateECC

--- a/tpm2tools/keys_test.go
+++ b/tpm2tools/keys_test.go
@@ -1,7 +1,6 @@
 package tpm2tools
 
 import (
-	"crypto/rand"
 	"io"
 	"reflect"
 	"testing"
@@ -33,7 +32,7 @@ func TestNameMatchesPublicArea(t *testing.T) {
 func TestCreateSigningKeysInHierarchies(t *testing.T) {
 	rwc := internal.GetTPM(t)
 	defer CheckedClose(t, rwc)
-	template := AIKTemplateRSA(nil)
+	template := AIKTemplateRSA()
 
 	// We are not authorized to create keys in the Platform Hierarchy
 	for _, hierarchy := range []tpmutil.Handle{tpm2.HandleOwner, tpm2.HandleEndorsement, tpm2.HandleNull} {
@@ -112,14 +111,7 @@ func TestKeyCreation(t *testing.T) {
 		{"AIK-ECC", AttestationIdentityKeyECC},
 		{"SRK-RSA", StorageRootKeyRSA},
 		{"EK-RSA", EndorsementKeyRSA},
-		{"AIK-RSA-Default", func(rw io.ReadWriter) (*Key, error) {
-			return AttestationIdentityKeyRSA(rw, nil)
-		}},
-		{"AIK-RSA-Nonce", func(rw io.ReadWriter) (*Key, error) {
-			nonce := make([]byte, 16)
-			rand.Read(nonce)
-			return AttestationIdentityKeyRSA(rw, nonce)
-		}},
+		{"AIK-RSA", AttestationIdentityKeyRSA},
 	}
 
 	for _, test := range tests {
@@ -143,7 +135,7 @@ func BenchmarkKeyCreation(b *testing.B) {
 	}{
 		{"SRK-ECC-Cached", StorageRootKeyECC},
 		{"EK-ECC-Cached", EndorsementKeyECC},
-		{"AIK-ECC-Default-Cached", AttestationIdentityKeyECC},
+		{"AIK-ECC-Cached", AttestationIdentityKeyECC},
 
 		{"SRK-ECC", func(rw io.ReadWriter) (*Key, error) {
 			return NewKey(rw, tpm2.HandleOwner, SRKTemplateECC())
@@ -151,15 +143,13 @@ func BenchmarkKeyCreation(b *testing.B) {
 		{"EK-ECC", func(rw io.ReadWriter) (*Key, error) {
 			return NewKey(rw, tpm2.HandleEndorsement, DefaultEKTemplateECC())
 		}},
-		{"AIK-ECC-Default", func(rw io.ReadWriter) (*Key, error) {
+		{"AIK-ECC", func(rw io.ReadWriter) (*Key, error) {
 			return NewKey(rw, tpm2.HandleOwner, AIKTemplateECC())
 		}},
 
 		{"SRK-RSA-Cached", StorageRootKeyRSA},
 		{"EK-RSA-Cached", EndorsementKeyRSA},
-		{"AIK-RSA-Default-Cached", func(rw io.ReadWriter) (*Key, error) {
-			return AttestationIdentityKeyRSA(rw, nil)
-		}},
+		{"AIK-RSA-Cached", AttestationIdentityKeyRSA},
 
 		{"SRK-RSA", func(rw io.ReadWriter) (*Key, error) {
 			return NewKey(rw, tpm2.HandleEndorsement, SRKTemplateRSA())
@@ -168,9 +158,7 @@ func BenchmarkKeyCreation(b *testing.B) {
 			return NewKey(rw, tpm2.HandleOwner, DefaultEKTemplateRSA())
 		}},
 		{"AIK-RSA", func(rw io.ReadWriter) (*Key, error) {
-			nonce := make([]byte, 16)
-			rand.Read(nonce)
-			return AttestationIdentityKeyRSA(rw, nonce)
+			return NewKey(rw, tpm2.HandleOwner, AIKTemplateRSA())
 		}},
 	}
 

--- a/tpm2tools/signer_test.go
+++ b/tpm2tools/signer_test.go
@@ -15,7 +15,7 @@ import (
 )
 
 func templateSSA(hash tpm2.Algorithm) tpm2.Public {
-	template := AIKTemplateRSA(nil)
+	template := AIKTemplateRSA()
 	// Can't sign arbitrary data if restricted.
 	template.Attributes &= ^tpm2.FlagRestricted
 	template.RSAParameters.Sign.Hash = hash

--- a/tpm2tools/template.go
+++ b/tpm2tools/template.go
@@ -88,7 +88,7 @@ func DefaultEKTemplateECC() tpm2.Public {
 // This is very similar to DefaultEKTemplateRSA, except that this will be a
 // signing key instead of an encrypting key. The random nonce provided allows
 // for multiple AIKs to easily cooexist on the same TPM (which only has 1 EK).
-func AIKTemplateRSA(nonce []byte) tpm2.Public {
+func AIKTemplateRSA() tpm2.Public {
 	return tpm2.Public{
 		Type:       tpm2.AlgRSA,
 		NameAlg:    tpm2.AlgSHA256,
@@ -98,8 +98,7 @@ func AIKTemplateRSA(nonce []byte) tpm2.Public {
 				Alg:  tpm2.AlgRSASSA,
 				Hash: tpm2.AlgSHA256,
 			},
-			KeyBits:    2048,
-			ModulusRaw: nonce, // Use public.unique to generate distinct keys
+			KeyBits: 2048,
 		},
 	}
 }


### PR DESCRIPTION
**This is a backwards incompatible change**

We already don't use one for AIK ECC keys, we shouldn't have one for
the RSA keys. Users can still use a nonce if they want by modifying the
template manually.

Signed-off-by: Joe Richey <joerichey@google.com>