### PR TITLE
Change FetchCertChain bool option to HTTP client

### DIFF
--- a/client/attest.go
+++ b/client/attest.go
@@ -35,7 +35,7 @@ type AttestOpts struct {
 	// If non-nil, will be used to fetch the AK certificate chain for validation.
 	// Key.Attest() will construct the certificate chain by making GET requests to
 	// the contents of Key.cert.IssuingCertificateURL using this client.
-	FetchCertChainClient *http.Client
+	CertChainFetcher *http.Client
 }
 
 // Given a certificate, iterates through its IssuingCertificateURLs and returns
@@ -148,8 +148,8 @@ func (k *Key) Attest(opts AttestOpts) (*pb.Attestation, error) {
 
 	// Attempt to construct certificate chain. fetchIssuingCertificate checks if
 	// AK cert is present and contains intermediate cert URLs.
-	if opts.FetchCertChainClient != nil {
-		attestation.IntermediateCerts, err = k.getCertificateChain(opts.FetchCertChainClient)
+	if opts.CertChainFetcher != nil {
+		attestation.IntermediateCerts, err = k.getCertificateChain(opts.CertChainFetcher)
 		if err != nil {
 			return nil, fmt.Errorf("fetching certificate chain: %w", err)
 		}

--- a/client/attest.go
+++ b/client/attest.go
@@ -32,17 +32,17 @@ type AttestOpts struct {
 	// firmware event log, where PCRs 0-9 and 14 are often measured. If the two
 	// logs overlap, server-side verification using this library may fail.
 	CanonicalEventLog []byte
-	// Indicates whether the AK certificate chain should be retrieved for validation.
-	// If true, Key.Attest() will construct the certificate chain by making GET requests to
-	// the contents of Key.cert.IssuingCertificateURL.
-	FetchCertChain bool
+	// If non-nil, will be used to fetch the AK certificate chain for validation.
+	// Key.Attest() will construct the certificate chain by making GET requests to
+	// the contents of Key.cert.IssuingCertificateURL using this client.
+	FetchCertChainClient *http.Client
 }
 
 // Given a certificate, iterates through its IssuingCertificateURLs and returns
 // the certificate that signed it. If the certificate lacks an
 // IssuingCertificateURL, return nil. If fetching the certificates fails or the
 // cert chain is malformed, return an error.
-func fetchIssuingCertificate(cert *x509.Certificate) (*x509.Certificate, error) {
+func fetchIssuingCertificate(client *http.Client, cert *x509.Certificate) (*x509.Certificate, error) {
 	// Check if we should event attempt fetching.
 	if cert == nil || len(cert.IssuingCertificateURL) == 0 {
 		return nil, nil
@@ -57,7 +57,7 @@ func fetchIssuingCertificate(cert *x509.Certificate) (*x509.Certificate, error) 
 		if i >= maxIssuingCertificateURLs {
 			break
 		}
-		resp, err := http.Get(url)
+		resp, err := client.Get(url)
 		if err != nil {
 			lastErr = fmt.Errorf("failed to retrieve certificate at %v: %w", url, err)
 			continue
@@ -92,11 +92,11 @@ func fetchIssuingCertificate(cert *x509.Certificate) (*x509.Certificate, error) 
 
 // Constructs the certificate chain for the key's certificate.
 // If an error is encountered in the process, return what has been constructed so far.
-func (k *Key) getCertificateChain() ([][]byte, error) {
+func (k *Key) getCertificateChain(client *http.Client) ([][]byte, error) {
 	var certs [][]byte
 	currentCert := k.cert
 	for len(certs) <= maxCertChainLength {
-		issuingCert, err := fetchIssuingCertificate(currentCert)
+		issuingCert, err := fetchIssuingCertificate(client, currentCert)
 		if err != nil {
 			return nil, err
 		}
@@ -148,8 +148,8 @@ func (k *Key) Attest(opts AttestOpts) (*pb.Attestation, error) {
 
 	// Attempt to construct certificate chain. fetchIssuingCertificate checks if
 	// AK cert is present and contains intermediate cert URLs.
-	if opts.FetchCertChain {
-		attestation.IntermediateCerts, err = k.getCertificateChain()
+	if opts.FetchCertChainClient != nil {
+		attestation.IntermediateCerts, err = k.getCertificateChain(opts.FetchCertChainClient)
 		if err != nil {
 			return nil, fmt.Errorf("fetching certificate chain: %w", err)
 		}

--- a/client/attest_network_test.go
+++ b/client/attest_network_test.go
@@ -10,6 +10,8 @@ import (
 	"google.golang.org/protobuf/proto"
 )
 
+var externalClient = http.DefaultClient
+
 func TestNetworkFetchIssuingCertificate(t *testing.T) {
 	attestBytes := test.COS85Nonce9009
 	att := &pb.Attestation{}
@@ -24,7 +26,7 @@ func TestNetworkFetchIssuingCertificate(t *testing.T) {
 
 	key := &Key{cert: akCert}
 
-	certChain, err := key.getCertificateChain(&http.Client{})
+	certChain, err := key.getCertificateChain(externalClient)
 	if err != nil {
 		t.Error(err)
 	}

--- a/client/attest_network_test.go
+++ b/client/attest_network_test.go
@@ -2,6 +2,7 @@ package client
 
 import (
 	"crypto/x509"
+	"net/http"
 	"testing"
 
 	"github.com/google/go-tpm-tools/internal/test"
@@ -23,7 +24,7 @@ func TestNetworkFetchIssuingCertificate(t *testing.T) {
 
 	key := &Key{cert: akCert}
 
-	certChain, err := key.getCertificateChain()
+	certChain, err := key.getCertificateChain(&http.Client{})
 	if err != nil {
 		t.Error(err)
 	}

--- a/client/attest_test.go
+++ b/client/attest_test.go
@@ -14,6 +14,8 @@ import (
 	"github.com/google/go-tpm-tools/internal/test"
 )
 
+var localClient = http.DefaultClient
+
 // Returns an x509 Certificate with the provided issuingURL and signed with the provided parent certificate and key.
 // If parentCert and parentKey are nil, the certificate will be self-signed.
 func getTestCert(t *testing.T, issuingURL []string, parentCert *x509.Certificate, parentKey *rsa.PrivateKey) (*x509.Certificate, *rsa.PrivateKey) {
@@ -62,7 +64,7 @@ func TestFetchIssuingCertificateSucceeds(t *testing.T) {
 
 	leafCert, _ := getTestCert(t, []string{"invalid.URL", ts.URL}, testCA, caKey)
 
-	cert, err := fetchIssuingCertificate(&http.Client{}, leafCert)
+	cert, err := fetchIssuingCertificate(localClient, leafCert)
 	if err != nil || cert == nil {
 		t.Errorf("fetchIssuingCertificate() did not find valid intermediate cert: %v", err)
 	}
@@ -78,7 +80,7 @@ func TestFetchIssuingCertificateReturnsErrorIfMalformedCertificateFound(t *testi
 	testCA, caKey := getTestCert(t, nil, nil, nil)
 	leafCert, _ := getTestCert(t, []string{ts.URL}, testCA, caKey)
 
-	_, err := fetchIssuingCertificate(&http.Client{}, leafCert)
+	_, err := fetchIssuingCertificate(localClient, leafCert)
 	if err == nil {
 		t.Fatal("expected fetchIssuingCertificate to fail with malformed cert")
 	}
@@ -109,7 +111,7 @@ func TestGetCertificateChainSucceeds(t *testing.T) {
 
 	key := &Key{cert: leafCert}
 
-	certChain, err := key.getCertificateChain(&http.Client{})
+	certChain, err := key.getCertificateChain(localClient)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -140,7 +142,7 @@ func TestKeyAttestSucceedsWithCertChainRetrieval(t *testing.T) {
 
 	ak.cert = leafCert
 
-	attestation, err := ak.Attest(AttestOpts{Nonce: []byte("some nonce"), FetchCertChainClient: &http.Client{}})
+	attestation, err := ak.Attest(AttestOpts{Nonce: []byte("some nonce"), CertChainFetcher: localClient})
 	if err != nil {
 		t.Fatalf("Attest returned with error: %v", err)
 	}
@@ -172,18 +174,18 @@ func TestKeyAttestGetCertificateChainConditions(t *testing.T) {
 		cert                 *x509.Certificate
 	}{
 		{
-			name:                 "fetchCertChainClient is nil",
+			name:                 "CertChainFetcher is nil",
 			fetchCertChainClient: nil,
 			cert:                 nil,
 		},
 		{
-			name:                 "fetchCertChainClient is present, key.cert is nil",
-			fetchCertChainClient: &http.Client{},
+			name:                 "CertChainFetcher is present, key.cert is nil",
+			fetchCertChainClient: localClient,
 			cert:                 nil,
 		},
 		{
-			name:                 "fetchCertChainClient is present, key.cert has nil IssuingCertificateURL",
-			fetchCertChainClient: &http.Client{},
+			name:                 "CertChainFetcher is present, key.cert has nil IssuingCertificateURL",
+			fetchCertChainClient: localClient,
 			cert:                 akCert,
 		},
 	}
@@ -192,7 +194,7 @@ func TestKeyAttestGetCertificateChainConditions(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			ak.cert = tc.cert
 
-			att, err := ak.Attest(AttestOpts{Nonce: []byte("some nonce"), FetchCertChainClient: tc.fetchCertChainClient})
+			att, err := ak.Attest(AttestOpts{Nonce: []byte("some nonce"), CertChainFetcher: tc.fetchCertChainClient})
 			if err != nil {
 				t.Fatalf("Attest returned error: %v", err)
 			}


### PR DESCRIPTION
Instead of a boolean flag, have an http.Client specified for fetching AK Certificate chains.