### PR TITLE
Automatically use attestation intermediates for AK cert verification

### DIFF
--- a/server/verify.go
+++ b/server/verify.go
@@ -75,7 +75,7 @@ func VerifyAttestation(attestation *pb.Attestation, opts VerifyOpts) (*pb.Machin
 		for _, certBytes := range attestation.IntermediateCerts {
 			cert, err := x509.ParseCertificate(certBytes)
 			if err != nil {
-				return nil, fmt.Errorf("filed to parse intermediate certificate in attestation: %w", err)
+				return nil, fmt.Errorf("failed to parse intermediate certificate in attestation: %w", err)
 			}
 
 			opts.IntermediateCerts.AddCert(cert)

--- a/server/verify.go
+++ b/server/verify.go
@@ -65,6 +65,22 @@ func VerifyAttestation(attestation *pb.Attestation, opts VerifyOpts) (*pb.Machin
 	if err != nil {
 		return nil, fmt.Errorf("failed to get AK public key: %w", err)
 	}
+
+	// Add intermediate certs in the attestation if they exist.
+	if len(attestation.IntermediateCerts) != 0 {
+		if opts.IntermediateCerts == nil {
+			opts.IntermediateCerts = x509.NewCertPool()
+		}
+
+		for _, certBytes := range attestation.IntermediateCerts {
+			cert, err := x509.ParseCertificate(certBytes)
+			if err != nil {
+				return nil, fmt.Errorf("filed to parse intermediate certificate in attestation: %w", err)
+			}
+
+			opts.IntermediateCerts.AddCert(cert)
+		}
+	}
 	if err := checkAKTrusted(akPubKey, attestation.GetAkCert(), opts); err != nil {
 		return nil, fmt.Errorf("failed to validate AK: %w", err)
 	}

--- a/server/verify_test.go
+++ b/server/verify_test.go
@@ -477,6 +477,23 @@ func TestVerifyAutomaticallyUsesIntermediatesInAttestation(t *testing.T) {
 	}
 }
 
+func TestVerifySucceedsWithOverlappingIntermediatesInOptionsAndAttestation(t *testing.T) {
+	attestBytes := test.COS85Nonce9009
+	att := &attestpb.Attestation{}
+	if err := proto.Unmarshal(attestBytes, att); err != nil {
+		t.Fatalf("failed to unmarshal attestation: %v", err)
+	}
+	att.IntermediateCerts = [][]byte{gceEKIntermediateCA2}
+
+	if _, err := VerifyAttestation(att, VerifyOpts{
+		Nonce:             []byte{0x90, 0x09},
+		TrustedRootCerts:  GceEKRoots,
+		IntermediateCerts: GceEKIntermediates,
+	}); err != nil {
+		t.Errorf("failed to VerifyAttestation with overlapping intermediates provided in attestation and options: %v", err)
+	}
+}
+
 func TestVerifyFailWithCertsAndPubkey(t *testing.T) {
 	att := &attestpb.Attestation{}
 	if err := proto.Unmarshal(test.COS85NoNonce, att); err != nil {


### PR DESCRIPTION
If an attestation contains intermediate certificates, automatically add them to the options for `checkAKTrusted`