### PR TITLE
Start to use AK cert in attestation

### DIFF
--- a/launcher/container_runner.go
+++ b/launcher/container_runner.go
@@ -150,7 +150,7 @@ func NewRunner(ctx context.Context, cdClient *containerd.Client, token oauth2.To
 		container,
 		launchSpec,
 		conn,
-		CreateAttestationAgent(tpm, client.AttestationKeyECC, conn, principalFetcher),
+		CreateAttestationAgent(tpm, client.GceAttestationKeyECC, conn, principalFetcher),
 	}, nil
 }
 

--- a/server/verify.go
+++ b/server/verify.go
@@ -49,8 +49,8 @@ type VerifyOpts struct {
 
 // TODO: Change int64 fields to uint64 when compatible with ASN1 parsing.
 type gceSecurityProperties struct {
-	SecurityVersion int64 `asn1:"optional"`
-	IsProduction    bool  `asn1:"optional"`
+	SecurityVersion int64 `asn1:"explicit,tag:0,optional"`
+	IsProduction    bool  `asn1:"explicit,tag:1,optional"`
 }
 
 type gceInstanceInfo struct {
@@ -59,7 +59,7 @@ type gceInstanceInfo struct {
 	ProjectID          string `asn1:"utf8"`
 	InstanceID         int64
 	InstanceName       string                `asn1:"utf8"`
-	SecurityProperties gceSecurityProperties `asn1:"optional"`
+	SecurityProperties gceSecurityProperties `asn1:"explicit,optional"`
 }
 
 // VerifyAttestation performs the following checks on an Attestation:

--- a/server/verify_test.go
+++ b/server/verify_test.go
@@ -786,3 +786,34 @@ func TestGetInstanceInfoError(t *testing.T) {
 		t.Error("getInstanceInfo returned successfully, expected error")
 	}
 }
+
+func TestGetInstanceInfoASN(t *testing.T) {
+	expectedInstanceInfo := &attestpb.GCEInstanceInfo{
+		Zone:          "us-west1-b",
+		ProjectId:     "jiankun-vm-test",
+		ProjectNumber: 620438545889,
+		InstanceName:  "jkltest42102",
+		InstanceId:    3560342035431930290,
+	}
+
+	// The payload is extract from a real AK cert, the ASN1 encoding requires gceSecurityProperties
+	// to have explicit ASN tag.
+	extPayload := []byte{48, 95, 12, 10, 117, 115, 45, 119, 101, 115, 116, 49, 45, 98, 2, 6, 0, 144, 117, 4, 229, 225, 12, 15, 106, 105, 97, 110, 107, 117, 110, 45, 118, 109, 45, 116, 101, 115, 116, 2, 8, 49, 104, 224, 55, 188, 207, 185, 178, 12, 12, 106, 107, 108, 116, 101, 115, 116, 52, 50, 49, 48, 50, 160, 32, 48, 30, 160, 3, 2, 1, 0, 161, 3, 1, 1, 255, 162, 3, 1, 1, 0, 163, 3, 1, 1, 0, 164, 3, 1, 1, 0, 165, 3, 1, 1, 0}
+
+	ext := []pkix.Extension{{
+		Id:    cloudComputeInstanceIdentifierOID,
+		Value: extPayload,
+	}}
+
+	instanceInfo, err := getInstanceInfo(ext)
+	if err != nil {
+		t.Fatalf("getInstanceInfo returned with error: %v", err)
+	}
+	if instanceInfo == nil {
+		t.Fatal("getInstanceInfo returned nil instance info.")
+	}
+
+	if !proto.Equal(instanceInfo, expectedInstanceInfo) {
+		t.Errorf("getInstanceInfo did not return expected instance info: got %v, want %v", instanceInfo, expectedInstanceInfo)
+	}
+}


### PR DESCRIPTION
Start to use AK cert in launcher/attestation

Fix ASN1 annotation in `gceInstanceInfo`
Previously it would ignore the optional `gceSecurityProperties` when unmarshaling a real AK cert.