### PR TITLE
Fix tests for physical TPMs

### DIFF
--- a/cel/cos_tlv_test.go
+++ b/cel/cos_tlv_test.go
@@ -2,7 +2,6 @@ package cel
 
 import (
 	"bytes"
-	"crypto"
 	"strings"
 	"testing"
 
@@ -16,7 +15,6 @@ func TestCosEventlog(t *testing.T) {
 	tpm := test.GetTPM(t)
 	defer client.CheckedClose(t, tpm)
 
-	hashAlgoList := []crypto.Hash{crypto.SHA256, crypto.SHA1, crypto.SHA512}
 	cel := &CEL{}
 
 	testEvents := []struct {
@@ -38,7 +36,7 @@ func TestCosEventlog(t *testing.T) {
 
 	for _, testEvent := range testEvents {
 		cos := CosTlv{testEvent.cosNestedEventType, testEvent.eventPayload}
-		if err := cel.AppendEvent(tpm, testEvent.pcr, hashAlgoList, cos); err != nil {
+		if err := cel.AppendEvent(tpm, testEvent.pcr, measuredHashes, cos); err != nil {
 			t.Fatal(err.Error())
 		}
 	}

--- a/client/pcr_test.go
+++ b/client/pcr_test.go
@@ -53,7 +53,7 @@ func TestReadPCRs(t *testing.T) {
 	}{
 		{"SHA1", tpm2.AlgSHA1},
 		{"SHA256", tpm2.AlgSHA256},
-		{"SHA384", tpm2.AlgSHA512},
+		{"SHA384", tpm2.AlgSHA384},
 	}
 
 	for _, c := range cases {


### PR DESCRIPTION
Some tests were failing on some physical TPMs due to certain hash algos are not supported. 
Changing them to SHA1 and SHA256 which most TPM2 chips should support.

Reset the Test PCR for certain tests where requiring the PCR bank to be zero value at the beginning of the test.