### PR TITLE
Properly handle empty TCG Eventlog

### DIFF
--- a/server/eventlog.go
+++ b/server/eventlog.go
@@ -220,6 +220,11 @@ func getPlatformState(hash crypto.Hash, events []*pb.Event) (*pb.PlatformState, 
 // Separate helper function so we can use attest.ParseSecurebootState without
 // needing to reparse the entire event log.
 func parseReplayHelper(rawEventLog []byte, pcrs *tpmpb.PCRs) ([]attest.Event, error) {
+	// Similar to parseCanonicalEventLog, just return an empty array of events for an empty log
+	if len(rawEventLog) == 0 {
+		return nil, nil
+	}
+
 	attestPcrs, err := convertToAttestPcrs(pcrs)
 	if err != nil {
 		return nil, fmt.Errorf("received bad PCR proto: %v", err)
@@ -236,9 +241,6 @@ func parseReplayHelper(rawEventLog []byte, pcrs *tpmpb.PCRs) ([]attest.Event, er
 }
 
 func convertToAttestPcrs(pcrProto *tpmpb.PCRs) ([]attest.PCR, error) {
-	if len(pcrProto.GetPcrs()) == 0 {
-		return nil, errors.New("no PCRs to convert")
-	}
 	hash := tpm2.Algorithm(pcrProto.GetHash())
 	cryptoHash, err := hash.Hash()
 	if err != nil {

--- a/server/eventlog_test.go
+++ b/server/eventlog_test.go
@@ -326,6 +326,41 @@ func TestSystemParseEventLog(t *testing.T) {
 	}
 }
 
+func TestEmptyEventlog(t *testing.T) {
+	emptyLog := []byte{}
+
+	// SHA-1 PCR data consisting of all zero digests (i.e. the reset state)
+	zeroDigest := make([]byte, crypto.SHA1.Size())
+	zeroPCRs := &pb.PCRs{Hash: pb.HashAlgo_SHA1, Pcrs: make(map[uint32][]byte)}
+	for i := uint32(0); i < 24; i++ {
+		zeroPCRs.Pcrs[i] = zeroDigest
+	}
+
+	// For our "Real" PCR data, use the simulated TPM (which has extended events)
+	rwc := test.GetTPM(t)
+	defer client.CheckedClose(t, rwc)
+	realPCRs, err := client.ReadPCRs(rwc, client.FullPcrSel(tpm2.AlgSHA1))
+	if err != nil {
+		t.Fatalf("failed to read PCRs: %v", err)
+	}
+
+	cases := []struct {
+		name string
+		pcrs *pb.PCRs
+	}{
+		{"Empty", &pb.PCRs{Hash: pb.HashAlgo_SHA1}},
+		{"AllZero", zeroPCRs},
+		{"Real", realPCRs},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if _, err := parsePCClientEventLog(emptyLog, c.pcrs); err != nil {
+				t.Errorf("parsing empty eventlog: %v", err)
+			}
+		})
+	}
+}
+
 func TestParseSecureBootState(t *testing.T) {
 	for _, bank := range UbuntuAmdSevGCE.Banks {
 		msState, err := parsePCClientEventLog(UbuntuAmdSevGCE.RawLog, bank)


### PR DESCRIPTION
This allows for attestations which do not have a TCG Event Log
to still be processed by VerifyAttestation. Any components of the
MachineState (like SecureBoot state) which depend on these events
will not be present.

This makes our processing more consistent with how we handle the CEL
log. Fixes #162

Signed-off-by: Joe Richey <joerichey@google.com>