### PR TITLE
Improve testing (and add tests for client.Attest)

### DIFF
--- a/client/eventlog.go
+++ b/client/eventlog.go
@@ -1,0 +1,19 @@
+package client
+
+import "io"
+
+// GetEventLog grabs the crypto-agile TCG event log for the system. The TPM can
+// override this implementation by implementing EventLogGetter.
+func GetEventLog(rw io.ReadWriter) ([]byte, error) {
+	if elg, ok := rw.(EventLogGetter); ok {
+		return elg.EventLog()
+	}
+	return getRealEventLog()
+}
+
+// EventLogGetter allows a TPM (io.ReadWriter) to specify a particular
+// implementation for GetEventLog(). This is useful for testing and necessary
+// for Windows Event Log support (which requires a handle to the TPM).
+type EventLogGetter interface {
+	EventLog() ([]byte, error)
+}

--- a/client/eventlog_linux.go
+++ b/client/eventlog_linux.go
@@ -4,7 +4,6 @@ import (
 	"io/ioutil"
 )
 
-// GetEventLog grabs the crypto-agile TCG event log for the system.
-func GetEventLog() ([]byte, error) {
+func getRealEventLog() ([]byte, error) {
 	return ioutil.ReadFile("/sys/kernel/security/tpm0/binary_bios_measurements")
 }

--- a/client/eventlog_other.go
+++ b/client/eventlog_other.go
@@ -4,7 +4,6 @@ package client
 
 import "errors"
 
-// GetEventLog grabs the crypto-agile TCG event log for the system.
-func GetEventLog() ([]byte, error) {
+func getRealEventLog() ([]byte, error) {
 	return nil, errors.New("failed to get event log: only Linux supported")
 }

--- a/client/keys.go
+++ b/client/keys.go
@@ -413,7 +413,7 @@ func (k *Key) Attest(nonce []byte) (*tpmpb.Attestation, error) {
 			return nil, err
 		}
 	}
-	if attestation.EventLog, err = GetEventLog(); err != nil {
+	if attestation.EventLog, err = GetEventLog(k.rw); err != nil {
 		return nil, fmt.Errorf("failed to retrieve TCG Event Log: %w", err)
 	}
 	return &attestation, nil

--- a/cmd/seal_test.go
+++ b/cmd/seal_test.go
@@ -5,6 +5,7 @@ import (
 	"crypto/sha256"
 	"io/ioutil"
 	"os"
+	"strconv"
 	"testing"
 
 	"github.com/google/go-tpm-tools/client"
@@ -96,6 +97,8 @@ func TestUnsealFail(t *testing.T) {
 	ExternalTPM = rwc
 	extension := bytes.Repeat([]byte{0xAA}, sha256.Size)
 
+	sealPCR := internal.DebugPCR
+	certPCR := internal.ApplicationPCR
 	tests := []struct {
 		name        string
 		sealPCRs    string
@@ -103,9 +106,9 @@ func TestUnsealFail(t *testing.T) {
 		pcrToExtend []int
 	}{
 		// TODO(joerichey): Add test that TPM2_Reset make unsealing fail
-		{"ExtendPCRAndUnseal", "23", "", []int{23}},
-		{"ExtendPCRAndCertify", "23", "7", []int{7}},
-		{"ExtendPCRAndCertify2", "", "5", []int{5}},
+		{"ExtendPCRAndUnseal", strconv.Itoa(sealPCR), "", []int{sealPCR}},
+		{"ExtendPCRAndCertify", strconv.Itoa(sealPCR), strconv.Itoa(certPCR), []int{certPCR}},
+		{"ExtendPCRAndCertify2", "", strconv.Itoa(certPCR), []int{certPCR}},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {

--- a/internal/test_tpm.go
+++ b/internal/test_tpm.go
@@ -8,7 +8,6 @@ import (
 	"testing"
 
 	"github.com/google/go-attestation/attest"
-	"github.com/google/go-tpm-tools/client"
 	"github.com/google/go-tpm-tools/simulator"
 	"github.com/google/go-tpm/tpm2"
 	"github.com/google/go-tpm/tpmutil"
@@ -34,8 +33,20 @@ func (n noClose) Close() error {
 	return nil
 }
 
+type simulatedTpm struct {
+	io.ReadWriteCloser
+	eventLog []byte
+}
+
+func (s simulatedTpm) EventLog() ([]byte, error) {
+	return s.eventLog, nil
+}
+
 // GetTPM is a cross-platform testing helper function that retrives the
 // appropriate TPM device from the flags passed into "go test".
+//
+// If using a test TPM, this will also retrieve a test eventlog. In this case,
+// GetTPM extends the test event log's events into the test TPM.
 func GetTPM(tb testing.TB) io.ReadWriteCloser {
 	tb.Helper()
 	if useRealTPM() {
@@ -54,24 +65,6 @@ func GetTPM(tb testing.TB) io.ReadWriteCloser {
 	if err != nil {
 		tb.Fatalf("Simulator initialization failed: %v", err)
 	}
-	return simulator
-}
-
-// GetEventLog is a testing helper function that gets the TCG event log
-// on supported systems, if using a real TPM, or a test event log, if not.
-//
-// Note that GetEventLog may have side effects.
-// If a test requests a test event log, GetEventLog extends
-// the test event log's events into the simulator.
-func GetEventLog(tb testing.TB, rw io.ReadWriter) []byte {
-	if useRealTPM() {
-		eventLog, err := client.GetEventLog()
-		if err != nil {
-			tb.Fatalf("Failed to get system event log: %v", err)
-		}
-		return eventLog
-	}
-
 	absPath, err := filepath.Abs("../server/test/ubuntu-2104-event-log")
 	if err != nil {
 		tb.Fatalf("failed to get abs path: %v", err)
@@ -82,8 +75,8 @@ func GetEventLog(tb testing.TB, rw io.ReadWriter) []byte {
 	}
 
 	// Extend event log events on simulator TPM.
-	simulateEventLogEvents(tb, rw, eventLog)
-	return eventLog
+	simulateEventLogEvents(tb, simulator, eventLog)
+	return simulatedTpm{simulator, eventLog}
 }
 
 // simulateEventLogEvents simulates the events in the the test event log

--- a/internal/test_tpm.go
+++ b/internal/test_tpm.go
@@ -20,6 +20,12 @@ var (
 	lock sync.Mutex
 )
 
+// PCR registers that are OK to use in tests (can be reset without reboot)
+var (
+	DebugPCR       = 16
+	ApplicationPCR = 23
+)
+
 type noClose struct {
 	io.ReadWriter
 }

--- a/server/eventlog_test.go
+++ b/server/eventlog_test.go
@@ -108,7 +108,11 @@ func readEventLog(filePath string) ([]byte, error) {
 func TestSystemParseEventLog(t *testing.T) {
 	rwc := internal.GetTPM(t)
 	defer client.CheckedClose(t, rwc)
-	evtLog := internal.GetEventLog(t, rwc)
+
+	evtLog, err := client.GetEventLog(rwc)
+	if err != nil {
+		t.Fatalf("failed to retrieve Event Log: %v", err)
+	}
 
 	sel := client.FullPcrSel(tpm2.AlgSHA1)
 	pcrs, err := client.ReadPCRs(rwc, sel)


### PR DESCRIPTION
This PR implements multiple testing fixes:
  - Only uses PCRs 16 and 23 (to avoid breaking real systems)
  - Change `client.GetEventLog` to take the TPM as an argument (allowing the TPM to override the implementation)
  - Add tests for `client.Attest`