### PR TITLE
Add cloudbuild config and scripts

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,0 +1,43 @@
+substitutions:
+  '_BASE_IMAGE': 'cos-dev-101-16963-0-0'
+  '_BASE_IMAGE_PROJECT': 'cos-cloud'
+  '_OUTPUT_IMAGE': ''
+  '_ATTEST_ENDPOINT': ''
+
+steps:
+  - name: golang:1.18
+    entrypoint: /bin/bash
+    args:
+      - -c
+      - |
+        cd launcher
+        go build  
+  - name: 'gcr.io/cos-cloud/cos-customizer'
+    args: ['start-image-build',
+           '-gcs-bucket=${PROJECT_ID}_cloudbuild',
+           '-gcs-workdir=customizer-${BUILD_ID}',
+           '-image-name=${_BASE_IMAGE}',
+           '-image-project=${_BASE_IMAGE_PROJECT}']
+  - name: 'gcr.io/cos-cloud/cos-customizer'
+    args: ['run-script',
+           '-script=launcher/preload.sh',
+           '-env=ATTEST_ENDPOINT=${_ATTEST_ENDPOINT}']
+  - name: 'gcr.io/cos-cloud/cos-customizer'
+    args: ['seal-oem']
+  - name: 'gcr.io/cos-cloud/cos-customizer'
+    args: ['run-script',
+           '-script=launcher/fixup_oem.sh']
+  - name: 'gcr.io/cos-cloud/cos-customizer'
+    args: ['finish-image-build',
+           '-oem-size=500M',
+           '-disk-size-gb=11',
+           '-image-name=attest-cos-dev-${_OUTPUT_IMAGE}',
+           '-image-family=attest-cos-dev',
+           '-image-project=${PROJECT_ID}',
+           '-zone=us-central1-a',
+           '-project=${PROJECT_ID}']
+
+timeout: '3000s'
+
+options:
+  logging: CLOUD_LOGGING_ONLY

--- a/launcher/container-runner.service
+++ b/launcher/container-runner.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=Vegas Container Runner
+Wants=network-online.target gcr-online.target containerd.service
+After=network-online.target gcr-online.target containerd.service
+
+[Service]
+ExecStart=/var/lib/google/cc_container_launcher --addr=${ATTEST_ENDPOINT}
+Restart=no
+# RestartSec=90
+StandardOutput=journal+console
+
+[Install]
+WantedBy=multi-user.target
+

--- a/launcher/entrypoint.sh
+++ b/launcher/entrypoint.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+main() {
+  # copy the binary
+  cp /usr/share/oem/cc_container_launcher /var/lib/google/cc_container_launcher
+  chmod +x /var/lib/google/cc_container_launcher
+  
+  cp /usr/share/oem/container-runner.service /etc/systemd/system/container-runner.service
+  systemctl daemon-reload
+  systemctl enable container-runner.service
+  systemctl start container-runner.service
+}
+
+main

--- a/launcher/fixup_oem.sh
+++ b/launcher/fixup_oem.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+main() {
+  if [[ ! -d /mnt/disks/efi ]]; then
+    mkdir /mnt/disks/efi
+  fi
+  mount /dev/sda12 /mnt/disks/efi
+  sed -i -e 's|systemd.mask=usr-share-oem.mount||g' /mnt/disks/efi/efi/boot/grub.cfg
+  umount /mnt/disks/efi
+}
+
+main

--- a/launcher/preload.sh
+++ b/launcher/preload.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+copy_launcher() {
+  cp launcher/launcher /usr/share/oem/cc_container_launcher
+}
+
+setup_launcher_systemd_unit() {
+  cp launcher/container-runner.service /usr/share/oem/container-runner.service
+  # set attest service endpoint
+  sed -i 's/\${ATTEST_ENDPOINT}/'${ATTEST_ENDPOINT}'/g' /usr/share/oem/container-runner.service
+}
+
+append_cmdline() {
+  local arg="$1"
+  if [[ ! -d /mnt/disks/efi ]]; then
+    mkdir /mnt/disks/efi
+  fi
+  mount /dev/sda12 /mnt/disks/efi
+  sed -i -e "s|cros_efi|cros_efi ${arg}|g" /mnt/disks/efi/efi/boot/grub.cfg
+  umount /mnt/disks/efi
+}
+
+configure_entrypoint() {
+  cp "$1" /usr/share/oem/user-data
+  touch /usr/share/oem/meta-data
+  append_cmdline "'ds=nocloud;s=/usr/share/oem/'"
+}
+
+main() {
+  mount -o remount,rw /usr/share/oem
+  configure_entrypoint "launcher/entrypoint.sh"
+  copy_launcher
+  setup_launcher_systemd_unit
+}
+
+main


### PR DESCRIPTION
Add the basci cloudbuild config and related scripts.

The workflow will build the launcher and install it in a COS image using the cos-customizer.
cos-customizer will also setup the entrypoint script for the machine.