### PR TITLE
Add client.ReadAllPCRs and use it in "gotpm read pcr"

### DIFF
--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -13,12 +13,11 @@ import (
 )
 
 var (
-	output   string
-	input    string
-	nvIndex  uint32
-	keyAlgo  = tpm2.AlgRSA
-	pcrs     []int
-	hashAlgo = tpm2.AlgSHA256
+	output  string
+	input   string
+	nvIndex uint32
+	keyAlgo = tpm2.AlgRSA
+	pcrs    []int
 )
 
 type pcrsFlag struct {
@@ -48,12 +47,13 @@ func (f *pcrsFlag) String() string {
 }
 
 var algos = map[tpm2.Algorithm]string{
-	tpm2.AlgRSA:    "rsa",
-	tpm2.AlgECC:    "ecc",
-	tpm2.AlgSHA1:   "sha1",
-	tpm2.AlgSHA256: "sha256",
-	tpm2.AlgSHA384: "sha384",
-	tpm2.AlgSHA512: "sha512",
+	tpm2.AlgUnknown: "",
+	tpm2.AlgRSA:     "rsa",
+	tpm2.AlgECC:     "ecc",
+	tpm2.AlgSHA1:    "sha1",
+	tpm2.AlgSHA256:  "sha256",
+	tpm2.AlgSHA384:  "sha384",
+	tpm2.AlgSHA512:  "sha512",
 }
 
 type algoFlag struct {
@@ -128,8 +128,8 @@ func addPublicKeyAlgoFlag(cmd *cobra.Command) {
 	cmd.PersistentFlags().Var(&f, "algo", "public key algorithm: "+f.Allowed())
 }
 
-func addHashAlgoFlag(cmd *cobra.Command) {
-	f := algoFlag{&hashAlgo, []tpm2.Algorithm{tpm2.AlgSHA1, tpm2.AlgSHA256, tpm2.AlgSHA384, tpm2.AlgSHA512}}
+func addHashAlgoFlag(cmd *cobra.Command, hashAlgo *tpm2.Algorithm) {
+	f := algoFlag{hashAlgo, []tpm2.Algorithm{tpm2.AlgSHA1, tpm2.AlgSHA256, tpm2.AlgSHA384, tpm2.AlgSHA512}}
 	cmd.PersistentFlags().Var(&f, "hash-algo", "hash algorithm: "+f.Allowed())
 }
 
@@ -172,10 +172,6 @@ func dataInput() io.Reader {
 		return alwaysError{err}
 	}
 	return file
-}
-
-func getSelection() tpm2.PCRSelection {
-	return tpm2.PCRSelection{Hash: hashAlgo, PCRs: pcrs}
 }
 
 // Load SRK based on tpm2.Algorithm set in the global flag vars.

--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"errors"
+	"fmt"
 	"io"
 	"os"
 	"strconv"
@@ -43,7 +44,15 @@ func (f *pcrsFlag) Type() string {
 }
 
 func (f *pcrsFlag) String() string {
-	return "" // Don't display a default value
+	if len(*f.value) == 0 {
+		return ""
+	}
+	var b strings.Builder
+	fmt.Fprintf(&b, "%d", (*f.value)[0])
+	for _, pcr := range (*f.value)[1:] {
+		fmt.Fprintf(&b, ",%d", pcr)
+	}
+	return b.String()
 }
 
 var algos = map[tpm2.Algorithm]string{

--- a/cmd/open_other.go
+++ b/cmd/open_other.go
@@ -11,7 +11,7 @@ import (
 var tpmPath string
 
 func init() {
-	RootCmd.PersistentFlags().StringVar(&tpmPath, "tpm-path", "/dev/tpm0",
+	RootCmd.PersistentFlags().StringVar(&tpmPath, "tpm-path", "/dev/tpmrm0",
 		"path to TPM device")
 }
 

--- a/cmd/read.go
+++ b/cmd/read.go
@@ -16,6 +16,8 @@ var readCmd = &cobra.Command{
 	Args:  cobra.NoArgs,
 }
 
+var pcrHashAlgo = tpm2.AlgUnknown
+
 var pcrCmd = &cobra.Command{
 	Use:   "pcr",
 	Short: "Read PCRs from the TPM",
@@ -33,9 +35,9 @@ If --pcrs is not provided, all pcrs are read for that hash algorithm.`,
 		}
 		defer rwc.Close()
 
-		sel := getSelection()
+		sel := tpm2.PCRSelection{Hash: pcrHashAlgo, PCRs: pcrs}
 		if len(sel.PCRs) == 0 {
-			sel = client.FullPcrSel(hashAlgo)
+			sel = client.FullPcrSel(sel.Hash)
 		}
 
 		fmt.Fprintf(debugOutput(), "Reading pcrs (%v)\n", sel.PCRs)
@@ -87,7 +89,7 @@ func init() {
 	readCmd.AddCommand(nvReadCmd)
 	addOutputFlag(pcrCmd)
 	addPCRsFlag(pcrCmd)
-	addHashAlgoFlag(pcrCmd)
+	addHashAlgoFlag(pcrCmd, &pcrHashAlgo)
 	addIndexFlag(nvReadCmd)
 	nvReadCmd.MarkPersistentFlagRequired("index")
 	addOutputFlag(nvReadCmd)

--- a/cmd/read.go
+++ b/cmd/read.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/google/go-tpm-tools/client"
@@ -47,6 +48,9 @@ If --pcrs is not provided, all PCRs are read for that hash algorithm.`,
 				return err
 			}
 			return pcrList.PrettyFormat(dataOutput())
+		}
+		if len(pcrs) != 0 {
+			return errors.New("--hash-algo must be used with --pcrs")
 		}
 
 		fmt.Fprintln(debugOutput(), "Reading all PCRs")

--- a/cmd/seal.go
+++ b/cmd/seal.go
@@ -11,6 +11,8 @@ import (
 	"github.com/google/go-tpm/tpm2"
 )
 
+var sealHashAlgo = tpm2.AlgSHA256
+
 var sealCmd = &cobra.Command{
 	Use:   "seal",
 	Short: "Seal some data to the TPM",
@@ -45,7 +47,7 @@ state (like Secure Boot).`,
 			return err
 		}
 
-		sel := getSelection()
+		sel := tpm2.PCRSelection{Hash: sealHashAlgo, PCRs: pcrs}
 		fmt.Fprintf(debugOutput(), "Sealing to PCRs: %v\n", sel.PCRs)
 		var sOpt client.SealOpt
 		if len(sel.PCRs) > 0 {
@@ -142,7 +144,7 @@ func init() {
 	addOutputFlag(unsealCmd)
 	// PCRs and hash algorithm only used for sealing
 	addPCRsFlag(sealCmd)
-	addHashAlgoFlag(sealCmd)
+	addHashAlgoFlag(sealCmd, &sealHashAlgo)
 	addPCRsFlag(unsealCmd)
 	addPublicKeyAlgoFlag(sealCmd)
 }

--- a/proto/pcrs.go
+++ b/proto/pcrs.go
@@ -6,10 +6,38 @@ import (
 	"bytes"
 	"crypto"
 	"fmt"
+	"io"
 
 	"github.com/google/go-tpm/tpm2"
 	"github.com/google/go-tpm/tpmutil"
 )
+
+const minPCRIndex = uint32(0)
+
+func (x *Pcrs) maxPCRIndex() uint32 {
+	max := minPCRIndex
+	for idx := range x.Pcrs {
+		if idx > max {
+			max = idx
+		}
+	}
+	return max
+}
+
+// PrettyFormat writes a multiline representation of the PCR values to w.
+func (x *Pcrs) PrettyFormat(w io.Writer) error {
+	if _, err := fmt.Fprintf(w, "%v:\n", x.Hash); err != nil {
+		return err
+	}
+	for idx := minPCRIndex; idx <= x.maxPCRIndex(); idx++ {
+		if val, ok := x.Pcrs[idx]; ok {
+			if _, err := fmt.Fprintf(w, "  %2d: 0x%X\n", idx, val); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
 
 // CheckIfSubsetOf verifies if the pcrs PCRs are a valid "subset" of the provided
 // "superset" of PCRs. The PCR values must match (if present), and all PCRs must


### PR DESCRIPTION
This change also includes some other minor cleanups for the command line tool:
  - Formatting of PCRs is improved (to look more like what `tpm2-tools` does)
  - Now `gotpm read pcr` and `gotpm seal` can still both use `--hash-algo`, but have different default values
  - We now use `/dev/tpmrm0` by default.