### PR TITLE
Add client.AttestOpts

### DIFF
--- a/client/keys.go
+++ b/client/keys.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"crypto"
 	"crypto/subtle"
+	"errors"
 	"fmt"
 	"io"
 
@@ -407,11 +408,19 @@ func (k *Key) Quote(selpcr tpm2.PCRSelection, extraData []byte) (*tpmpb.Quote, e
 	return &quote, nil
 }
 
+// AttestOpts allows for optional Attest functionality to be enabled.
+type AttestOpts interface{}
+
 // Attest generates an Attestation containing the TCG Event Log and a Quote over
 // all PCR banks. The provided nonce can be used to guarantee freshness of the
 // attestation. This function will return an error if the key is not a
 // restricted signing key.
-func (k *Key) Attest(nonce []byte) (*tpmpb.Attestation, error) {
+//
+// An optional AttestOpts can also be passed. Currently, this parameter must be nil.
+func (k *Key) Attest(nonce []byte, opts AttestOpts) (*tpmpb.Attestation, error) {
+	if opts != nil {
+		return nil, errors.New("provided AttestOpts must be nil")
+	}
 	sels, err := implementedPCRs(k.rw)
 	if err != nil {
 		return nil, err

--- a/client/pcr.go
+++ b/client/pcr.go
@@ -104,8 +104,8 @@ type SealCurrent struct{ tpm2.PCRSelection }
 // SealTarget predicatively seals data to the given specified PCR values.
 type SealTarget struct{ *tpmpb.Pcrs }
 
-// SealOpt specifies the PCR values that should be used for Seal().
-type SealOpt interface {
+// SealOpts specifies the PCR values that should be used for Seal().
+type SealOpts interface {
 	PCRsForSealing(rw io.ReadWriter) (*tpmpb.Pcrs, error)
 }
 
@@ -133,8 +133,8 @@ type CertifyCurrent struct{ tpm2.PCRSelection }
 // Hash Algorithm in the PCR proto should be CertifyHashAlgTpm.
 type CertifyExpected struct{ *tpmpb.Pcrs }
 
-// CertifyOpt determines if the given PCR value can pass certification in Unseal().
-type CertifyOpt interface {
+// CertifyOpts determines if the given PCR value can pass certification in Unseal().
+type CertifyOpts interface {
 	CertifyPCRs(rw io.ReadWriter, certified *tpmpb.Pcrs) error
 }
 

--- a/client/pcr.go
+++ b/client/pcr.go
@@ -102,7 +102,7 @@ func ReadAllPCRs(rw io.ReadWriter) ([]*tpmpb.Pcrs, error) {
 type SealCurrent struct{ tpm2.PCRSelection }
 
 // SealTarget predicatively seals data to the given specified PCR values.
-type SealTarget struct{ Pcrs *tpmpb.Pcrs }
+type SealTarget struct{ *tpmpb.Pcrs }
 
 // SealOpt specifies the PCR values that should be used for Seal().
 type SealOpt interface {
@@ -131,7 +131,7 @@ type CertifyCurrent struct{ tpm2.PCRSelection }
 
 // CertifyExpected certifies that the TPM had a specific set of PCR values when sealing.
 // Hash Algorithm in the PCR proto should be CertifyHashAlgTpm.
-type CertifyExpected struct{ Pcrs *tpmpb.Pcrs }
+type CertifyExpected struct{ *tpmpb.Pcrs }
 
 // CertifyOpt determines if the given PCR value can pass certification in Unseal().
 type CertifyOpt interface {

--- a/client/quote_test.go
+++ b/client/quote_test.go
@@ -127,7 +127,7 @@ func TestAttest(t *testing.T) {
 			}
 			defer ak.Close()
 
-			attestation, err := ak.Attest([]byte("some nonce"))
+			attestation, err := ak.Attest([]byte("some nonce"), nil)
 			if !key.shouldSucceed {
 				if err == nil {
 					t.Error("expected failure when calling Attest")

--- a/cmd/seal.go
+++ b/cmd/seal.go
@@ -49,11 +49,11 @@ state (like Secure Boot).`,
 
 		sel := tpm2.PCRSelection{Hash: sealHashAlgo, PCRs: pcrs}
 		fmt.Fprintf(debugOutput(), "Sealing to PCRs: %v\n", sel.PCRs)
-		var sOpt client.SealOpt
+		var opts client.SealOpts
 		if len(sel.PCRs) > 0 {
-			sOpt = client.SealCurrent{PCRSelection: sel}
+			opts = client.SealCurrent{PCRSelection: sel}
 		}
-		sealed, err := srk.Seal(secret, sOpt)
+		sealed, err := srk.Seal(secret, opts)
 		if err != nil {
 			return fmt.Errorf("sealing data: %w", err)
 		}
@@ -117,11 +117,11 @@ machine state when sealing took place.
 		fmt.Fprintln(debugOutput(), "Unsealing data")
 
 		certifySel := tpm2.PCRSelection{Hash: client.CertifyHashAlgTpm, PCRs: pcrs}
-		var cOpt client.CertifyOpt
+		var opts client.CertifyOpts
 		if len(certifySel.PCRs) > 0 {
-			cOpt = client.CertifyCurrent{PCRSelection: certifySel}
+			opts = client.CertifyCurrent{PCRSelection: certifySel}
 		}
-		secret, err := srk.Unseal(&sealed, cOpt)
+		secret, err := srk.Unseal(&sealed, opts)
 		if err != nil {
 			return fmt.Errorf("unsealing data: %w", err)
 		}


### PR DESCRIPTION
This will allow us to add functionality to `client.Atttest` in a backwards compatible way.

Note that like many similar Go interfaces (e.g. [`PublicKey`](https://golang.org/pkg/crypto/#PublicKey), [`PrivateKey`](https://golang.org/pkg/crypto/#PrivateKey), [`DecrypterOpts`](https://golang.org/pkg/crypto/#DecrypterOpts), etc...) this `AttestOpts` interface has no methods. This just means we have to use casts to switch functionality, rather than using common methods. 

Also, rename `SealOpt` to `SealOpts` and `CertifyOpt` to `CertifyOpts`. This is the more consistent naming scheme.