### PR TITLE
Change SealOpts and UnsealOpts to a struct instead of interface

### DIFF
--- a/client/example_test.go
+++ b/client/example_test.go
@@ -172,7 +172,7 @@ func Example_sealAndUnseal() {
 	// properly but fail to certify it (thus we shouldn't unseal it because the creation status
 	// cannot be verify). This ensures we can unseal the sealed blob, and that its contents are
 	// equal to what we sealed.
-	output, err := srk.Unseal(sealedBlob, client.CertifyCurrent{PCRSelection: sel})
+	output, err := srk.Unseal(sealedBlob, client.UnsealOpts{CertifyCurrent: sel})
 	if err != nil {
 		// TODO: handle unseal error.
 		log.Fatalf("failed to unseal blob: %v", err)

--- a/client/example_test.go
+++ b/client/example_test.go
@@ -163,7 +163,7 @@ func Example_sealAndUnseal() {
 
 	sel := tpm2.PCRSelection{Hash: tpm2.AlgSHA256, PCRs: []int{7}}
 	// Seal the data to the current value of PCR7.
-	sealedBlob, err := srk.Seal([]byte(sealedSecret), client.SealCurrent{PCRSelection: sel})
+	sealedBlob, err := srk.Seal([]byte(sealedSecret), client.SealOpts{Current: sel})
 	if err != nil {
 		log.Fatalf("failed to seal to SRK: %v", err)
 	}

--- a/client/pcr.go
+++ b/client/pcr.go
@@ -99,31 +99,12 @@ func ReadAllPCRs(rw io.ReadWriter) ([]*pb.PCRs, error) {
 	return allPcrs, nil
 }
 
-// SealCurrent seals data to the current specified PCR selection.
-type SealCurrent struct{ tpm2.PCRSelection }
-
-// SealTarget predicatively seals data to the given specified PCR values.
-type SealTarget struct{ Pcrs *pb.PCRs }
-
 // SealOpts specifies the PCR values that should be used for Seal().
-type SealOpts interface {
-	PCRsForSealing(rw io.ReadWriter) (*pb.PCRs, error)
-}
-
-// PCRsForSealing read from TPM and return the selected PCRs.
-func (p SealCurrent) PCRsForSealing(rw io.ReadWriter) (*pb.PCRs, error) {
-	if len(p.PCRSelection.PCRs) == 0 {
-		panic("SealCurrent contains 0 PCRs")
-	}
-	return ReadPCRs(rw, p.PCRSelection)
-}
-
-// PCRsForSealing return the target PCRs.
-func (p SealTarget) PCRsForSealing(_ io.ReadWriter) (*pb.PCRs, error) {
-	if len(p.Pcrs.GetPcrs()) == 0 {
-		panic("SealTarget contains 0 PCRs")
-	}
-	return p.Pcrs, nil
+type SealOpts struct {
+	// Current seals data to the current specified PCR selection.
+	Current tpm2.PCRSelection
+	// Target predicatively seals data to the given specified PCR values.
+	Target *pb.PCRs
 }
 
 // CertifyCurrent certifies that a selection of current PCRs have the same value when sealing.

--- a/client/pcr.go
+++ b/client/pcr.go
@@ -128,3 +128,39 @@ func FullPcrSel(hash tpm2.Algorithm) tpm2.PCRSelection {
 	}
 	return sel
 }
+
+func mergePCRSelAndProto(rw io.ReadWriter, sel tpm2.PCRSelection, proto *pb.PCRs) (*pb.PCRs, error) {
+	if proto == nil || len(proto.GetPcrs()) == 0 {
+		return ReadPCRs(rw, sel)
+	}
+	if len(sel.PCRs) == 0 {
+		return proto, nil
+	}
+	if sel.Hash != tpm2.Algorithm(proto.Hash) {
+		return nil, fmt.Errorf("current hash (%v) differs from target hash (%v)",
+			sel.Hash, tpm2.Algorithm(proto.Hash))
+	}
+
+	// At this point, both sel and proto are non-empty.
+	// Verify no overlap in sel and proto PCR indexes.
+	overlap := make([]int, 0)
+	targetMap := proto.GetPcrs()
+	for _, pcrVal := range sel.PCRs {
+		if _, found := targetMap[uint32(pcrVal)]; found {
+			overlap = append(overlap, pcrVal)
+		}
+	}
+	if len(overlap) != 0 {
+		return nil, fmt.Errorf("found PCR overlap: %v", overlap)
+	}
+
+	currentPcrs, err := ReadPCRs(rw, sel)
+	if err != nil {
+		return nil, err
+	}
+
+	for pcr, val := range proto.GetPcrs() {
+		currentPcrs.Pcrs[pcr] = val
+	}
+	return currentPcrs, nil
+}

--- a/client/pcr.go
+++ b/client/pcr.go
@@ -109,13 +109,13 @@ type SealOpts struct {
 // UnsealOpts specifies the options that should be used for Unseal().
 // Currently, it specifies the PCRs that need to pass certification in order to
 // successfully unseal.
+// CertifyHashAlgTpm is the hard-coded algorithm that must be used with
+// UnsealOpts.
 type UnsealOpts struct {
 	// CertifyCurrent certifies that a selection of current PCRs have the same
 	// value when sealing.
-	// Hash Algorithm in the selection should be CertifyHashAlgTpm.
 	CertifyCurrent tpm2.PCRSelection
 	// CertifyExpected certifies that the TPM had a specific set of PCR values when sealing.
-	// Hash Algorithm in the PCR proto should be CertifyHashAlgTpm.
 	CertifyExpected *pb.PCRs
 }
 

--- a/client/seal_test.go
+++ b/client/seal_test.go
@@ -182,10 +182,10 @@ func TestReseal(t *testing.T) {
 		t.Fatalf("failed to seal: %v", err)
 	}
 
-	opts := client.UnsealOpts{
+	uOpts := client.UnsealOpts{
 		CertifyCurrent: sel,
 	}
-	unseal, err := key.Unseal(sealed, opts)
+	unseal, err := key.Unseal(sealed, uOpts)
 	if err != nil {
 		t.Fatalf("failed to unseal: %v", err)
 	}
@@ -202,7 +202,8 @@ func TestReseal(t *testing.T) {
 	extensions := [][]byte{bytes.Repeat([]byte{0xAA}, sha256.Size)}
 	predictedPcrsValue.GetPcrs()[uint32(pcrToChange)] = computePCRValue(predictedPcrsValue.GetPcrs()[uint32(pcrToChange)], extensions)
 
-	resealed, err := key.Reseal(sealed, opts, client.SealOpts{Target: predictedPcrsValue})
+	sOpts := client.SealOpts{Target: predictedPcrsValue}
+	resealed, err := key.Reseal(sealed, uOpts, sOpts)
 	if err != nil {
 		t.Fatalf("failed to reseal: %v", err)
 	}
@@ -389,8 +390,8 @@ func TestSealOpts(t *testing.T) {
 	}
 	for _, testcase := range opts {
 		t.Run(testcase.name, func(t *testing.T) {
-			sealed, err := srk.Seal([]byte("secretzz"),
-				client.SealOpts{Current: testcase.current, Target: testcase.target})
+			sOpts := client.SealOpts{Current: testcase.current, Target: testcase.target}
+			sealed, err := srk.Seal([]byte("secretzz"), sOpts)
 			if err != nil {
 				t.Errorf("error calling Seal with SealOpts: %v", err)
 			}
@@ -403,8 +404,7 @@ func TestSealOpts(t *testing.T) {
 	}
 
 	// Run empty SealOpts.
-	_, err = srk.Seal([]byte("secretzz"),
-		client.SealOpts{})
+	_, err = srk.Seal([]byte("secretzz"), client.SealOpts{})
 	if err != nil {
 		t.Errorf("error calling Seal with SealOpts: %v", err)
 	}
@@ -434,9 +434,9 @@ func TestSealAndUnsealOptsFail(t *testing.T) {
 
 	for _, testcase := range opts {
 		t.Run("Seal"+testcase.name, func(t *testing.T) {
-			_, err := srk.Seal([]byte("secretzz"),
-				client.SealOpts{Current: testcase.current,
-					Target: testcase.target})
+			sOpts := client.SealOpts{Current: testcase.current,
+				Target: testcase.target}
+			_, err := srk.Seal([]byte("secretzz"), sOpts)
 			if err == nil {
 				t.Errorf("expected failure calling SealOpts")
 			}
@@ -449,9 +449,9 @@ func TestSealAndUnsealOptsFail(t *testing.T) {
 	}
 	for _, testcase := range opts {
 		t.Run("Unseal"+testcase.name, func(t *testing.T) {
-			_, err := srk.Unseal(sealed,
-				client.UnsealOpts{CertifyCurrent: testcase.current,
-					CertifyExpected: testcase.target})
+			uOpts := client.UnsealOpts{CertifyCurrent: testcase.current,
+				CertifyExpected: testcase.target}
+			_, err := srk.Unseal(sealed, uOpts)
 			if err == nil {
 				t.Errorf("expected failure calling SealOpts")
 			}

--- a/cmd/seal.go
+++ b/cmd/seal.go
@@ -117,9 +117,9 @@ machine state when sealing took place.
 		fmt.Fprintln(debugOutput(), "Unsealing data")
 
 		certifySel := tpm2.PCRSelection{Hash: client.CertifyHashAlgTpm, PCRs: pcrs}
-		var opts client.CertifyOpts
+		var opts client.UnsealOpts
 		if len(certifySel.PCRs) > 0 {
-			opts = client.CertifyCurrent{PCRSelection: certifySel}
+			opts = client.UnsealOpts{CertifyCurrent: certifySel}
 		}
 		secret, err := srk.Unseal(&sealed, opts)
 		if err != nil {

--- a/cmd/seal.go
+++ b/cmd/seal.go
@@ -51,7 +51,7 @@ state (like Secure Boot).`,
 		fmt.Fprintf(debugOutput(), "Sealing to PCRs: %v\n", sel.PCRs)
 		var opts client.SealOpts
 		if len(sel.PCRs) > 0 {
-			opts = client.SealCurrent{PCRSelection: sel}
+			opts = client.SealOpts{Current: sel}
 		}
 		sealed, err := srk.Seal(secret, opts)
 		if err != nil {

--- a/cmd/seal.go
+++ b/cmd/seal.go
@@ -47,12 +47,10 @@ state (like Secure Boot).`,
 			return err
 		}
 
-		sel := tpm2.PCRSelection{Hash: sealHashAlgo, PCRs: pcrs}
-		fmt.Fprintf(debugOutput(), "Sealing to PCRs: %v\n", sel.PCRs)
-		var opts client.SealOpts
-		if len(sel.PCRs) > 0 {
-			opts = client.SealOpts{Current: sel}
-		}
+		fmt.Fprintf(debugOutput(), "Sealing to PCRs: %v\n", pcrs)
+		opts := client.SealOpts{Current: tpm2.PCRSelection{
+			Hash: sealHashAlgo,
+			PCRs: pcrs}}
 		sealed, err := srk.Seal(secret, opts)
 		if err != nil {
 			return fmt.Errorf("sealing data: %w", err)
@@ -66,7 +64,7 @@ state (like Secure Boot).`,
 		if _, err = dataOutput().Write(output); err != nil {
 			return err
 		}
-		fmt.Fprintf(debugOutput(), "Sealed data to PCRs: %v\n", sel.PCRs)
+		fmt.Fprintf(debugOutput(), "Sealed data to PCRs: %v\n", pcrs)
 		return nil
 	},
 }
@@ -116,11 +114,9 @@ machine state when sealing took place.
 
 		fmt.Fprintln(debugOutput(), "Unsealing data")
 
-		certifySel := tpm2.PCRSelection{Hash: client.CertifyHashAlgTpm, PCRs: pcrs}
-		var opts client.UnsealOpts
-		if len(certifySel.PCRs) > 0 {
-			opts = client.UnsealOpts{CertifyCurrent: certifySel}
-		}
+		opts := client.UnsealOpts{CertifyCurrent: tpm2.PCRSelection{
+			Hash: client.CertifyHashAlgTpm,
+			PCRs: pcrs}}
 		secret, err := srk.Unseal(&sealed, opts)
 		if err != nil {
 			return fmt.Errorf("unsealing data: %w", err)


### PR DESCRIPTION
SealOpts was previously an interface that implemented PCRsForSealing.
This did not allow users the option to seal to both a current PCR
selection and a target PCR selection without first reading PCRs manually
and merging into the target. 

CertifyOpts was previously an interface that implemented CertifyPCRs.
This did not allow users the option to seal to both a current PCR
selection and an expected PCR selection without manually reading PCRs
and merging into the target.

These structs allows these use cases more
easily and support future options.
