### PR TITLE
Retrieve instance info from AK certificate

### DIFF
--- a/server/verify.go
+++ b/server/verify.go
@@ -163,7 +163,7 @@ func getInstanceInfo(extensions []pkix.Extension) (*pb.GCEInstanceInfo, error) {
 	}
 
 	// If GCE Instance Info extension is not found.
-	if rawInfo == nil {
+	if len(rawInfo) == 0 {
 		return nil, nil
 	}
 
@@ -174,7 +174,7 @@ func getInstanceInfo(extensions []pkix.Extension) (*pb.GCEInstanceInfo, error) {
 
 	// TODO: Remove when fields are changed to uint64.
 	if info.ProjectNumber < 0 || info.InstanceID < 0 || info.SecurityProperties.SecurityVersion < 0 {
-		return nil, fmt.Errorf("instance Information should not contain negative integer fields")
+		return nil, fmt.Errorf("negative integer fields found in GCE Instance Information Extension")
 	}
 
 	// Check production.

--- a/server/verify_test.go
+++ b/server/verify_test.go
@@ -6,6 +6,8 @@ import (
 	"crypto/rand"
 	"crypto/rsa"
 	"crypto/sha256"
+	"crypto/x509/pkix"
+	"encoding/asn1"
 	"fmt"
 	"io"
 	"reflect"

--- a/server/verify_test.go
+++ b/server/verify_test.go
@@ -639,10 +639,10 @@ func TestGetInstanceInfo(t *testing.T) {
 
 	extStruct := gceInstanceInfo{
 		Zone:               expectedInstanceInfo.Zone,
-		ProjectId:          expectedInstanceInfo.ProjectId,
+		ProjectID:          expectedInstanceInfo.ProjectId,
 		ProjectNumber:      int64(expectedInstanceInfo.ProjectNumber),
 		InstanceName:       expectedInstanceInfo.InstanceName,
-		InstanceId:         int64(expectedInstanceInfo.InstanceId),
+		InstanceID:         int64(expectedInstanceInfo.InstanceId),
 		SecurityProperties: gceSecurityProperties{IsProduction: true},
 	}
 
@@ -672,10 +672,10 @@ func TestGetInstanceInfo(t *testing.T) {
 func TestGetInstanceInfoReturnsNil(t *testing.T) {
 	extStruct := gceInstanceInfo{
 		Zone:               "zone",
-		ProjectId:          "project id",
+		ProjectID:          "project id",
 		ProjectNumber:      0,
 		InstanceName:       "instance name",
-		InstanceId:         1,
+		InstanceID:         1,
 		SecurityProperties: gceSecurityProperties{IsProduction: false},
 	}
 

--- a/server/verify_test.go
+++ b/server/verify_test.go
@@ -10,7 +10,6 @@ import (
 	"encoding/asn1"
 	"fmt"
 	"io"
-	"reflect"
 	"strconv"
 	"strings"
 	"testing"
@@ -666,7 +665,7 @@ func TestGetInstanceInfo(t *testing.T) {
 		t.Fatal("getInstanceInfo returned nil instance info.")
 	}
 
-	if !reflect.DeepEqual(instanceInfo, expectedInstanceInfo) {
+	if !proto.Equal(instanceInfo, expectedInstanceInfo) {
 		t.Errorf("getInstanceInfo did not return expected instance info: got %v, want %v", instanceInfo, expectedInstanceInfo)
 	}
 }


### PR DESCRIPTION
After validating the AK certificate, look for an extension with a specific ObjectIdentifier that contains GCE instance information and return it in a MachineState.