### PR TITLE
server: Fix AK Cert checking bug 

### DIFF
--- a/server/verify.go
+++ b/server/verify.go
@@ -67,10 +67,8 @@ func VerifyAttestation(attestation *pb.Attestation, opts VerifyOpts) (*pb.Machin
 	if err != nil {
 		return nil, fmt.Errorf("failed to get AK public key: %w", err)
 	}
-	if err := checkAkTrusted(akPubKey, opts); err != nil {
-		if err := validateAkCert(attestation.AkCert, opts.IntermediateCerts, opts.TrustedRootCerts); err != nil {
-			return nil, fmt.Errorf("failed to validate attestation key: AKPub is untrusted and %v", err)
-		}
+	if err := checkAKTrusted(akPubKey, attestation.GetAkCert(), opts); err != nil {
+		return nil, fmt.Errorf("failed to validate AK: %w", err)
 	}
 
 	// Verify the signing hash algorithm
@@ -138,33 +136,35 @@ func pubKeysEqual(k1 crypto.PublicKey, k2 crypto.PublicKey) bool {
 }
 
 // Checks if the provided AK public key can be trusted
-func checkAkTrusted(ak crypto.PublicKey, opts VerifyOpts) error {
-	if len(opts.TrustedAKs) == 0 {
-		return fmt.Errorf("no mechanism for AK verification provided")
+func checkAKTrusted(ak crypto.PublicKey, akCertBytes []byte, opts VerifyOpts) error {
+	checkPub := len(opts.TrustedAKs) > 0
+	checkCert := opts.TrustedRootCerts != nil && len(opts.TrustedRootCerts.Subjects()) > 0
+	if !checkPub && !checkCert {
+		return fmt.Errorf("no trust mechanism provided, either use TrustedAKs or TrustedRootCerts")
 	}
 
 	// Check against known AKs
-	for _, trusted := range opts.TrustedAKs {
-		if pubKeysEqual(ak, trusted) {
-			return nil
+	if checkPub {
+		for _, trusted := range opts.TrustedAKs {
+			if pubKeysEqual(ak, trusted) {
+				return nil
+			}
 		}
+		return fmt.Errorf("public key is not trusted")
 	}
-	return fmt.Errorf("AK public key is not trusted")
-}
 
-func validateAkCert(akCertBytes []byte, intermediates *x509.CertPool, roots *x509.CertPool) error {
+	// Check if the AK Cert chains to a trusted root
 	if len(akCertBytes) == 0 {
-		return errors.New("AKCert is empty")
+		return errors.New("no certificate provided in attestation")
 	}
-
 	akCert, err := x509.ParseCertificate(akCertBytes)
 	if err != nil {
-		return fmt.Errorf("failed to parse AKCert: %v", err)
+		return fmt.Errorf("failed to parse certificate: %w", err)
 	}
 
-	if _, err := akCert.Verify(x509.VerifyOptions{
-		Roots:         roots,
-		Intermediates: intermediates,
+	x509Opts := x509.VerifyOptions{
+		Roots:         opts.TrustedRootCerts,
+		Intermediates: opts.IntermediateCerts,
 		// x509 (both ct and crypto) marks the SAN extension unhandled if SAN
 		// does not parse any of DNSNames, EmailAddresses, IPAddresses, or URIs.
 		// https://cs.opensource.google/go/go/+/master:src/crypto/x509/parser.go;l=668-678
@@ -175,8 +175,9 @@ func validateAkCert(akCertBytes []byte, intermediates *x509.CertPool, roots *x50
 		// - https://oidref.com/2.23.133.8.3
 		// https://pkg.go.dev/crypto/x509#VerifyOptions
 		KeyUsages: []x509.ExtKeyUsage{x509.ExtKeyUsage(x509.ExtKeyUsageAny)},
-	}); err != nil {
-		return fmt.Errorf("failed to verify AKCert against trusted roots: %v", err)
+	}
+	if _, err := akCert.Verify(x509Opts); err != nil {
+		return fmt.Errorf("failed to verify certificate against trusted roots: %v", err)
 	}
 	return nil
 }

--- a/server/verify.go
+++ b/server/verify.go
@@ -142,6 +142,9 @@ func checkAKTrusted(ak crypto.PublicKey, akCertBytes []byte, opts VerifyOpts) er
 	if !checkPub && !checkCert {
 		return fmt.Errorf("no trust mechanism provided, either use TrustedAKs or TrustedRootCerts")
 	}
+	if checkPub && checkCert {
+		return fmt.Errorf("multiple trust mechanisms provided, only use one of TrustedAKs or TrustedRootCerts")
+	}
 
 	// Check against known AKs
 	if checkPub {

--- a/server/verify.go
+++ b/server/verify.go
@@ -164,6 +164,9 @@ func checkAKTrusted(ak crypto.PublicKey, akCertBytes []byte, opts VerifyOpts) er
 	if err != nil {
 		return fmt.Errorf("failed to parse certificate: %w", err)
 	}
+	if !pubKeysEqual(ak, akCert.PublicKey) {
+		return fmt.Errorf("mismatch between public key and certificate")
+	}
 
 	x509Opts := x509.VerifyOptions{
 		Roots:         opts.TrustedRootCerts,

--- a/server/verify_test.go
+++ b/server/verify_test.go
@@ -451,6 +451,27 @@ func TestVerifyAttestationWithCerts(t *testing.T) {
 	}
 }
 
+func TestVerifyFailWithCertsAndPubkey(t *testing.T) {
+	att := &attestpb.Attestation{}
+	if err := proto.Unmarshal(test.COS85NoNonce, att); err != nil {
+		t.Fatalf("failed to unmarshal attestation: %v", err)
+	}
+
+	priv, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatal(err)
+	}
+	opts := VerifyOpts{
+		Nonce:             nil,
+		TrustedRootCerts:  GceEKRoots,
+		IntermediateCerts: GceEKIntermediates,
+		TrustedAKs:        []crypto.PublicKey{priv.Public()},
+	}
+	if _, err := VerifyAttestation(att, opts); err == nil {
+		t.Error("Verified attestation even with multiple trust methods")
+	}
+}
+
 func TestVerifyAttestationEmptyRootsIntermediates(t *testing.T) {
 	attestBytes := test.COS85NoNonce
 	att := &attestpb.Attestation{}


### PR DESCRIPTION
Without this change, providing a good AK Cert but a bad AKPub will result in VerifyAttestation succeeding. Now, we check that the AKPub and AKCert (if present) have the same public key.

I also reorganized the code into one `checkAKTrusted` method, which should make things easier to understand.