### PR TITLE
Rename tpm2tools to client and AIK to AK

### DIFF
--- a/client/close.go
+++ b/client/close.go
@@ -1,4 +1,4 @@
-package tpm2tools
+package client
 
 import (
 	"io"

--- a/client/handles.go
+++ b/client/handles.go
@@ -20,8 +20,8 @@ const (
 // Picked available handles from TPM 2.0 Handles and Localities 2.3.1 - Table 11
 // go-tpm-tools will use handles in the range from 0x81008F00 to 0x81008FFF
 const (
-	DefaultAIKECCHandle = tpmutil.Handle(0x81008F00)
-	DefaultAIKRSAHandle = tpmutil.Handle(0x81008F01)
+	DefaultAKECCHandle = tpmutil.Handle(0x81008F00)
+	DefaultAKRSAHandle = tpmutil.Handle(0x81008F01)
 )
 
 func isHierarchy(h tpmutil.Handle) bool {

--- a/client/handles.go
+++ b/client/handles.go
@@ -1,4 +1,4 @@
-package tpm2tools
+package client
 
 import (
 	"fmt"

--- a/client/handles_test.go
+++ b/client/handles_test.go
@@ -1,4 +1,4 @@
-package tpm2tools
+package client
 
 import (
 	"reflect"

--- a/client/import.go
+++ b/client/import.go
@@ -1,4 +1,4 @@
-package tpm2tools
+package client
 
 import (
 	"fmt"

--- a/client/keys.go
+++ b/client/keys.go
@@ -1,5 +1,5 @@
-// Package tpm2tools contains some high-level TPM 2.0 functions.
-package tpm2tools
+// Package client contains some high-level TPM 2.0 functions.
+package client
 
 import (
 	"bytes"

--- a/client/keys.go
+++ b/client/keys.go
@@ -45,19 +45,19 @@ func StorageRootKeyECC(rw io.ReadWriter) (*Key, error) {
 	return NewCachedKey(rw, tpm2.HandleOwner, SRKTemplateECC(), SRKECCReservedHandle)
 }
 
-// AttestationIdentityKeyRSA generates and loads a key from AIKTemplateRSA
-func AttestationIdentityKeyRSA(rw io.ReadWriter) (*Key, error) {
-	return NewCachedKey(rw, tpm2.HandleOwner, AIKTemplateRSA(), DefaultAIKRSAHandle)
+// AttestationKeyRSA generates and loads a key from AKTemplateRSA
+func AttestationKeyRSA(rw io.ReadWriter) (*Key, error) {
+	return NewCachedKey(rw, tpm2.HandleOwner, AKTemplateRSA(), DefaultAKRSAHandle)
 }
 
-// AttestationIdentityKeyECC generates and loads a key from AIKTemplateECC
-func AttestationIdentityKeyECC(rw io.ReadWriter) (*Key, error) {
-	return NewCachedKey(rw, tpm2.HandleOwner, AIKTemplateECC(), DefaultAIKECCHandle)
+// AttestationKeyECC generates and loads a key from AKTemplateECC
+func AttestationKeyECC(rw io.ReadWriter) (*Key, error) {
+	return NewCachedKey(rw, tpm2.HandleOwner, AKTemplateECC(), DefaultAKECCHandle)
 }
 
 // EndorsementKeyFromNvIndex generates and loads an endorsement key using the
 // template stored at the provided nvdata index. This is useful for TPMs which
-// have a preinstalled AIK template.
+// have a preinstalled AK template.
 func EndorsementKeyFromNvIndex(rw io.ReadWriter, idx uint32) (*Key, error) {
 	return KeyFromNvIndex(rw, tpm2.HandleEndorsement, idx)
 }
@@ -309,7 +309,7 @@ func (k *Key) Unseal(in *tpmpb.SealedBytes, cOpt CertifyOpt) ([]byte, error) {
 		// We can detect this bug, as it triggers a RCInsufficient
 		// Unmarshalling error.
 		if paramErr, ok := certErr.(tpm2.ParameterError); ok && paramErr.Code == tpm2.RCInsufficient {
-			signer, err := AttestationIdentityKeyECC(k.rw)
+			signer, err := AttestationKeyECC(k.rw)
 			if err != nil {
 				return nil, fmt.Errorf("failed to create fallback signing key: %w", err)
 			}

--- a/client/keys_test.go
+++ b/client/keys_test.go
@@ -1,4 +1,4 @@
-package tpm2tools
+package client
 
 import (
 	"io"

--- a/client/keys_test.go
+++ b/client/keys_test.go
@@ -32,7 +32,7 @@ func TestNameMatchesPublicArea(t *testing.T) {
 func TestCreateSigningKeysInHierarchies(t *testing.T) {
 	rwc := internal.GetTPM(t)
 	defer CheckedClose(t, rwc)
-	template := AIKTemplateRSA()
+	template := AKTemplateRSA()
 
 	// We are not authorized to create keys in the Platform Hierarchy
 	for _, hierarchy := range []tpmutil.Handle{tpm2.HandleOwner, tpm2.HandleEndorsement, tpm2.HandleNull} {
@@ -108,10 +108,10 @@ func TestKeyCreation(t *testing.T) {
 	}{
 		{"SRK-ECC", StorageRootKeyECC},
 		{"EK-ECC", EndorsementKeyECC},
-		{"AIK-ECC", AttestationIdentityKeyECC},
+		{"AK-ECC", AttestationKeyECC},
 		{"SRK-RSA", StorageRootKeyRSA},
 		{"EK-RSA", EndorsementKeyRSA},
-		{"AIK-RSA", AttestationIdentityKeyRSA},
+		{"AK-RSA", AttestationKeyRSA},
 	}
 
 	for _, test := range tests {
@@ -135,7 +135,7 @@ func BenchmarkKeyCreation(b *testing.B) {
 	}{
 		{"SRK-ECC-Cached", StorageRootKeyECC},
 		{"EK-ECC-Cached", EndorsementKeyECC},
-		{"AIK-ECC-Cached", AttestationIdentityKeyECC},
+		{"AK-ECC-Cached", AttestationKeyECC},
 
 		{"SRK-ECC", func(rw io.ReadWriter) (*Key, error) {
 			return NewKey(rw, tpm2.HandleOwner, SRKTemplateECC())
@@ -143,13 +143,13 @@ func BenchmarkKeyCreation(b *testing.B) {
 		{"EK-ECC", func(rw io.ReadWriter) (*Key, error) {
 			return NewKey(rw, tpm2.HandleEndorsement, DefaultEKTemplateECC())
 		}},
-		{"AIK-ECC", func(rw io.ReadWriter) (*Key, error) {
-			return NewKey(rw, tpm2.HandleOwner, AIKTemplateECC())
+		{"AK-ECC", func(rw io.ReadWriter) (*Key, error) {
+			return NewKey(rw, tpm2.HandleOwner, AKTemplateECC())
 		}},
 
 		{"SRK-RSA-Cached", StorageRootKeyRSA},
 		{"EK-RSA-Cached", EndorsementKeyRSA},
-		{"AIK-RSA-Cached", AttestationIdentityKeyRSA},
+		{"AK-RSA-Cached", AttestationKeyRSA},
 
 		{"SRK-RSA", func(rw io.ReadWriter) (*Key, error) {
 			return NewKey(rw, tpm2.HandleEndorsement, SRKTemplateRSA())
@@ -157,8 +157,8 @@ func BenchmarkKeyCreation(b *testing.B) {
 		{"EK-RSA", func(rw io.ReadWriter) (*Key, error) {
 			return NewKey(rw, tpm2.HandleOwner, DefaultEKTemplateRSA())
 		}},
-		{"AIK-RSA", func(rw io.ReadWriter) (*Key, error) {
-			return NewKey(rw, tpm2.HandleOwner, AIKTemplateRSA())
+		{"AK-RSA", func(rw io.ReadWriter) (*Key, error) {
+			return NewKey(rw, tpm2.HandleOwner, AKTemplateRSA())
 		}},
 	}
 

--- a/client/pcr.go
+++ b/client/pcr.go
@@ -1,4 +1,4 @@
-package tpm2tools
+package client
 
 import (
 	"bytes"

--- a/client/pcr_test.go
+++ b/client/pcr_test.go
@@ -1,4 +1,4 @@
-package tpm2tools
+package client
 
 import (
 	"bytes"

--- a/client/seal_test.go
+++ b/client/seal_test.go
@@ -1,4 +1,4 @@
-package tpm2tools
+package client
 
 import (
 	"bytes"

--- a/client/session.go
+++ b/client/session.go
@@ -1,4 +1,4 @@
-package tpm2tools
+package client
 
 import (
 	"io"

--- a/client/signer.go
+++ b/client/signer.go
@@ -1,4 +1,4 @@
-package tpm2tools
+package client
 
 import (
 	"crypto"

--- a/client/signer_test.go
+++ b/client/signer_test.go
@@ -1,4 +1,4 @@
-package tpm2tools
+package client
 
 import (
 	"crypto"

--- a/client/signer_test.go
+++ b/client/signer_test.go
@@ -15,7 +15,7 @@ import (
 )
 
 func templateSSA(hash tpm2.Algorithm) tpm2.Public {
-	template := AIKTemplateRSA()
+	template := AKTemplateRSA()
 	// Can't sign arbitrary data if restricted.
 	template.Attributes &= ^tpm2.FlagRestricted
 	template.RSAParameters.Sign.Hash = hash
@@ -29,7 +29,7 @@ func templatePSS(hash tpm2.Algorithm) tpm2.Public {
 }
 
 func templateECC(hash tpm2.Algorithm) tpm2.Public {
-	template := AIKTemplateECC()
+	template := AKTemplateECC()
 	template.Attributes &= ^tpm2.FlagRestricted
 	template.ECCParameters.Sign.Hash = hash
 	return template

--- a/client/template.go
+++ b/client/template.go
@@ -84,10 +84,10 @@ func DefaultEKTemplateECC() tpm2.Public {
 	}
 }
 
-// AIKTemplateRSA returns a potential Attestation Identity Key (AIK) template.
+// AKTemplateRSA returns a potential Attestation Key (AK) template.
 // This is very similar to DefaultEKTemplateRSA, except that this will be a
 // signing key instead of an encrypting key.
-func AIKTemplateRSA() tpm2.Public {
+func AKTemplateRSA() tpm2.Public {
 	return tpm2.Public{
 		Type:       tpm2.AlgRSA,
 		NameAlg:    tpm2.AlgSHA256,
@@ -102,10 +102,10 @@ func AIKTemplateRSA() tpm2.Public {
 	}
 }
 
-// AIKTemplateECC returns a potential Attestation Identity Key (AIK) template.
+// AKTemplateECC returns a potential Attestation Key (AK) template.
 // This is very similar to DefaultEKTemplateECC, except that this will be a
 // signing key instead of an encrypting key.
-func AIKTemplateECC() tpm2.Public {
+func AKTemplateECC() tpm2.Public {
 	params := defaultECCParams()
 	params.Symmetric = nil
 	params.Sign = &tpm2.SigScheme{

--- a/client/template.go
+++ b/client/template.go
@@ -1,4 +1,4 @@
-package tpm2tools
+package client
 
 import (
 	"crypto/sha256"

--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -7,7 +7,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/google/go-tpm-tools/tpm2tools"
+	"github.com/google/go-tpm-tools/client"
 	"github.com/google/go-tpm/tpm2"
 	"github.com/spf13/cobra"
 )
@@ -31,7 +31,7 @@ func (f *pcrsFlag) Set(val string) error {
 		if err != nil {
 			return err
 		}
-		if pcr < 0 || pcr >= tpm2tools.NumPCRs {
+		if pcr < 0 || pcr >= client.NumPCRs {
 			return errors.New("pcr out of range")
 		}
 		*f.value = append(*f.value, pcr)
@@ -179,24 +179,24 @@ func getSelection() tpm2.PCRSelection {
 }
 
 // Load SRK based on tpm2.Algorithm set in the global flag vars.
-func getSRK(rwc io.ReadWriter) (*tpm2tools.Key, error) {
+func getSRK(rwc io.ReadWriter) (*client.Key, error) {
 	switch keyAlgo {
 	case tpm2.AlgRSA:
-		return tpm2tools.StorageRootKeyRSA(rwc)
+		return client.StorageRootKeyRSA(rwc)
 	case tpm2.AlgECC:
-		return tpm2tools.StorageRootKeyECC(rwc)
+		return client.StorageRootKeyECC(rwc)
 	default:
 		panic("unexpected keyAlgo")
 	}
 }
 
 // Load EK based on tpm2.Algorithm set in the global flag vars.
-func getEK(rwc io.ReadWriter) (*tpm2tools.Key, error) {
+func getEK(rwc io.ReadWriter) (*client.Key, error) {
 	switch keyAlgo {
 	case tpm2.AlgRSA:
-		return tpm2tools.EndorsementKeyRSA(rwc)
+		return client.EndorsementKeyRSA(rwc)
 	case tpm2.AlgECC:
-		return tpm2tools.EndorsementKeyECC(rwc)
+		return client.EndorsementKeyECC(rwc)
 	default:
 		panic("unexpected keyAlgo")
 	}

--- a/cmd/flush.go
+++ b/cmd/flush.go
@@ -3,7 +3,7 @@ package cmd
 import (
 	"fmt"
 
-	"github.com/google/go-tpm-tools/tpm2tools"
+	"github.com/google/go-tpm-tools/client"
 	"github.com/google/go-tpm/tpm2"
 	"github.com/spf13/cobra"
 )
@@ -57,7 +57,7 @@ Which handles are flushed depends on the argument passed:
 
 		totalHandles := 0
 		for _, handleType := range handleNames[args[0]] {
-			handles, err := tpm2tools.Handles(rwc, handleType)
+			handles, err := client.Handles(rwc, handleType)
 			if err != nil {
 				return fmt.Errorf("getting handles: %w", err)
 			}

--- a/cmd/flush_test.go
+++ b/cmd/flush_test.go
@@ -3,14 +3,14 @@ package cmd
 import (
 	"testing"
 
+	"github.com/google/go-tpm-tools/client"
 	"github.com/google/go-tpm-tools/internal"
-	"github.com/google/go-tpm-tools/tpm2tools"
 	"github.com/google/go-tpm/tpm2"
 )
 
 func TestFlushNothing(t *testing.T) {
 	rwc := internal.GetTPM(t)
-	defer tpm2tools.CheckedClose(t, rwc)
+	defer client.CheckedClose(t, rwc)
 	ExternalTPM = rwc
 
 	RootCmd.SetArgs([]string{"flush", "all", "--quiet"})
@@ -21,7 +21,7 @@ func TestFlushNothing(t *testing.T) {
 
 func TestFlush(t *testing.T) {
 	rwc := internal.GetTPM(t)
-	defer tpm2tools.CheckedClose(t, rwc)
+	defer client.CheckedClose(t, rwc)
 	ExternalTPM = rwc
 
 	RootCmd.SetArgs([]string{"flush", "transient", "--quiet"})
@@ -37,7 +37,7 @@ func TestFlush(t *testing.T) {
 		}
 
 		// Ensure there are no active handles after that.
-		h, err := tpm2tools.Handles(rwc, tpm2.HandleTypeTransient)
+		h, err := client.Handles(rwc, tpm2.HandleTypeTransient)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/cmd/pubkey.go
+++ b/cmd/pubkey.go
@@ -7,7 +7,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/google/go-tpm-tools/tpm2tools"
+	"github.com/google/go-tpm-tools/client"
 	"github.com/google/go-tpm/tpmutil"
 
 	"github.com/google/go-tpm/tpm2"
@@ -69,11 +69,11 @@ func init() {
 	addPublicKeyAlgoFlag(pubkeyCmd)
 }
 
-func getKey(rw io.ReadWriter, hierarchy tpmutil.Handle, algo tpm2.Algorithm) (*tpm2tools.Key, error) {
+func getKey(rw io.ReadWriter, hierarchy tpmutil.Handle, algo tpm2.Algorithm) (*client.Key, error) {
 	fmt.Fprintf(debugOutput(), "Using hierarchy 0x%x\n", hierarchy)
 	if nvIndex != 0 {
 		fmt.Fprintf(debugOutput(), "Reading from NVDATA index %d\n", nvIndex)
-		return tpm2tools.KeyFromNvIndex(rw, hierarchy, nvIndex)
+		return client.KeyFromNvIndex(rw, hierarchy, nvIndex)
 	}
 
 	switch hierarchy {

--- a/cmd/read.go
+++ b/cmd/read.go
@@ -3,7 +3,7 @@ package cmd
 import (
 	"fmt"
 
-	"github.com/google/go-tpm-tools/tpm2tools"
+	"github.com/google/go-tpm-tools/client"
 	"github.com/google/go-tpm/tpm2"
 	"github.com/google/go-tpm/tpmutil"
 	"github.com/spf13/cobra"
@@ -35,16 +35,16 @@ If --pcrs is not provided, all pcrs are read for that hash algorithm.`,
 
 		sel := getSelection()
 		if len(sel.PCRs) == 0 {
-			sel = tpm2tools.FullPcrSel(hashAlgo)
+			sel = client.FullPcrSel(hashAlgo)
 		}
 
 		fmt.Fprintf(debugOutput(), "Reading pcrs (%v)\n", sel.PCRs)
-		pcrList, err := tpm2tools.ReadPCRs(rwc, sel)
+		pcrList, err := client.ReadPCRs(rwc, sel)
 		if err != nil {
 			return err
 		}
 
-		for idx := uint32(0); idx < tpm2tools.NumPCRs; idx++ {
+		for idx := uint32(0); idx < client.NumPCRs; idx++ {
 			if val, ok := pcrList.Pcrs[idx]; ok {
 				if _, err = fmt.Fprintf(dataOutput(), "%2d: %x\n", idx, val); err != nil {
 					return err

--- a/cmd/seal.go
+++ b/cmd/seal.go
@@ -6,8 +6,8 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/google/go-tpm-tools/client"
 	tpmpb "github.com/google/go-tpm-tools/proto"
-	"github.com/google/go-tpm-tools/tpm2tools"
 	"github.com/google/go-tpm/tpm2"
 )
 
@@ -47,9 +47,9 @@ state (like Secure Boot).`,
 
 		sel := getSelection()
 		fmt.Fprintf(debugOutput(), "Sealing to PCRs: %v\n", sel.PCRs)
-		var sOpt tpm2tools.SealOpt
+		var sOpt client.SealOpt
 		if len(sel.PCRs) > 0 {
-			sOpt = tpm2tools.SealCurrent{PCRSelection: sel}
+			sOpt = client.SealCurrent{PCRSelection: sel}
 		}
 		sealed, err := srk.Seal(secret, sOpt)
 		if err != nil {
@@ -114,10 +114,10 @@ machine state when sealing took place.
 
 		fmt.Fprintln(debugOutput(), "Unsealing data")
 
-		certifySel := tpm2.PCRSelection{Hash: tpm2tools.CertifyHashAlgTpm, PCRs: pcrs}
-		var cOpt tpm2tools.CertifyOpt
+		certifySel := tpm2.PCRSelection{Hash: client.CertifyHashAlgTpm, PCRs: pcrs}
+		var cOpt client.CertifyOpt
 		if len(certifySel.PCRs) > 0 {
-			cOpt = tpm2tools.CertifyCurrent{PCRSelection: certifySel}
+			cOpt = client.CertifyCurrent{PCRSelection: certifySel}
 		}
 		secret, err := srk.Unseal(&sealed, cOpt)
 		if err != nil {

--- a/cmd/seal_test.go
+++ b/cmd/seal_test.go
@@ -7,8 +7,8 @@ import (
 	"os"
 	"testing"
 
+	"github.com/google/go-tpm-tools/client"
 	"github.com/google/go-tpm-tools/internal"
-	"github.com/google/go-tpm-tools/tpm2tools"
 	"github.com/google/go-tpm/tpm2"
 	"github.com/google/go-tpm/tpmutil"
 )
@@ -30,7 +30,7 @@ func makeTempFile(tb testing.TB, content []byte) string {
 
 func TestSealPlain(t *testing.T) {
 	rwc := internal.GetTPM(t)
-	defer tpm2tools.CheckedClose(t, rwc)
+	defer client.CheckedClose(t, rwc)
 	ExternalTPM = rwc
 
 	tests := []struct {
@@ -92,7 +92,7 @@ func TestSealPlain(t *testing.T) {
 
 func TestUnsealFail(t *testing.T) {
 	rwc := internal.GetTPM(t)
-	defer tpm2tools.CheckedClose(t, rwc)
+	defer client.CheckedClose(t, rwc)
 	ExternalTPM = rwc
 	extension := bytes.Repeat([]byte{0xAA}, sha256.Size)
 

--- a/server/import.go
+++ b/server/import.go
@@ -16,13 +16,13 @@ import (
 	"github.com/google/go-tpm/tpm2"
 	"github.com/google/go-tpm/tpmutil"
 
+	"github.com/google/go-tpm-tools/client"
 	tpmpb "github.com/google/go-tpm-tools/proto"
-	"github.com/google/go-tpm-tools/tpm2tools"
 )
 
 // CreateImportBlob uses the provided public EK to encrypt the sensitive data.
 // The returned ImportBlob can then be decrypted and imported using the
-// tpm2tools Key.Import() method. A non-nil pcrs parameter adds a requirement
+// client Key.Import() method. A non-nil pcrs parameter adds a requirement
 // that the TPM must have specific PCR values for Import() to succeed.
 func CreateImportBlob(ekPub crypto.PublicKey, sensitive []byte, pcrs *tpmpb.Pcrs) (*tpmpb.ImportBlob, error) {
 	ek, err := CreateEKPublicAreaFromKey(ekPub)
@@ -38,7 +38,7 @@ func CreateImportBlob(ekPub crypto.PublicKey, sensitive []byte, pcrs *tpmpb.Pcrs
 // CreateSigningKeyImportBlob uses the provided public EK to encrypt the signing
 // key into import blob format. The returned import blob can be used to import
 // the signing key into the TPM associated with the provided EK without exposing
-// the private area to the TPM's OS using the tpm2tools Key.ImportSigningKey()
+// the private area to the TPM's OS using the client Key.ImportSigningKey()
 // method. A non-nil pcrs parameter adds a requirement that the TPM must have
 // specific PCR values to use the signing key.
 func CreateSigningKeyImportBlob(ekPub crypto.PublicKey, signingKey crypto.PrivateKey, pcrs *tpmpb.Pcrs) (*tpmpb.ImportBlob, error) {
@@ -96,7 +96,7 @@ func setPublicAuth(public *tpm2.Public, pcrs *tpmpb.Pcrs) {
 		public.AuthPolicy = nil
 		public.Attributes |= tpm2.FlagUserWithAuth
 	} else {
-		public.AuthPolicy = tpm2tools.ComputePCRSessionAuth(pcrs)
+		public.AuthPolicy = client.ComputePCRSessionAuth(pcrs)
 		public.Attributes |= tpm2.FlagAdminWithPolicy
 	}
 }

--- a/server/import_test.go
+++ b/server/import_test.go
@@ -8,23 +8,23 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/google/go-tpm-tools/client"
 	"github.com/google/go-tpm-tools/internal"
 	tpmpb "github.com/google/go-tpm-tools/proto"
-	"github.com/google/go-tpm-tools/tpm2tools"
 	"github.com/google/go-tpm/tpm2"
 )
 
 func TestImport(t *testing.T) {
 	rwc := internal.GetTPM(t)
-	defer tpm2tools.CheckedClose(t, rwc)
+	defer client.CheckedClose(t, rwc)
 	tests := []struct {
 		name     string
 		template tpm2.Public
 	}{
-		{"RSA", tpm2tools.DefaultEKTemplateRSA()},
-		{"ECC", tpm2tools.DefaultEKTemplateECC()},
-		{"SRK-RSA", tpm2tools.SRKTemplateRSA()},
-		{"SRK-ECC", tpm2tools.SRKTemplateECC()},
+		{"RSA", client.DefaultEKTemplateRSA()},
+		{"ECC", client.DefaultEKTemplateECC()},
+		{"SRK-RSA", client.SRKTemplateRSA()},
+		{"SRK-ECC", client.SRKTemplateECC()},
 		{"ECC-P224", getECCTemplate(tpm2.CurveNISTP224)},
 		{"ECC-P256", getECCTemplate(tpm2.CurveNISTP256)},
 		{"ECC-P384", getECCTemplate(tpm2.CurveNISTP384)},
@@ -32,7 +32,7 @@ func TestImport(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			ek, err := tpm2tools.NewKey(rwc, tpm2.HandleEndorsement, test.template)
+			ek, err := client.NewKey(rwc, tpm2.HandleEndorsement, test.template)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -57,7 +57,7 @@ func TestImport(t *testing.T) {
 
 func TestBadImport(t *testing.T) {
 	rwc := internal.GetTPM(t)
-	defer tpm2tools.CheckedClose(t, rwc)
+	defer client.CheckedClose(t, rwc)
 
 	valueErr := tpm2.ParameterError{
 		Code:      tpm2.RCValue,
@@ -78,15 +78,15 @@ func TestBadImport(t *testing.T) {
 		wrongKeyErr  tpm2.ParameterError
 		corruptedErr tpm2.ParameterError
 	}{
-		{"RSA", tpm2tools.DefaultEKTemplateRSA(), valueErr, valueErr},
-		{"ECC", tpm2tools.DefaultEKTemplateECC(), integrityErr, pointErr},
-		{"SRK-RSA", tpm2tools.SRKTemplateRSA(), valueErr, valueErr},
-		{"SRK-ECC", tpm2tools.SRKTemplateECC(), integrityErr, pointErr},
+		{"RSA", client.DefaultEKTemplateRSA(), valueErr, valueErr},
+		{"ECC", client.DefaultEKTemplateECC(), integrityErr, pointErr},
+		{"SRK-RSA", client.SRKTemplateRSA(), valueErr, valueErr},
+		{"SRK-ECC", client.SRKTemplateECC(), integrityErr, pointErr},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			ek, err := tpm2tools.NewKey(rwc, tpm2.HandleEndorsement, test.template)
+			ek, err := client.NewKey(rwc, tpm2.HandleEndorsement, test.template)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -96,7 +96,7 @@ func TestBadImport(t *testing.T) {
 			// Create a second, different key
 			template2 := test.template
 			template2.Attributes ^= tpm2.FlagNoDA
-			ek2, err := tpm2tools.NewKey(rwc, tpm2.HandleEndorsement, template2)
+			ek2, err := client.NewKey(rwc, tpm2.HandleEndorsement, template2)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -124,9 +124,9 @@ func TestBadImport(t *testing.T) {
 
 func TestImportPCRs(t *testing.T) {
 	rwc := internal.GetTPM(t)
-	defer tpm2tools.CheckedClose(t, rwc)
+	defer client.CheckedClose(t, rwc)
 
-	ek, err := tpm2tools.EndorsementKeyRSA(rwc)
+	ek, err := client.EndorsementKeyRSA(rwc)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -172,9 +172,9 @@ func TestImportPCRs(t *testing.T) {
 
 func TestSigningKeyImport(t *testing.T) {
 	rwc := internal.GetTPM(t)
-	defer tpm2tools.CheckedClose(t, rwc)
+	defer client.CheckedClose(t, rwc)
 
-	ek, err := tpm2tools.EndorsementKeyRSA(rwc)
+	ek, err := client.EndorsementKeyRSA(rwc)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/server/key_conversion.go
+++ b/server/key_conversion.go
@@ -8,11 +8,11 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/google/go-tpm-tools/tpm2tools"
+	"github.com/google/go-tpm-tools/client"
 	"github.com/google/go-tpm/tpm2"
 )
 
-var defaultNameAlg = tpm2tools.DefaultEKTemplateRSA().NameAlg
+var defaultNameAlg = client.DefaultEKTemplateRSA().NameAlg
 
 // CreateEKPublicAreaFromKey creates a public area from a go interface PublicKey.
 // Supports RSA and ECC keys.
@@ -28,7 +28,7 @@ func CreateEKPublicAreaFromKey(k crypto.PublicKey) (tpm2.Public, error) {
 }
 
 func createEKPublicRSA(rsaKey *rsa.PublicKey) (tpm2.Public, error) {
-	public := tpm2tools.DefaultEKTemplateRSA()
+	public := client.DefaultEKTemplateRSA()
 	if rsaKey.N.BitLen() != int(public.RSAParameters.KeyBits) {
 		return tpm2.Public{}, fmt.Errorf("unexpected RSA modulus size: %d bits", rsaKey.N.BitLen())
 	}
@@ -40,7 +40,7 @@ func createEKPublicRSA(rsaKey *rsa.PublicKey) (tpm2.Public, error) {
 }
 
 func createEKPublicECC(eccKey *ecdsa.PublicKey) (public tpm2.Public, err error) {
-	public = tpm2tools.DefaultEKTemplateECC()
+	public = client.DefaultEKTemplateECC()
 	public.ECCParameters.Point = tpm2.ECPoint{
 		XRaw: eccIntToBytes(eccKey.Curve, eccKey.X),
 		YRaw: eccIntToBytes(eccKey.Curve, eccKey.Y),

--- a/server/key_conversion_test.go
+++ b/server/key_conversion_test.go
@@ -8,13 +8,13 @@ import (
 	"crypto/rsa"
 	"testing"
 
+	"github.com/google/go-tpm-tools/client"
 	"github.com/google/go-tpm-tools/internal"
-	"github.com/google/go-tpm-tools/tpm2tools"
 	"github.com/google/go-tpm/tpm2"
 )
 
 func getECCTemplate(curve tpm2.EllipticCurve) tpm2.Public {
-	public := tpm2tools.DefaultEKTemplateECC()
+	public := client.DefaultEKTemplateECC()
 	public.ECCParameters.CurveID = curve
 	public.ECCParameters.Point.XRaw = nil
 	public.ECCParameters.Point.YRaw = nil
@@ -27,11 +27,11 @@ func TestCreateEKPublicAreaFromKeyGeneratedKey(t *testing.T) {
 		template    tpm2.Public
 		generateKey func() (crypto.PublicKey, error)
 	}{
-		{"RSA", tpm2tools.DefaultEKTemplateRSA(), func() (crypto.PublicKey, error) {
+		{"RSA", client.DefaultEKTemplateRSA(), func() (crypto.PublicKey, error) {
 			priv, err := rsa.GenerateKey(rand.Reader, 2048)
 			return priv.Public(), err
 		}},
-		{"ECC", tpm2tools.DefaultEKTemplateECC(), func() (crypto.PublicKey, error) {
+		{"ECC", client.DefaultEKTemplateECC(), func() (crypto.PublicKey, error) {
 			priv, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 			return priv.Public(), err
 		}},
@@ -71,14 +71,14 @@ func TestCreateEKPublicAreaFromKeyGeneratedKey(t *testing.T) {
 
 func TestCreateEKPublicAreaFromKeyTPMKey(t *testing.T) {
 	rwc := internal.GetTPM(t)
-	defer tpm2tools.CheckedClose(t, rwc)
+	defer client.CheckedClose(t, rwc)
 
 	tests := []struct {
 		name     string
 		template tpm2.Public
 	}{
-		{"RSA", tpm2tools.DefaultEKTemplateRSA()},
-		{"ECC", tpm2tools.DefaultEKTemplateECC()},
+		{"RSA", client.DefaultEKTemplateRSA()},
+		{"ECC", client.DefaultEKTemplateECC()},
 		{"ECC-P224", getECCTemplate(tpm2.CurveNISTP224)},
 		{"ECC-P256", getECCTemplate(tpm2.CurveNISTP256)},
 		{"ECC-P384", getECCTemplate(tpm2.CurveNISTP384)},
@@ -86,7 +86,7 @@ func TestCreateEKPublicAreaFromKeyTPMKey(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			ek, err := tpm2tools.NewKey(rwc, tpm2.HandleEndorsement, test.template)
+			ek, err := client.NewKey(rwc, tpm2.HandleEndorsement, test.template)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/simulator/README.md
+++ b/simulator/README.md
@@ -22,23 +22,23 @@ operations performed.
 
 To do this:
 1. Compile a test as a standalone binary. For example, if you were using a
-  `go-tpm-tools/tpm2tools` test (which all run against the simulator), compile
-  the test binary named `tpm2tools.test` by running:
+  `go-tpm-tools/client` test (which all run against the simulator), compile
+  the test binary named `client.test` by running:
     ```bash
-    go test -c github.com/google/go-tpm-tools/tpm2tools
+    go test -c github.com/google/go-tpm-tools/client
     ```
 1. Now you can debug the binary using GDB:
     ```bash
     # Load the binary into GDB (fixing any errors/warnings you get)
-    gdb ./tpm2tools.test
+    gdb ./client.test
     # In GDB, set a breakpoint in the funciton you want to use.
     (gdb) break TPM2_CreatePrimary 
     Breakpoint 1 at 0x5d3710: file ./TPMCmd/tpm/src/command/Hierarchy/CreatePrimary.c, line 72.
     # Now you can either run all the tests in the package, or just one.
     # As we want to depug TPM2_CreatePrimary we'll run TestSeal
     (gdb) run -test.run TestSeal
-    Starting program: ./tpm2tools.test -test.run TestSeal
-    Thread 1 "tpm2tools.test" hit Breakpoint 1, TPM2_CreatePrimary
+    Starting program: ./client.test -test.run TestSeal
+    Thread 1 "client.test" hit Breakpoint 1, TPM2_CreatePrimary
         at ./TPMCmd/tpm/src/command/Hierarchy/CreatePrimary.c:72
     72	{
     # Go to the next line

--- a/simulator/internal/internal.go
+++ b/simulator/internal/internal.go
@@ -27,8 +27,6 @@ package internal
 // #cgo CFLAGS: -DECC_NIST_P521=YES
 // #cgo CFLAGS: -DALG_SHA512=ALG_YES
 // #cgo CFLAGS: -DMAX_CONTEXT_SIZE=1360
-// #cgo CFLAGS: -I /Users/wuale/homebrew/opt/openssl@1.1/include
-// #cgo LDFLAGS: -L/Users/wuale/homebrew/opt/openssl@1.1/lib
 // #cgo LDFLAGS: -lcrypto
 //
 // #include <stdlib.h>

--- a/simulator/internal/internal.go
+++ b/simulator/internal/internal.go
@@ -27,6 +27,8 @@ package internal
 // #cgo CFLAGS: -DECC_NIST_P521=YES
 // #cgo CFLAGS: -DALG_SHA512=ALG_YES
 // #cgo CFLAGS: -DMAX_CONTEXT_SIZE=1360
+// #cgo CFLAGS: -I /Users/wuale/homebrew/opt/openssl@1.1/include
+// #cgo LDFLAGS: -L/Users/wuale/homebrew/opt/openssl@1.1/lib
 // #cgo LDFLAGS: -lcrypto
 //
 // #include <stdlib.h>

--- a/simulator/simulator_test.go
+++ b/simulator/simulator_test.go
@@ -22,7 +22,7 @@ import (
 	"math/big"
 	"testing"
 
-	"github.com/google/go-tpm-tools/tpm2tools"
+	"github.com/google/go-tpm-tools/client"
 	"github.com/google/go-tpm/tpm2"
 )
 
@@ -37,7 +37,7 @@ func getSimulator(t *testing.T) *Simulator {
 
 func getEKModulus(t *testing.T, rwc io.ReadWriteCloser) *big.Int {
 	t.Helper()
-	ek, err := tpm2tools.EndorsementKeyRSA(rwc)
+	ek, err := client.EndorsementKeyRSA(rwc)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -48,7 +48,7 @@ func getEKModulus(t *testing.T, rwc io.ReadWriteCloser) *big.Int {
 
 func TestResetDoesntChangeEK(t *testing.T) {
 	s := getSimulator(t)
-	defer tpm2tools.CheckedClose(t, s)
+	defer client.CheckedClose(t, s)
 
 	modulus1 := getEKModulus(t, s)
 	if err := s.Reset(); err != nil {
@@ -62,7 +62,7 @@ func TestResetDoesntChangeEK(t *testing.T) {
 }
 func TestManufactureResetChangesEK(t *testing.T) {
 	s := getSimulator(t)
-	defer tpm2tools.CheckedClose(t, s)
+	defer client.CheckedClose(t, s)
 
 	modulus1 := getEKModulus(t, s)
 	if err := s.ManufactureReset(); err != nil {
@@ -77,7 +77,7 @@ func TestManufactureResetChangesEK(t *testing.T) {
 
 func TestGetRandom(t *testing.T) {
 	s := getSimulator(t)
-	defer tpm2tools.CheckedClose(t, s)
+	defer client.CheckedClose(t, s)
 	result, err := tpm2.GetRandom(s, 10)
 	if err != nil {
 		t.Fatalf("GetRandom: %v", err)
@@ -97,7 +97,7 @@ func TestFixedSeedExpectedModulus(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer tpm2tools.CheckedClose(t, s)
+	defer client.CheckedClose(t, s)
 
 	modulus := getEKModulus(t, s)
 	if modulus.Cmp(zeroSeedModulus()) != 0 {
@@ -110,7 +110,7 @@ func TestDifferentSeedDifferentModulus(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer tpm2tools.CheckedClose(t, s)
+	defer client.CheckedClose(t, s)
 
 	modulus := getEKModulus(t, s)
 	if modulus.Cmp(zeroSeedModulus()) == 0 {


### PR DESCRIPTION
Here, I rename the tpm2tools package to client in order to better split up go-tpm-tools along what libraries should be used client-side vs. what should be used server-side. 

I also rename the references to attestation identity key (AIK) to the TPM 2.0 attestation key (AK), #90.