### PR TITLE
Add Cloud Logging; Update the service file for launcher

### DIFF
--- a/go.work.sum
+++ b/go.work.sum
@@ -1,3 +1,1 @@
-cloud.google.com/go v0.100.2 h1:t9Iw5QH5v4XtlEQaCtUY7x6sCABps8sW0acw7e2WQ6Y=
 github.com/googleapis/gax-go v2.0.2+incompatible h1:silFMLAnr330+NRuag/VjIGF7TLp/LBrV2CJKFLWEww=
-github.com/googleapis/gax-go/v2 v2.1.1 h1:dp3bWCh+PPO1zjRRiCSczJav13sBvG4UhNyVTa1KqdU=

--- a/launcher/attest_test.go
+++ b/launcher/attest_test.go
@@ -41,7 +41,7 @@ func TestAttest(t *testing.T) {
 		t.Fatalf("failed to connect to attestation service: %v", err)
 	}
 	// Cannot test a GCE key on the simulator.
-	agent := CreateAttestationAgent(tpm, client.AttestationKeyECC, conn, placeholderFetcher)
+	agent := CreateAttestationAgent(tpm, client.AttestationKeyECC, conn, placeholderFetcher, log.Default())
 
 	token, err := agent.Attest(context.Background())
 	if err != nil {

--- a/launcher/container-runner.service
+++ b/launcher/container-runner.service
@@ -1,14 +1,15 @@
 [Unit]
-Description=Vegas Container Runner
+Description=Confidential Space Launcher
 Wants=network-online.target gcr-online.target containerd.service
 After=network-online.target gcr-online.target containerd.service
 
 [Service]
 ExecStart=/var/lib/google/cc_container_launcher --addr=${ATTEST_ENDPOINT}
+# Shutdown the host after the launcher exits
+ExecStopPost=systemctl poweroff
 Restart=no
 # RestartSec=90
 StandardOutput=journal+console
 
 [Install]
 WantedBy=multi-user.target
-

--- a/launcher/container_runner.go
+++ b/launcher/container_runner.go
@@ -325,7 +325,7 @@ func (r *ContainerRunner) fetchAndWriteToken(ctx context.Context) error {
 }
 
 // Run the container
-// Container output will always be redirected to stdio for now
+// Container output will always be redirected to logger writer for now
 func (r *ContainerRunner) Run(ctx context.Context) error {
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
@@ -339,7 +339,7 @@ func (r *ContainerRunner) Run(ctx context.Context) error {
 	}
 
 	for {
-		task, err := r.container.NewTask(ctx, cio.NewCreator(cio.WithStdio))
+		task, err := r.container.NewTask(ctx, cio.NewCreator(cio.WithStreams(nil, r.logger.Writer(), r.logger.Writer())))
 		if err != nil {
 			return err
 		}

--- a/launcher/container_runner_test.go
+++ b/launcher/container_runner_test.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log"
 	"net/http"
 	"os"
 	"path"
@@ -84,6 +85,7 @@ func TestRefreshToken(t *testing.T) {
 				return expectedToken, nil
 			},
 		},
+		logger: log.Default(),
 	}
 
 	if err := os.MkdirAll(HostTokenPath, 0744); err != nil {
@@ -142,6 +144,7 @@ func TestRefreshTokenError(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			runner := ContainerRunner{
 				attestAgent: tc.agent,
+				logger:      log.Default(),
 			}
 
 			if _, err := runner.refreshToken(context.Background()); err == nil {
@@ -164,6 +167,7 @@ func TestFetchAndWriteTokenSucceeds(t *testing.T) {
 				return expectedToken, nil
 			},
 		},
+		logger: log.Default(),
 	}
 
 	if err := runner.fetchAndWriteToken(ctx); err != nil {
@@ -197,6 +201,7 @@ func TestTokenIsNotChangedIfRefreshFails(t *testing.T) {
 
 	runner := ContainerRunner{
 		attestAgent: &fakeAttestationAgent{attestFunc: successfulAttestFunc},
+		logger:      log.Default(),
 	}
 
 	if err := runner.fetchAndWriteToken(ctx); err != nil {
@@ -242,6 +247,7 @@ func TestFetchAndWriteTokenWithTokenRefresh(t *testing.T) {
 				return expectedToken, nil
 			},
 		},
+		logger: log.Default(),
 	}
 
 	if err := runner.fetchAndWriteToken(ctx); err != nil {

--- a/launcher/go.mod
+++ b/launcher/go.mod
@@ -4,6 +4,7 @@ go 1.18
 
 require (
 	cloud.google.com/go/compute v1.5.0
+	cloud.google.com/go/logging v1.4.2
 	github.com/containerd/containerd v1.6.1
 	github.com/golang-jwt/jwt/v4 v4.4.1
 	github.com/google/go-cmp v0.5.7
@@ -19,6 +20,7 @@ require (
 )
 
 require (
+	cloud.google.com/go v0.100.2 // indirect
 	github.com/Microsoft/go-winio v0.5.1 // indirect
 	github.com/Microsoft/hcsshim v0.9.2 // indirect
 	github.com/containerd/cgroups v1.0.3 // indirect
@@ -35,6 +37,7 @@ require (
 	github.com/google/go-attestation v0.4.4-0.20220404204839-8820d49b18d9 // indirect
 	github.com/google/go-tspi v0.2.1-0.20190423175329-115dea689aad // indirect
 	github.com/google/uuid v1.2.0 // indirect
+	github.com/googleapis/gax-go/v2 v2.1.1 // indirect
 	github.com/klauspost/compress v1.11.13 // indirect
 	github.com/moby/locker v1.0.1 // indirect
 	github.com/moby/sys/mountinfo v0.5.0 // indirect

--- a/launcher/go.sum
+++ b/launcher/go.sum
@@ -36,6 +36,7 @@ cloud.google.com/go v0.93.3/go.mod h1:8utlLll2EF5XMAV15woO4lSbWQlk8rer9aLOfLh7+Y
 cloud.google.com/go v0.94.1/go.mod h1:qAlAugsXlC+JWO+Bke5vCtc9ONxjQT3drlTTnAplMW4=
 cloud.google.com/go v0.97.0/go.mod h1:GF7l59pYBVlXQIBLx3a761cZ41F9bBH3JUlihCt2Udc=
 cloud.google.com/go v0.99.0/go.mod h1:w0Xx2nLzqWJPuozYQX+hFfCSI8WioryfRDzkoI/Y2ZA=
+cloud.google.com/go v0.100.2 h1:t9Iw5QH5v4XtlEQaCtUY7x6sCABps8sW0acw7e2WQ6Y=
 cloud.google.com/go v0.100.2/go.mod h1:4Xra9TjzAeYHrl5+oeLlzbM2k3mjVhZh4UqTZ//w99A=
 cloud.google.com/go/bigquery v1.0.1/go.mod h1:i/xbL2UlR5RvWAURpBYZTtm/cXjCha9lbfbpx4poX+o=
 cloud.google.com/go/bigquery v1.3.0/go.mod h1:PjpwJnslEMmckchkHFfq+HTD2DmtT67aNFKH1/VBDHE=
@@ -50,6 +51,8 @@ cloud.google.com/go/compute v1.5.0/go.mod h1:9SMHyhJlzhlkJqrPAc839t2BZFTSk6Jdj6m
 cloud.google.com/go/datastore v1.0.0/go.mod h1:LXYbyblFSglQ5pkeyhO+Qmw7ukd3C+pD7TKLgZqpHYE=
 cloud.google.com/go/datastore v1.1.0/go.mod h1:umbIZjpQpHh4hmRpGhH4tLFup+FVzqBi1b3c64qFpCk=
 cloud.google.com/go/firestore v1.1.0/go.mod h1:ulACoGHTpvq5r8rxGJ4ddJZBZqakUQqClKRT5SZwBmk=
+cloud.google.com/go/logging v1.4.2 h1:Mu2Q75VBDQlW1HlBMjTX4X84UFR73G1TiLlRYc/b7tA=
+cloud.google.com/go/logging v1.4.2/go.mod h1:jco9QZSx8HiVVqLJReq7z7bVdj0P1Jb9PDFs63T+axo=
 cloud.google.com/go/monitoring v0.1.0/go.mod h1:Hpm3XfzJv+UTiXzCG5Ffp0wijzHTC7Cv4eR7o3x/fEE=
 cloud.google.com/go/pubsub v1.0.1/go.mod h1:R0Gpsv3s54REJCy4fxDixWD93lHJMoZTyQ2kNxGRt3I=
 cloud.google.com/go/pubsub v1.1.0/go.mod h1:EwwdRX2sKPjnvnqCa270oGRyludottCI76h+R3AArQw=
@@ -645,7 +648,6 @@ github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+
 github.com/google/uuid v1.2.0 h1:qJYtXnJRWmpe7m/3XlyhrsLrEURqHRM2kxzoxXqyUDs=
 github.com/google/uuid v1.2.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/wire v0.3.0/go.mod h1:i1DMg/Lu8Sz5yYl25iOdmc5CT5qusaa+zmRWs16741s=
-github.com/googleapis/gax-go v2.0.2+incompatible h1:silFMLAnr330+NRuag/VjIGF7TLp/LBrV2CJKFLWEww=
 github.com/googleapis/gax-go v2.0.2+incompatible/go.mod h1:SFVmujtThgffbyetf+mdk2eWhX2bMyUtNHzFKcPA9HY=
 github.com/googleapis/gax-go/v2 v2.0.4/go.mod h1:0Wqv26UfaUD9n4G6kQubkQ+KchISgw+vpHVxEJEs9eg=
 github.com/googleapis/gax-go/v2 v2.0.5/go.mod h1:DWXyrwAJ9X0FpwwEdw+IPEYBICEFu5mhpdKc/us6bOk=
@@ -1750,6 +1752,7 @@ google.golang.org/genproto v0.0.0-20210413151531-c14fb6ef47c3/go.mod h1:P3QM42oQ
 google.golang.org/genproto v0.0.0-20210427215850-f767ed18ee4d/go.mod h1:P3QM42oQyzQSnHPnZ/vqoCdDmzH28fzWByN9asMeM8A=
 google.golang.org/genproto v0.0.0-20210429181445-86c259c2b4ab/go.mod h1:P3QM42oQyzQSnHPnZ/vqoCdDmzH28fzWByN9asMeM8A=
 google.golang.org/genproto v0.0.0-20210513213006-bf773b8c8384/go.mod h1:P3QM42oQyzQSnHPnZ/vqoCdDmzH28fzWByN9asMeM8A=
+google.golang.org/genproto v0.0.0-20210517163617-5e0236093d7a/go.mod h1:P3QM42oQyzQSnHPnZ/vqoCdDmzH28fzWByN9asMeM8A=
 google.golang.org/genproto v0.0.0-20210602131652-f16073e35f0c/go.mod h1:UODoCrxHCcBojKKwX1terBiRUaqAsFqJiF615XL43r0=
 google.golang.org/genproto v0.0.0-20210604141403-392c879c8b08/go.mod h1:UODoCrxHCcBojKKwX1terBiRUaqAsFqJiF615XL43r0=
 google.golang.org/genproto v0.0.0-20210608205507-b6d2f5bf0d7d/go.mod h1:UODoCrxHCcBojKKwX1terBiRUaqAsFqJiF615XL43r0=


### PR DESCRIPTION
All launcher log will be sent to Cloud Logging as INFO if running on GCE.

Stdout/Stderr of the container will still be redirected to Stdout/err and won't be sent to Cloud Logging.

Host will poweroff after the launcher exits.

Wrap the `main` function with `run()` so we can call os.exit with non-zero code and execute deferred function.

Update the container io: stdin changed to nil and stdout/stderr will be redirected to logger.

Signed-off-by: Jiankun Lu <jiankun@google.com>