### PR TITLE
Add impersonate service accounts to launcherspec

### DIFF
--- a/launcher/spec/launcher_spec.go
+++ b/launcher/spec/launcher_spec.go
@@ -29,11 +29,12 @@ const (
 )
 
 const (
-	imageRefKey        = "tee-image-reference"
-	restartPolicyKey   = "tee-restart-policy"
-	cmdKey             = "tee-cmd"
-	envKeyPrefix       = "tee-env-"
-	instanceAttributes = "instance/attributes/?recursive=true"
+	imageRefKey                = "tee-image-reference"
+	restartPolicyKey           = "tee-restart-policy"
+	cmdKey                     = "tee-cmd"
+	envKeyPrefix               = "tee-env-"
+	instanceAttributes         = "instance/attributes/?recursive=true"
+	impersonateServiceAccounts = "tee-impersonate-service-accounts"
 )
 
 var errImageRefNotSpecified = fmt.Errorf("%s is not specified in the custom metadata", imageRefKey)
@@ -47,12 +48,13 @@ type EnvVar struct {
 // LauncherSpec contains specification set by the operator who wants to
 // launch a container.
 type LauncherSpec struct {
-	ImageRef               string
-	RestartPolicy          RestartPolicy
-	Cmd                    []string
-	Envs                   []EnvVar
-	UseLocalImage          bool
-	AttestationServiceAddr string
+	ImageRef                   string
+	RestartPolicy              RestartPolicy
+	Cmd                        []string
+	Envs                       []EnvVar
+	UseLocalImage              bool
+	AttestationServiceAddr     string
+	ImpersonateServiceAccounts []string
 }
 
 // UnmarshalJSON unmarshals an instance attributes list in JSON format from the metadata
@@ -75,6 +77,11 @@ func (s *LauncherSpec) UnmarshalJSON(b []byte) error {
 	}
 	if err := s.RestartPolicy.isValid(); err != nil {
 		return err
+	}
+
+	if val, ok := unmarshaledMap[impersonateServiceAccounts]; ok && val != "" {
+		delegates := strings.Split(val, ",")
+		s.ImpersonateServiceAccounts = append(s.ImpersonateServiceAccounts, delegates...)
 	}
 
 	// populate cmd override

--- a/launcher/spec/launcher_spec_test.go
+++ b/launcher/spec/launcher_spec_test.go
@@ -15,29 +15,32 @@ func TestLauncherSpecUnmarshalJSONHappyCases(t *testing.T) {
 			"HappyCase",
 			`{
 				"tee-cmd":"[\"--foo\",\"--bar\",\"--baz\"]",
-				"tee-env-enva":"aaa",
+				"tee-env-foo":"bar",
 				"tee-image-reference":"docker.io/library/hello-world:latest",
-				"tee-restart-policy":"Always"
+				"tee-restart-policy":"Always",
+				"tee-impersonate-service-accounts":"sv1@developer.gserviceaccount.com,sv2@developer.gserviceaccount.com"
 			}`,
 		},
 		{
 			"HappyCaseWithExtraUnknowFields",
 			`{
 				"tee-cmd":"[\"--foo\",\"--bar\",\"--baz\"]",
-				"tee-env-enva":"aaa",
+				"tee-env-foo":"bar",
 				"tee-unknown":"unknown",
 				"unknown":"unknown",
 				"tee-image-reference":"docker.io/library/hello-world:latest",
-				"tee-restart-policy":"Always"
+				"tee-restart-policy":"Always",
+				"tee-impersonate-service-accounts":"sv1@developer.gserviceaccount.com,sv2@developer.gserviceaccount.com"
 			}`,
 		},
 	}
 
 	want := &LauncherSpec{
-		ImageRef:      "docker.io/library/hello-world:latest",
-		RestartPolicy: Always,
-		Cmd:           []string{"--foo", "--bar", "--baz"},
-		Envs:          []EnvVar{{"enva", "aaa"}},
+		ImageRef:                   "docker.io/library/hello-world:latest",
+		RestartPolicy:              Always,
+		Cmd:                        []string{"--foo", "--bar", "--baz"},
+		Envs:                       []EnvVar{{"foo", "bar"}},
+		ImpersonateServiceAccounts: []string{"sv1@developer.gserviceaccount.com", "sv2@developer.gserviceaccount.com"},
 	}
 
 	for _, testcase := range testCases {
@@ -98,7 +101,10 @@ func TestLauncherSpecUnmarshalJSONBadInput(t *testing.T) {
 }
 
 func TestLauncherSpecUnmarshalJSONWithDefaultValue(t *testing.T) {
-	mdsJSON := `{"tee-image-reference":"docker.io/library/hello-world:latest"}`
+	mdsJSON := `{
+		"tee-image-reference":"docker.io/library/hello-world:latest",
+		"tee-impersonate-service-accounts":""
+		}`
 
 	spec := &LauncherSpec{}
 	if err := spec.UnmarshalJSON([]byte(mdsJSON)); err != nil {
@@ -108,8 +114,6 @@ func TestLauncherSpecUnmarshalJSONWithDefaultValue(t *testing.T) {
 	want := &LauncherSpec{
 		ImageRef:      "docker.io/library/hello-world:latest",
 		RestartPolicy: Never,
-		Cmd:           nil,
-		Envs:          nil,
 	}
 
 	if !cmp.Equal(spec, want) {
@@ -120,7 +124,7 @@ func TestLauncherSpecUnmarshalJSONWithDefaultValue(t *testing.T) {
 func TestLauncherSpecUnmarshalJSONWithoutImageReference(t *testing.T) {
 	mdsJSON := `{
 		"tee-cmd":"[\"--foo\",\"--bar\",\"--baz\"]",
-		"tee-env-enva":"aaa",
+		"tee-env-foo":"bar",
 		"tee-restart-policy":"Never"
 		}`
 


### PR DESCRIPTION
Create the metadata service field to input service accounts for impersonation.

Operator can leave the field blank, and the default GCE service account will be used;
Or, they can input just one service account which will be the impersonation target;
Or, they can input a list of service accounts, the last service account will be the impersonation target, service accounts before that will act as delegates.

The actual implementation will be in a followup PR