### PR TITLE
Add Key.SetCert() function

### DIFF
--- a/client/keys.go
+++ b/client/keys.go
@@ -471,11 +471,7 @@ func (k *Key) CertDERBytes() []byte {
 
 // SetCert assigns the provided certificate to the key after verifying it matches the key.
 func (k *Key) SetCert(cert *x509.Certificate) error {
-	certPubKey, ok := cert.PublicKey.(crypto.PublicKey)
-	if !ok {
-		return errors.New("certificate public key is not the appropriate type")
-	}
-
+	certPubKey := cert.PublicKey.(crypto.PublicKey) // This cast cannot fail
 	if !internal.PubKeysEqual(certPubKey, k.pubKey) {
 		return errors.New("certificate does not match key")
 	}

--- a/client/keys.go
+++ b/client/keys.go
@@ -9,7 +9,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"reflect"
 
 	"github.com/google/go-tpm-tools/internal"
 	pb "github.com/google/go-tpm-tools/proto/tpm"
@@ -477,7 +476,7 @@ func (k *Key) SetCert(cert *x509.Certificate) error {
 		return errors.New("certificate public key is not the appropriate type")
 	}
 
-	if !reflect.DeepEqual(certPubKey, k.pubKey) {
+	if !internal.PubKeysEqual(certPubKey, k.pubKey) {
 		return errors.New("certificate does not match key")
 	}
 

--- a/client/keys.go
+++ b/client/keys.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"reflect"
 
 	"github.com/google/go-tpm-tools/internal"
 	pb "github.com/google/go-tpm-tools/proto/tpm"
@@ -476,7 +477,7 @@ func (k *Key) SetCert(cert *x509.Certificate) error {
 		return errors.New("certificate public key is not the appropriate type")
 	}
 
-	if certPubKey != k.pubKey {
+	if !reflect.DeepEqual(certPubKey, k.pubKey) {
 		return errors.New("certificate does not match key")
 	}
 

--- a/client/keys.go
+++ b/client/keys.go
@@ -6,6 +6,7 @@ import (
 	"crypto"
 	"crypto/subtle"
 	"crypto/x509"
+	"errors"
 	"fmt"
 	"io"
 
@@ -466,6 +467,21 @@ func (k *Key) CertDERBytes() []byte {
 		return nil
 	}
 	return k.cert.Raw
+}
+
+// SetCert assigns the provided certificate to the key after verifying it matches the key.
+func (k *Key) SetCert(cert *x509.Certificate) error {
+	certPubKey, ok := cert.PublicKey.(crypto.PublicKey)
+	if !ok {
+		return errors.New("certificate public key is not the appropriate type")
+	}
+
+	if certPubKey != k.pubKey {
+		return errors.New("certificate does not match key")
+	}
+
+	k.cert = cert
+	return nil
 }
 
 func getCertificateFromNvram(rw io.ReadWriter, index uint32) (*x509.Certificate, error) {

--- a/internal/public.go
+++ b/internal/public.go
@@ -1,6 +1,7 @@
 package internal
 
 import (
+	"crypto"
 	"fmt"
 
 	"github.com/google/go-tpm/tpm2"
@@ -32,4 +33,17 @@ func GetSigningHashAlg(pubArea tpm2.Public) (tpm2.Algorithm, error) {
 	default:
 		return tpm2.AlgNull, fmt.Errorf("unsupported signing algorithm: %v", sigScheme.Alg)
 	}
+}
+
+// PubKeysEqual returns whether the two public keys are equal.
+func PubKeysEqual(k1 crypto.PublicKey, k2 crypto.PublicKey) bool {
+	// Common interface for all the standard public key types, see:
+	// https://pkg.go.dev/crypto@go1.18beta1#PublicKey
+	type publicKey interface {
+		Equal(crypto.PublicKey) bool
+	}
+	if key, ok := k1.(publicKey); ok {
+		return key.Equal(k2)
+	}
+	return false
 }

--- a/server/verify.go
+++ b/server/verify.go
@@ -122,18 +122,6 @@ func VerifyAttestation(attestation *pb.Attestation, opts VerifyOpts) (*pb.Machin
 	return nil, fmt.Errorf("attestation does not contain a supported quote")
 }
 
-func pubKeysEqual(k1 crypto.PublicKey, k2 crypto.PublicKey) bool {
-	// Common interface for all the standard public key types, see:
-	// https://pkg.go.dev/crypto@go1.18beta1#PublicKey
-	type publicKey interface {
-		Equal(crypto.PublicKey) bool
-	}
-	if key, ok := k1.(publicKey); ok {
-		return key.Equal(k2)
-	}
-	return false
-}
-
 // Checks if the provided AK public key can be trusted
 func checkAKTrusted(ak crypto.PublicKey, akCertBytes []byte, opts VerifyOpts) error {
 	checkPub := len(opts.TrustedAKs) > 0
@@ -148,7 +136,7 @@ func checkAKTrusted(ak crypto.PublicKey, akCertBytes []byte, opts VerifyOpts) er
 	// Check against known AKs
 	if checkPub {
 		for _, trusted := range opts.TrustedAKs {
-			if pubKeysEqual(ak, trusted) {
+			if internal.PubKeysEqual(ak, trusted) {
 				return nil
 			}
 		}
@@ -163,7 +151,7 @@ func checkAKTrusted(ak crypto.PublicKey, akCertBytes []byte, opts VerifyOpts) er
 	if err != nil {
 		return fmt.Errorf("failed to parse certificate: %w", err)
 	}
-	if !pubKeysEqual(ak, akCert.PublicKey) {
+	if !internal.PubKeysEqual(ak, akCert.PublicKey) {
 		return fmt.Errorf("mismatch between public key and certificate")
 	}
 


### PR DESCRIPTION
Add a SetCert() function to client.Key that allows setting the AK Certificate. The function will verify that the cert matches Key.pubKey.