### PR TITLE
Add helper methods for getting the GCE AKs

### DIFF
--- a/client/handles.go
+++ b/client/handles.go
@@ -24,6 +24,12 @@ const (
 	DefaultAKRSAHandle = tpmutil.Handle(0x81008F01)
 )
 
+// NV Indices holding GCE AK Templates
+const (
+	GceAKTemplateNVIndexRSA uint32 = 0x01c10001
+	GceAKTemplateNVIndexECC uint32 = 0x01c10003
+)
+
 func isHierarchy(h tpmutil.Handle) bool {
 	return h == tpm2.HandleOwner || h == tpm2.HandleEndorsement ||
 		h == tpm2.HandlePlatform || h == tpm2.HandleNull

--- a/client/keys.go
+++ b/client/keys.go
@@ -45,12 +45,12 @@ func StorageRootKeyECC(rw io.ReadWriter) (*Key, error) {
 	return NewCachedKey(rw, tpm2.HandleOwner, SRKTemplateECC(), SRKECCReservedHandle)
 }
 
-// AttestationKeyRSA generates and loads a key from AKTemplateRSA
+// AttestationKeyRSA generates and loads a key from AKTemplateRSA in the Owner hierarchy.
 func AttestationKeyRSA(rw io.ReadWriter) (*Key, error) {
 	return NewCachedKey(rw, tpm2.HandleOwner, AKTemplateRSA(), DefaultAKRSAHandle)
 }
 
-// AttestationKeyECC generates and loads a key from AKTemplateECC
+// AttestationKeyECC generates and loads a key from AKTemplateECC in the Owner hierarchy.
 func AttestationKeyECC(rw io.ReadWriter) (*Key, error) {
 	return NewCachedKey(rw, tpm2.HandleOwner, AKTemplateECC(), DefaultAKECCHandle)
 }
@@ -60,6 +60,20 @@ func AttestationKeyECC(rw io.ReadWriter) (*Key, error) {
 // have a preinstalled AK template.
 func EndorsementKeyFromNvIndex(rw io.ReadWriter, idx uint32) (*Key, error) {
 	return KeyFromNvIndex(rw, tpm2.HandleEndorsement, idx)
+}
+
+// GceAttestationKeyRSA generates and loads the GCE RSA AK. Note that this
+// function will only work on a GCE VM. Unlike AttestationKeyRSA, this key uses
+// the Endorsement Hierarchy and its template loaded from GceAKTemplateNVIndexRSA.
+func GceAttestationKeyRSA(rw io.ReadWriter) (*Key, error) {
+	return EndorsementKeyFromNvIndex(rw, GceAKTemplateNVIndexRSA)
+}
+
+// GceAttestationKeyECC generates and loads the GCE ECC AK. Note that this
+// function will only work on a GCE VM. Unlike AttestationKeyECC, this key uses
+// the Endorsement Hierarchy and its template loaded from GceAKTemplateNVIndexECC.
+func GceAttestationKeyECC(rw io.ReadWriter) (*Key, error) {
+	return EndorsementKeyFromNvIndex(rw, GceAKTemplateNVIndexECC)
 }
 
 // KeyFromNvIndex generates and loads a key under the provided parent


### PR DESCRIPTION
This makes it easier to perform attestation, you just do:
```go
tpm, _ := tpm2.OpenTpm()
ak, _ := client.GceAttestationKeyRSA(tpm)
attestation, _ := ak.Attest()
```

Signed-off-by: Joe Richey <joerichey@google.com>