### PR TITLE
Move Alg checks to getSigningHashAlg

### DIFF
--- a/tpm2tools/signer_test.go
+++ b/tpm2tools/signer_test.go
@@ -242,3 +242,21 @@ func TestFailSignPSS(t *testing.T) {
 		})
 	}
 }
+
+// Signing keys without a signature scheme are incompatible with GetSigner
+func TestFailGetSignerNullScheme(t *testing.T) {
+	template := templateSSA(tpm2.AlgSHA256)
+	template.RSAParameters.Sign = nil
+
+	rwc := internal.GetTPM(t)
+	defer CheckedClose(t, rwc)
+	key, err := NewKey(rwc, tpm2.HandleEndorsement, template)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer key.Close()
+
+	if _, err = key.GetSigner(); err == nil {
+		t.Error("expected failure when calling GetSigner")
+	}
+}


### PR DESCRIPTION
This makes it easier to add other signing operations going forward.

This also fixes a bug where we would segfault when using a signing key
with a Null SigScheme. There is now a test to check for this.

Signed-off-by: Joe Richey <joerichey@google.com>