### PR TITLE
server: Support all public key types in pubKeysEqual

### DIFF
--- a/server/verify.go
+++ b/server/verify.go
@@ -123,7 +123,8 @@ func VerifyAttestation(attestation *pb.Attestation, opts VerifyOpts) (*pb.Machin
 }
 
 func pubKeysEqual(k1 crypto.PublicKey, k2 crypto.PublicKey) bool {
-	// Common interface for all public keys (see crypto.PublicKey documentation)
+	// Common interface for all the standard public key types, see:
+	// https://pkg.go.dev/crypto@go1.18beta1#PublicKey
 	type publicKey interface {
 		Equal(crypto.PublicKey) bool
 	}

--- a/server/verify.go
+++ b/server/verify.go
@@ -2,8 +2,6 @@ package server
 
 import (
 	"crypto"
-	"crypto/ecdsa"
-	"crypto/rsa"
 	"errors"
 	"fmt"
 
@@ -125,14 +123,14 @@ func VerifyAttestation(attestation *pb.Attestation, opts VerifyOpts) (*pb.Machin
 }
 
 func pubKeysEqual(k1 crypto.PublicKey, k2 crypto.PublicKey) bool {
-	switch key := k1.(type) {
-	case *rsa.PublicKey:
-		return key.Equal(k2)
-	case *ecdsa.PublicKey:
-		return key.Equal(k2)
-	default:
-		return false
+	// Common interface for all public keys (see crypto.PublicKey documentation)
+	type publicKey interface {
+		Equal(crypto.PublicKey) bool
 	}
+	if key, ok := k1.(publicKey); ok {
+		return key.Equal(k2)
+	}
+	return false
 }
 
 // Checks if the provided AK public key can be trusted


### PR DESCRIPTION
Mostly just a style nit

Instead of checking the concrete types for `crypto.PublicKey`, we try to cast the key to an interface containing the expected `Equals` method. This approach is [explicitly mentioned in the `crypto.PublicKey` documentation](https://cs.opensource.google/go/go/+/refs/tags/go1.18beta1:src/crypto/crypto.go;l=154-161).

Signed-off-by: Joe Richey <joerichey@google.com>