### PR TITLE
Change crypto/x509 dependencies to ct/x509

### DIFF
--- a/client/attest.go
+++ b/client/attest.go
@@ -1,11 +1,11 @@
 package client
 
 import (
-	"crypto/x509"
 	"fmt"
 	"io/ioutil"
 	"net/http"
 
+	"github.com/google/certificate-transparency-go/x509"
 	pb "github.com/google/go-tpm-tools/proto/attest"
 )
 

--- a/client/attest_network_test.go
+++ b/client/attest_network_test.go
@@ -1,10 +1,10 @@
 package client
 
 import (
-	"crypto/x509"
 	"net/http"
 	"testing"
 
+	"github.com/google/certificate-transparency-go/x509"
 	"github.com/google/go-tpm-tools/internal/test"
 	pb "github.com/google/go-tpm-tools/proto/attest"
 	"google.golang.org/protobuf/proto"

--- a/client/attest_test.go
+++ b/client/attest_test.go
@@ -4,13 +4,13 @@ import (
 	"bytes"
 	"crypto/rand"
 	"crypto/rsa"
-	"crypto/x509"
 	"math/big"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 	"time"
 
+	"github.com/google/certificate-transparency-go/x509"
 	"github.com/google/go-tpm-tools/internal/test"
 )
 

--- a/client/keys.go
+++ b/client/keys.go
@@ -5,11 +5,11 @@ import (
 	"bytes"
 	"crypto"
 	"crypto/subtle"
-	"crypto/x509"
 	"errors"
 	"fmt"
 	"io"
 
+	"github.com/google/certificate-transparency-go/x509"
 	"github.com/google/go-tpm-tools/internal"
 	pb "github.com/google/go-tpm-tools/proto/tpm"
 	"github.com/google/go-tpm/tpm2"

--- a/client/keys_test.go
+++ b/client/keys_test.go
@@ -4,13 +4,13 @@ import (
 	"crypto"
 	"crypto/rand"
 	"crypto/rsa"
-	"crypto/x509"
 	"io"
 	"math/big"
 	"reflect"
 	"testing"
 	"time"
 
+	"github.com/google/certificate-transparency-go/x509"
 	"github.com/google/go-tpm/tpm2"
 	"github.com/google/go-tpm/tpmutil"
 


### PR DESCRIPTION
Change crypto/x509 dependencies to certificate-transparency/x509 for consistency.

(also avoids attestation verifier tests breaking)