### PR TITLE
signer: Prevent nil dereference w/ PSSOptions

### DIFF
--- a/tpm2tools/signer.go
+++ b/tpm2tools/signer.go
@@ -36,6 +36,9 @@ func (signer *tpmSigner) Public() crypto.PublicKey {
 // where saltLen is not digestSize is when using 1024 keyBits with SHA512.
 func (signer *tpmSigner) Sign(_ io.Reader, digest []byte, opts crypto.SignerOpts) (signature []byte, err error) {
 	if pssOpts, ok := opts.(*rsa.PSSOptions); ok {
+		if signer.Key.pubArea.RSAParameters == nil {
+			return nil, fmt.Errorf("invalid options: PSSOptions can only be used with RSA keys")
+		}
 		if signer.Key.pubArea.RSAParameters.Sign.Alg != tpm2.AlgRSAPSS {
 			return nil, fmt.Errorf("invalid options: PSSOptions cannot be used with signing alg: %v", signer.Key.pubArea.RSAParameters.Sign.Alg)
 		}

--- a/tpm2tools/signer_test.go
+++ b/tpm2tools/signer_test.go
@@ -206,3 +206,40 @@ func TestSignPSS(t *testing.T) {
 		})
 	}
 }
+
+/// Make sure signing fails when using PSS params with a non-PSS key
+func TestFailSignPSS(t *testing.T) {
+	rwc := internal.GetTPM(t)
+	defer CheckedClose(t, rwc)
+	tests := []struct {
+		name     string
+		template tpm2.Public
+	}{
+		{"SSA", templateSSA(tpm2.AlgSHA256)},
+		// {"PSS", templatePSS(tpm2.AlgSHA256)},
+		{"ECC", templateECC(tpm2.AlgSHA256)},
+	}
+
+	pssOpts := rsa.PSSOptions{SaltLength: rsa.PSSSaltLengthAuto, Hash: crypto.SHA256}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			key, err := NewKey(rwc, tpm2.HandleEndorsement, test.template)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer key.Close()
+
+			signer, err := key.GetSigner()
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			// Fake SHA-256 digest
+			digest := make([]byte, 32)
+			if _, err = signer.Sign(nil, digest, &pssOpts); err == nil {
+				t.Error("expected failure when using PSS options")
+			}
+		})
+	}
+}

--- a/tpm2tools/signer_test.go
+++ b/tpm2tools/signer_test.go
@@ -216,7 +216,6 @@ func TestFailSignPSS(t *testing.T) {
 		template tpm2.Public
 	}{
 		{"SSA", templateSSA(tpm2.AlgSHA256)},
-		// {"PSS", templatePSS(tpm2.AlgSHA256)},
 		{"ECC", templateECC(tpm2.AlgSHA256)},
 	}
 


### PR DESCRIPTION
Attempting to use PSSOptions with a non-RSA key results in a segfault
when attempting to access the RSAParameters. Fix this by adding
additional checks. Add a test for this case.

Signed-off-by: Joe Richey <joerichey@google.com>