### PR TITLE
tpm2tools: Fix NVReadEx bug

### DIFF
--- a/tpm2tools/keys.go
+++ b/tpm2tools/keys.go
@@ -66,7 +66,7 @@ func EndorsementKeyFromNvIndex(rw io.ReadWriter, idx uint32) (*Key, error) {
 // (possibly a hierarchy root tpm2.Handle{Owner|Endorsement|Platform|Null})
 // using the template stored at the provided nvdata index.
 func KeyFromNvIndex(rw io.ReadWriter, parent tpmutil.Handle, idx uint32) (*Key, error) {
-	data, err := tpm2.NVReadEx(rw, tpmutil.Handle(idx), parent, "", 0)
+	data, err := tpm2.NVReadEx(rw, tpmutil.Handle(idx), tpm2.HandleOwner, "", 0)
 	if err != nil {
 		return nil, fmt.Errorf("read error at index %d: %v", idx, err)
 	}


### PR DESCRIPTION
We should always read from NVData with the owner authorization.

This is what we do for "gotpm read nvdata", and we should be
consistient. This bug was causing issues when reading endorsement keys
with nvdata templates. 

Bug introduced in #74

Signed-off-by: Joe Richey <joerichey@google.com>