### PR TITLE
Move AttestationAgent code to its own package

### DIFF
--- a/launcher/agent/agent.go
+++ b/launcher/agent/agent.go
@@ -1,4 +1,4 @@
-package main
+package agent
 
 import (
 	"bytes"
@@ -22,8 +22,14 @@ type tpmKeyFetcher func(rw io.ReadWriter) (*client.Key, error)
 type principalIDTokenFetcher func(audience string) ([][]byte, error)
 
 // AttestationAgent is an agent that interacts with GCE's Attestation Service
-// to Verify an attestation message.
-type AttestationAgent struct {
+// to Verify an attestation message. It is an interface instead of a concrete
+// struct to make testing easier.
+type AttestationAgent interface {
+	MeasureEvent(cel.Content) error
+	Attest(context.Context) ([]byte, error)
+}
+
+type agent struct {
 	tpm              io.ReadWriteCloser
 	akFetcher        tpmKeyFetcher
 	client           verifier.Client
@@ -37,8 +43,8 @@ type AttestationAgent struct {
 // - akFetcher is a func to fetch an attestation key: see go-tpm-tools/client.
 // - conn is a client connection to the attestation service, typically created
 //   `grpc.Dial`. It is the client's responsibility to close the connection.
-func CreateAttestationAgent(tpm io.ReadWriteCloser, akFetcher tpmKeyFetcher, verifierClient verifier.Client, principalFetcher principalIDTokenFetcher) *AttestationAgent {
-	return &AttestationAgent{
+func CreateAttestationAgent(tpm io.ReadWriteCloser, akFetcher tpmKeyFetcher, verifierClient verifier.Client, principalFetcher principalIDTokenFetcher) AttestationAgent {
+	return &agent{
 		tpm:              tpm,
 		client:           verifierClient,
 		akFetcher:        akFetcher,
@@ -48,14 +54,14 @@ func CreateAttestationAgent(tpm io.ReadWriteCloser, akFetcher tpmKeyFetcher, ver
 
 // MeasureEvent takes in a cel.Content and appends it to the CEL eventlog
 // under the attestation agent.
-func (a *AttestationAgent) MeasureEvent(event cel.Content) error {
+func (a *agent) MeasureEvent(event cel.Content) error {
 	return a.cosCel.AppendEvent(a.tpm, defaultCELPCR, defaultCELHashAlgo, event)
 }
 
 // Attest fetches the nonce and connection ID from the Attestation Service,
 // creates an attestation message, and returns the resultant
 // principalIDTokens are Metadata Server-generated ID tokens for the instance.
-func (a *AttestationAgent) Attest(ctx context.Context) ([]byte, error) {
+func (a *agent) Attest(ctx context.Context) ([]byte, error) {
 	challenge, err := a.client.CreateChallenge(ctx)
 	if err != nil {
 		return nil, err
@@ -82,7 +88,7 @@ func (a *AttestationAgent) Attest(ctx context.Context) ([]byte, error) {
 	return resp.ClaimsToken, nil
 }
 
-func (a *AttestationAgent) getAttestation(nonce []byte) (*pb.Attestation, error) {
+func (a *agent) getAttestation(nonce []byte) (*pb.Attestation, error) {
 	ak, err := a.akFetcher(a.tpm)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get AK: %v", err)

--- a/launcher/agent/agent.go
+++ b/launcher/agent/agent.go
@@ -1,3 +1,8 @@
+// Package agent coordinates the communication between the TPM and the remote
+// attestation service. It handles:
+//  - All TPM-related functionality (quotes, logs, certs, etc...)
+//  - Fetching the relevant principal ID tokens
+//  - Calling VerifyAttestation on the remote service
 package agent
 
 import (

--- a/launcher/agent/agent_test.go
+++ b/launcher/agent/agent_test.go
@@ -1,4 +1,4 @@
-package main
+package agent
 
 import (
 	"bytes"

--- a/launcher/container_runner.go
+++ b/launcher/container_runner.go
@@ -21,6 +21,7 @@ import (
 	"github.com/golang-jwt/jwt/v4"
 	"github.com/google/go-tpm-tools/cel"
 	"github.com/google/go-tpm-tools/client"
+	"github.com/google/go-tpm-tools/launcher/agent"
 	"github.com/google/go-tpm-tools/launcher/internal/verifier"
 	servpb "github.com/google/go-tpm-tools/launcher/internal/verifier/proto/attestation_verifier/v0"
 	"github.com/google/go-tpm-tools/launcher/spec"
@@ -33,17 +34,12 @@ import (
 	"google.golang.org/grpc/credentials/insecure"
 )
 
-type attestationAgent interface {
-	MeasureEvent(cel.Content) error
-	Attest(context.Context) ([]byte, error)
-}
-
 // ContainerRunner contains information about the container settings
 type ContainerRunner struct {
 	container   containerd.Container
 	launchSpec  spec.LauncherSpec
 	attestConn  *grpc.ClientConn
-	attestAgent attestationAgent
+	attestAgent agent.AttestationAgent
 	logger      *log.Logger
 }
 
@@ -208,7 +204,7 @@ func NewRunner(ctx context.Context, cdClient *containerd.Client, token oauth2.To
 		container,
 		launchSpec,
 		conn,
-		CreateAttestationAgent(tpm, client.GceAttestationKeyECC, verifierClient, principalFetcher),
+		agent.CreateAttestationAgent(tpm, client.GceAttestationKeyECC, verifierClient, principalFetcher),
 		logger,
 	}, nil
 }


### PR DESCRIPTION
This make it easier to build a subset of the code in google3. It
also changes the external API of this package to just be an
interface. This lets us avoid changing our unit tests while also
avoiding code duplication.

Signed-off-by: Joe Richey <joerichey@google.com>