### PR TITLE
Check that Import gives the correct error codes

### DIFF
--- a/cmd/flush.go
+++ b/cmd/flush.go
@@ -9,11 +9,11 @@ import (
 )
 
 var handleNames = map[string][]tpm2.HandleType{
-	"all":        []tpm2.HandleType{tpm2.HandleTypeLoadedSession, tpm2.HandleTypeSavedSession, tpm2.HandleTypeTransient},
-	"loaded":     []tpm2.HandleType{tpm2.HandleTypeLoadedSession},
-	"saved":      []tpm2.HandleType{tpm2.HandleTypeSavedSession},
-	"transient":  []tpm2.HandleType{tpm2.HandleTypeTransient},
-	"persistent": []tpm2.HandleType{tpm2.HandleTypePersistent},
+	"all":        {tpm2.HandleTypeLoadedSession, tpm2.HandleTypeSavedSession, tpm2.HandleTypeTransient},
+	"loaded":     {tpm2.HandleTypeLoadedSession},
+	"saved":      {tpm2.HandleTypeSavedSession},
+	"transient":  {tpm2.HandleTypeTransient},
+	"persistent": {tpm2.HandleTypePersistent},
 }
 
 var flushCmd = &cobra.Command{

--- a/cmd/flush.go
+++ b/cmd/flush.go
@@ -59,17 +59,17 @@ Which handles are flushed depends on the argument passed:
 		for _, handleType := range handleNames[args[0]] {
 			handles, err := tpm2tools.Handles(rwc, handleType)
 			if err != nil {
-				return fmt.Errorf("getting handles: %v", err)
+				return fmt.Errorf("getting handles: %w", err)
 			}
 			for _, handle := range handles {
 				if handleType == tpm2.HandleTypePersistent {
 					if err = tpm2.EvictControl(rwc, "", tpm2.HandleOwner, handle, handle); err != nil {
-						return fmt.Errorf("evicting handle 0x%x: %v", handle, err)
+						return fmt.Errorf("evicting handle 0x%x: %w", handle, err)
 					}
 					fmt.Fprintf(debugOutput(), "Handle 0x%x evicted\n", handle)
 				} else {
 					if err = tpm2.FlushContext(rwc, handle); err != nil {
-						return fmt.Errorf("flushing handle 0x%x: %v", handle, err)
+						return fmt.Errorf("flushing handle 0x%x: %w", handle, err)
 					}
 					fmt.Fprintf(debugOutput(), "Handle 0x%x flushed\n", handle)
 				}

--- a/cmd/open.go
+++ b/cmd/open.go
@@ -26,7 +26,7 @@ func openTpm() (io.ReadWriteCloser, error) {
 	}
 	rwc, err := openImpl()
 	if err != nil {
-		return nil, fmt.Errorf("connecting to TPM: %v", err)
+		return nil, fmt.Errorf("connecting to TPM: %w", err)
 	}
 	return rwc, nil
 }

--- a/cmd/read.go
+++ b/cmd/read.go
@@ -74,7 +74,7 @@ The read is authenticated with the owner hierarchy and an empty password.`,
 			return err
 		}
 		if _, err := dataOutput().Write(data); err != nil {
-			return fmt.Errorf("cannot output NVData: %v", err)
+			return fmt.Errorf("cannot output NVData: %w", err)
 		}
 		return nil
 	},

--- a/cmd/seal.go
+++ b/cmd/seal.go
@@ -54,7 +54,7 @@ state (like Secure Boot).`,
 		}
 		sealed, err := srk.Seal(secret, sOpt)
 		if err != nil {
-			return fmt.Errorf("sealing data: %v", err)
+			return fmt.Errorf("sealing data: %w", err)
 		}
 
 		fmt.Fprintln(debugOutput(), "Writing sealed data")
@@ -118,12 +118,12 @@ machine state when sealing took place.
 		}
 		secret, err := srk.Unseal(&sealed, cOpt)
 		if err != nil {
-			return fmt.Errorf("unsealing data: %v", err)
+			return fmt.Errorf("unsealing data: %w", err)
 		}
 
 		fmt.Fprintln(debugOutput(), "Writing secret data")
 		if _, err := dataOutput().Write(secret); err != nil {
-			return fmt.Errorf("writing secret data: %v", err)
+			return fmt.Errorf("writing secret data: %w", err)
 		}
 		fmt.Fprintln(debugOutput(), "Unsealed data using TPM")
 		return nil

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/google/go-tpm-tools
 
-go 1.12
+go 1.13
 
 require (
 	github.com/golang/protobuf v1.3.2

--- a/simulator/simulator.go
+++ b/simulator/simulator.go
@@ -124,7 +124,7 @@ func (s *Simulator) Close() error {
 func (s *Simulator) on(manufactureReset bool) error {
 	// TPM2_Startup must be the first command the TPM receives.
 	if err := tpm2.Startup(s, tpm2.StartupClear); err != nil {
-		return fmt.Errorf("startup: %v", err)
+		return fmt.Errorf("startup: %w", err)
 	}
 	return nil
 }
@@ -133,7 +133,7 @@ func (s *Simulator) off() error {
 	// TPM2_Shutdown must be the last command the TPM receives. We call
 	// Shutdown with StartupClear to simulate a full reboot.
 	if err := tpm2.Shutdown(s, tpm2.StartupClear); err != nil {
-		return fmt.Errorf("shutdown: %v", err)
+		return fmt.Errorf("shutdown: %w", err)
 	}
 	return nil
 }

--- a/tpm2tools/import.go
+++ b/tpm2tools/import.go
@@ -15,7 +15,7 @@ func loadHandle(k *Key, blob *tpmpb.ImportBlob) (tpmutil.Handle, error) {
 	}
 	private, err := tpm2.Import(k.rw, k.Handle(), auth, blob.PublicArea, blob.Duplicate, blob.EncryptedSeed, nil, nil)
 	if err != nil {
-		return tpm2.HandleNull, fmt.Errorf("import failed: %s", err)
+		return tpm2.HandleNull, fmt.Errorf("import failed: %w", err)
 	}
 
 	auth, err = k.session.Auth()
@@ -24,7 +24,7 @@ func loadHandle(k *Key, blob *tpmpb.ImportBlob) (tpmutil.Handle, error) {
 	}
 	handle, _, err := tpm2.LoadUsingAuth(k.rw, k.Handle(), auth, blob.PublicArea, private)
 	if err != nil {
-		return tpm2.HandleNull, fmt.Errorf("load failed: %s", err)
+		return tpm2.HandleNull, fmt.Errorf("load failed: %w", err)
 	}
 	return handle, nil
 }
@@ -51,7 +51,7 @@ func (k *Key) Import(blob *tpmpb.ImportBlob) ([]byte, error) {
 	}
 	out, err := tpm2.UnsealWithSession(k.rw, auth.Session, handle, "")
 	if err != nil {
-		return nil, fmt.Errorf("unseal failed: %s", err)
+		return nil, fmt.Errorf("unseal failed: %w", err)
 	}
 	return out, nil
 }

--- a/tpm2tools/pcr_test.go
+++ b/tpm2tools/pcr_test.go
@@ -125,15 +125,15 @@ func TestHasSamePCRSelection(t *testing.T) {
 		expectedRes bool
 	}{
 		{&tpmpb.Pcrs{}, tpm2.PCRSelection{}, true},
-		{&tpmpb.Pcrs{Hash: tpmpb.HashAlgo(tpm2.AlgSHA256), Pcrs: map[uint32][]byte{1: []byte{}}},
+		{&tpmpb.Pcrs{Hash: tpmpb.HashAlgo(tpm2.AlgSHA256), Pcrs: map[uint32][]byte{1: {}}},
 			tpm2.PCRSelection{Hash: tpm2.AlgSHA256, PCRs: []int{1}}, true},
 		{&tpmpb.Pcrs{Hash: tpmpb.HashAlgo(tpm2.AlgSHA256), Pcrs: map[uint32][]byte{}},
 			tpm2.PCRSelection{Hash: tpm2.AlgSHA256, PCRs: []int{}}, true},
-		{&tpmpb.Pcrs{Hash: tpmpb.HashAlgo(tpm2.AlgSHA256), Pcrs: map[uint32][]byte{1: []byte{}}},
+		{&tpmpb.Pcrs{Hash: tpmpb.HashAlgo(tpm2.AlgSHA256), Pcrs: map[uint32][]byte{1: {}}},
 			tpm2.PCRSelection{Hash: tpm2.AlgSHA256, PCRs: []int{4}}, false},
-		{&tpmpb.Pcrs{Hash: tpmpb.HashAlgo(tpm2.AlgSHA256), Pcrs: map[uint32][]byte{1: []byte{}, 4: []byte{}}},
+		{&tpmpb.Pcrs{Hash: tpmpb.HashAlgo(tpm2.AlgSHA256), Pcrs: map[uint32][]byte{1: {}, 4: {}}},
 			tpm2.PCRSelection{Hash: tpm2.AlgSHA256, PCRs: []int{4}}, false},
-		{&tpmpb.Pcrs{Hash: tpmpb.HashAlgo(tpm2.AlgSHA256), Pcrs: map[uint32][]byte{1: []byte{}, 2: []byte{}}},
+		{&tpmpb.Pcrs{Hash: tpmpb.HashAlgo(tpm2.AlgSHA256), Pcrs: map[uint32][]byte{1: {}, 2: {}}},
 			tpm2.PCRSelection{Hash: tpm2.AlgSHA1, PCRs: []int{1, 2}}, false},
 	}
 	for _, test := range tests {


### PR DESCRIPTION
This PR first makes sure that we can inspect the errors returned by go-tpm, even if we wrap them. To do that we use `%w` format specifiers in `fmt.Errorf`, for more info see: https://blog.golang.org/go1.13-errors. This requires raising the minimum Go version to 1.13, but that's fine.

Second, we add tests where Import fails, making sure if fails with the correct error codes.

Finally, we cleanup some nits caught be the linter.