### PR TITLE
Update launcher flags and launcher_spec

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -2,7 +2,7 @@ substitutions:
   '_BASE_IMAGE': 'cos-dev-101-16963-0-0'
   '_BASE_IMAGE_PROJECT': 'cos-cloud'
   '_OUTPUT_IMAGE': ''
-  '_ATTEST_ENDPOINT': ''
+  '_IMAGE_ENV': 'debug'
 
 steps:
   - name: golang:1.18
@@ -21,7 +21,7 @@ steps:
   - name: 'gcr.io/cos-cloud/cos-customizer'
     args: ['run-script',
            '-script=launcher/preload.sh',
-           '-env=ATTEST_ENDPOINT=${_ATTEST_ENDPOINT}']
+           '-env=IMAGE_ENV=${_IMAGE_ENV}']
   - name: 'gcr.io/cos-cloud/cos-customizer'
     args: ['seal-oem']
   - name: 'gcr.io/cos-cloud/cos-customizer'

--- a/launcher/container-runner.service
+++ b/launcher/container-runner.service
@@ -4,7 +4,7 @@ Wants=network-online.target gcr-online.target containerd.service
 After=network-online.target gcr-online.target containerd.service
 
 [Service]
-ExecStart=/var/lib/google/cc_container_launcher --addr=${ATTEST_ENDPOINT}
+ExecStart=/var/lib/google/cc_container_launcher
 # Shutdown the host after the launcher exits
 ExecStopPost=/bin/sleep 60
 ExecStopPost=/usr/bin/systemctl poweroff

--- a/launcher/container_runner.go
+++ b/launcher/container_runner.go
@@ -393,14 +393,6 @@ func (r *ContainerRunner) Run(ctx context.Context) error {
 }
 
 func initImage(ctx context.Context, cdClient *containerd.Client, launchSpec spec.LauncherSpec, token oauth2.Token, logger *log.Logger) (containerd.Image, error) {
-	if launchSpec.UseLocalImage {
-		image, err := cdClient.GetImage(ctx, launchSpec.ImageRef)
-		if err != nil {
-			return nil, fmt.Errorf("cannot get local image: [%w]", err)
-		}
-		return image, nil
-	}
-
 	var remoteOpt containerd.RemoteOpt
 	if token.Valid() {
 		remoteOpt = containerd.WithResolver(Resolver(token.AccessToken))

--- a/launcher/debug.conf
+++ b/launcher/debug.conf
@@ -1,0 +1,3 @@
+[Service]
+# debug image machine won't shutdown
+ExecStopPost=

--- a/launcher/entrypoint.sh
+++ b/launcher/entrypoint.sh
@@ -5,7 +5,11 @@ main() {
   cp /usr/share/oem/cc_container_launcher /var/lib/google/cc_container_launcher
   chmod +x /var/lib/google/cc_container_launcher
   
+  # copy systemd files
   cp /usr/share/oem/container-runner.service /etc/systemd/system/container-runner.service
+  mkdir -p /etc/systemd/system/container-runner.service.d/
+  cp /usr/share/oem/launcher.conf /etc/systemd/system/container-runner.service.d/launcher.conf
+
   systemctl daemon-reload
   systemctl enable container-runner.service
   systemctl start container-runner.service

--- a/launcher/hardened.conf
+++ b/launcher/hardened.conf
@@ -1,0 +1,5 @@
+[Service]
+# hardened image should exit after workflow finished
+ExecStopPost=
+ExecStopPost=/bin/sleep 60
+ExecStopPost=/usr/bin/systemctl poweroff

--- a/launcher/main.go
+++ b/launcher/main.go
@@ -17,11 +17,6 @@ import (
 	"github.com/google/go-tpm/tpm2"
 )
 
-var (
-	useLocalImage = flag.Bool("use_local_image", false, "use local image instead of pulling image from the repo, only for testing purpose")
-	serverAddr    = flag.String("addr", "", "The server address in the format of host:port")
-)
-
 const (
 	logName = "confidential-space-launcher"
 )
@@ -59,8 +54,6 @@ func run() int {
 		return 1
 	}
 
-	spec.UseLocalImage = *useLocalImage
-	spec.AttestationServiceAddr = *serverAddr
 	logger.Println("Launcher Spec: ", spec)
 
 	client, err := containerd.New(defaults.DefaultAddress)

--- a/launcher/preload.sh
+++ b/launcher/preload.sh
@@ -7,7 +7,15 @@ copy_launcher() {
 setup_launcher_systemd_unit() {
   cp launcher/container-runner.service /usr/share/oem/container-runner.service
   # set attest service endpoint
-  sed -i 's/\${ATTEST_ENDPOINT}/'${ATTEST_ENDPOINT}'/g' /usr/share/oem/container-runner.service
+
+  if [ "$IMAGE_ENV" == "hardened" ]; then
+    cp launcher/hardened.conf /usr/share/oem/launcher.conf
+  elif [ "$IMAGE_ENV" == "debug" ]; then
+    cp launcher/debug.conf /usr/share/oem/launcher.conf
+  else
+    echo "Unknown IMAGE_ENV, use hardened or debug"
+    exit 1
+  fi
 }
 
 append_cmdline() {

--- a/launcher/spec/launcher_spec.go
+++ b/launcher/spec/launcher_spec.go
@@ -29,12 +29,20 @@ const (
 )
 
 const (
+	defaultAttestationServiceEndpoint = "attestation-verifier.confidential-computing-test-org.joonix.net:9090"
+)
+
+const (
 	imageRefKey                = "tee-image-reference"
 	restartPolicyKey           = "tee-restart-policy"
 	cmdKey                     = "tee-cmd"
 	envKeyPrefix               = "tee-env-"
 	impersonateServiceAccounts = "tee-impersonate-service-accounts"
-	instanceAttributesQuery    = "instance/attributes/?recursive=true"
+	attestationServiceAddrKey  = "tee-attestation-service-endpoint"
+)
+
+const (
+	instanceAttributesQuery = "instance/attributes/?recursive=true"
 )
 
 var errImageRefNotSpecified = fmt.Errorf("%s is not specified in the custom metadata", imageRefKey)
@@ -52,7 +60,6 @@ type LauncherSpec struct {
 	RestartPolicy              RestartPolicy
 	Cmd                        []string
 	Envs                       []EnvVar
-	UseLocalImage              bool
 	AttestationServiceAddr     string
 	ImpersonateServiceAccounts []string
 }
@@ -98,6 +105,8 @@ func (s *LauncherSpec) UnmarshalJSON(b []byte) error {
 		}
 	}
 
+	s.AttestationServiceAddr = unmarshaledMap[attestationServiceAddrKey]
+
 	return nil
 }
 
@@ -114,6 +123,10 @@ func GetLauncherSpec(client *metadata.Client) (LauncherSpec, error) {
 	spec := &LauncherSpec{}
 	if err := spec.UnmarshalJSON([]byte(data)); err != nil {
 		return LauncherSpec{}, err
+	}
+
+	if spec.AttestationServiceAddr == "" {
+		spec.AttestationServiceAddr = defaultAttestationServiceEndpoint
 	}
 
 	return *spec, nil


### PR DESCRIPTION
Remove useLocalImage and serverAddr flags
Add defaultAttestationServiceEndpoint in launcher_spec, and allow
the endpoint to be configured from MDS.
Update launcher service file to support prod and debug images

Signed-off-by: Jiankun Lu <jiankun@google.com>