### PR TITLE
Add IsHardened in launch spec

### DIFF
--- a/launcher/container_runner_test.go
+++ b/launcher/container_runner_test.go
@@ -88,7 +88,7 @@ func TestRefreshToken(t *testing.T) {
 		logger: log.Default(),
 	}
 
-	if err := os.MkdirAll(HostTokenPath, 0744); err != nil {
+	if err := os.MkdirAll(hostTokenPath, 0744); err != nil {
 		t.Fatalf("Error creating host token path directory: %v", err)
 	}
 
@@ -97,7 +97,7 @@ func TestRefreshToken(t *testing.T) {
 		t.Fatalf("refreshToken returned with error: %v", err)
 	}
 
-	filepath := path.Join(HostTokenPath, attestationVerifierTokenFile)
+	filepath := path.Join(hostTokenPath, attestationVerifierTokenFile)
 	data, err := os.ReadFile(filepath)
 	if err != nil {
 		t.Fatalf("Failed to read from %s: %v", filepath, err)
@@ -114,7 +114,7 @@ func TestRefreshToken(t *testing.T) {
 }
 
 func TestRefreshTokenError(t *testing.T) {
-	if err := os.MkdirAll(HostTokenPath, 0744); err != nil {
+	if err := os.MkdirAll(hostTokenPath, 0744); err != nil {
 		t.Fatalf("Error creating host token path directory: %v", err)
 	}
 
@@ -174,7 +174,7 @@ func TestFetchAndWriteTokenSucceeds(t *testing.T) {
 		t.Fatalf("fetchAndWriteToken failed: %v", err)
 	}
 
-	filepath := path.Join(HostTokenPath, attestationVerifierTokenFile)
+	filepath := path.Join(hostTokenPath, attestationVerifierTokenFile)
 	data, err := os.ReadFile(filepath)
 	if err != nil {
 		t.Fatalf("Failed to read from %s: %v", filepath, err)
@@ -208,7 +208,7 @@ func TestTokenIsNotChangedIfRefreshFails(t *testing.T) {
 		t.Fatalf("fetchAndWriteToken failed: %v", err)
 	}
 
-	filepath := path.Join(HostTokenPath, attestationVerifierTokenFile)
+	filepath := path.Join(hostTokenPath, attestationVerifierTokenFile)
 	data, err := os.ReadFile(filepath)
 	if err != nil {
 		t.Fatalf("Failed to read from %s: %v", filepath, err)
@@ -254,7 +254,7 @@ func TestFetchAndWriteTokenWithTokenRefresh(t *testing.T) {
 		t.Fatalf("fetchAndWriteToken failed: %v", err)
 	}
 
-	filepath := path.Join(HostTokenPath, attestationVerifierTokenFile)
+	filepath := path.Join(hostTokenPath, attestationVerifierTokenFile)
 	data, err := os.ReadFile(filepath)
 	if err != nil {
 		t.Fatalf("Failed to read from %s: %v", filepath, err)

--- a/launcher/image/preload.sh
+++ b/launcher/image/preload.sh
@@ -60,7 +60,7 @@ configure_necessary_systemd_units() {
 
 configure_systemd_units_for_debug() {
   # No-op for now, as debug will default to using multi-user.target.
-  exit 0
+  :
 }
 
 configure_systemd_units_for_hardened() {
@@ -91,8 +91,10 @@ main() {
 
   if [[ "${IMAGE_ENV}" == "debug" ]]; then
     configure_systemd_units_for_debug
+    append_cmdline "'confidential-space.hardened=false'"
   elif [[ "${IMAGE_ENV}" == "hardened" ]]; then
     configure_systemd_units_for_hardened
+    append_cmdline "'confidential-space.hardened=true'"
   else
     echo "Unknown image env: ${IMAGE_ENV}." \
          "Only 'debug' and 'hardened' are supported."

--- a/launcher/main.go
+++ b/launcher/main.go
@@ -48,13 +48,12 @@ func run() int {
 		logger.SetOutput(loggerAndStdout)
 	}
 
-	spec, err := spec.GetLauncherSpec(mdsClient)
+	launchSpec, err := spec.GetLaunchSpec(mdsClient)
 	if err != nil {
 		logger.Println(err)
 		return 1
 	}
-
-	logger.Println("Launcher Spec: ", spec)
+	logger.Println("Launch Spec: ", launchSpec)
 
 	client, err := containerd.New(defaults.DefaultAddress)
 	if err != nil {
@@ -75,7 +74,7 @@ func run() int {
 		logger.Printf("failed to retrieve auth token: %v, using empty auth", err)
 	}
 
-	r, err := NewRunner(ctx, client, token, spec, mdsClient, tpm, logger)
+	r, err := NewRunner(ctx, client, token, launchSpec, mdsClient, tpm, logger)
 	if err != nil {
 		logger.Println(err)
 		return 1

--- a/launcher/spec/launch_policy.go
+++ b/launcher/spec/launch_policy.go
@@ -42,9 +42,9 @@ func GetLaunchPolicy(imageLabels map[string]string) (LaunchPolicy, error) {
 	return launchPolicy, nil
 }
 
-// Verify will use the LaunchPolicy to verify the given LauncherSpec. If the verification passed, will return nil.
+// Verify will use the LaunchPolicy to verify the given LaunchSpec. If the verification passed, will return nil.
 // If there are multiple violations, the function will return the first error.
-func (p LaunchPolicy) Verify(ls LauncherSpec) error {
+func (p LaunchPolicy) Verify(ls LaunchSpec) error {
 	for _, e := range ls.Envs {
 		if !contains(p.AllowedEnvOverride, e.Name) {
 			return fmt.Errorf("env var %s is not allowed to be overridden on this image; allowed envs to be overridden: %v", e, p.AllowedEnvOverride)

--- a/launcher/spec/launch_policy_test.go
+++ b/launcher/spec/launch_policy_test.go
@@ -72,7 +72,7 @@ func TestVerify(t *testing.T) {
 	testCases := []struct {
 		testName  string
 		policy    LaunchPolicy
-		spec      LauncherSpec
+		spec      LaunchSpec
 		expectErr bool
 	}{
 		{
@@ -81,7 +81,7 @@ func TestVerify(t *testing.T) {
 				AllowedEnvOverride: []string{"foo"},
 				AllowedCmdOverride: true,
 			},
-			LauncherSpec{
+			LaunchSpec{
 				Envs: []EnvVar{{Name: "foo", Value: "foo"}},
 				Cmd:  []string{"foo"},
 			},
@@ -90,7 +90,7 @@ func TestVerify(t *testing.T) {
 		{
 			"default case",
 			LaunchPolicy{},
-			LauncherSpec{},
+			LaunchSpec{},
 			false,
 		},
 		{
@@ -98,7 +98,7 @@ func TestVerify(t *testing.T) {
 			LaunchPolicy{
 				AllowedEnvOverride: []string{"foo"},
 			},
-			LauncherSpec{
+			LaunchSpec{
 				Envs: []EnvVar{{Name: "bar", Value: ""}},
 			},
 			true,
@@ -108,7 +108,7 @@ func TestVerify(t *testing.T) {
 			LaunchPolicy{
 				AllowedCmdOverride: false,
 			},
-			LauncherSpec{
+			LaunchSpec{
 				Cmd: []string{"foo"},
 			},
 			true,
@@ -119,7 +119,7 @@ func TestVerify(t *testing.T) {
 				AllowedEnvOverride: []string{"foo"},
 				AllowedCmdOverride: true,
 			},
-			LauncherSpec{
+			LaunchSpec{
 				Envs: []EnvVar{{Name: "foo", Value: "foo"}},
 				Cmd:  []string{"foo"},
 			},

--- a/launcher/spec/launch_policy_test.go
+++ b/launcher/spec/launch_policy_test.go
@@ -141,3 +141,41 @@ func TestVerify(t *testing.T) {
 		})
 	}
 }
+
+func TestIsHardened(t *testing.T) {
+	testCases := []struct {
+		testName       string
+		kernelCmd      string
+		expectHardened bool
+	}{
+		{
+			"empty kernel cmd",
+			"",
+			false,
+		},
+		{
+			"no confidential-space.hardened arg",
+			"BOOT_IMAGE=/syslinux/vmlinuz.B init=/usr/lib/systemd/systemd boot=local rootwait ro noresume loglevel=7 console=tty1 console=ttyS0 security=apparmor virtio_net.napi_tx=1 nmi_watchdog=0 csm.disabled=1 loadpin.exclude=kernel-module modules-load=loadpin_trigger module.sig_enforce=1 dm_verity.error_behavior=3 dm_verity.max_bios=-1 dm_verity.dev_wait=1 i915.modeset=1 cros_efi cos.protected_stateful_partition=e systemd.mask=update-engine.service ds=nocloud;s=/usr/share/oem/ cros_debug root=/dev/dm-0 \"dm=2 vroot none ro 1,0 4077568 verity payload=PARTUUID=DC7DB0DC-DDCC-AA45-BAE3-A41CA1698E83 hashtree=PARTUUID=DC7DB0DC-DDCC-AA45-BAE3-A41CA1698E83 hashstart=4077568 alg=sha256 root_hexdigest=6d5887660805db1b366319bd1c2161600d11b9e53f059b0e44b760a7277e1b0a salt=f4a41993832655a00d48f5769351370bebafd7de906df068bc1b1929b175ee43,oemroot none ro 1, 0 1024000 verity payload=PARTUUID=fd5af56a-7b25-c448-a616-19eb240b3260 hashtree=PARTUUID=fd5af56a-7b25-c448-a616-19eb240b3260 hashstart=1024000 alg=sha256 root_hexdigest=50c406c129054649a432fa144eeff56aa8b707d4c86f3ab44edde589356e8b23 salt=2a3461269a26ad6247f4b64cacd84f64e5a3311cd4b2f742bab6442291bf4977\"",
+			false,
+		},
+		{
+			"has kernel arg confidential-space.hardened=true",
+			"BOOT_IMAGE=/syslinux/vmlinuz.B init=/usr/lib/systemd/systemd boot=local rootwait ro noresume loglevel=7 console=tty1 console=ttyS0 security=apparmor virtio_net.napi_tx=1 nmi_watchdog=0 csm.disabled=1 loadpin.exclude=kernel-module modules-load=loadpin_trigger module.sig_enforce=1 dm_verity.error_behavior=3 dm_verity.max_bios=-1 dm_verity.dev_wait=1 i915.modeset=1 cros_efi confidential-space.hardened=true cos.protected_stateful_partition=e systemd.mask=update-engine.service ds=nocloud;s=/usr/share/oem/ cros_debug root=/dev/dm-0 \"dm=2 vroot none ro 1,0 4077568 verity payload=PARTUUID=DC7DB0DC-DDCC-AA45-BAE3-A41CA1698E83 hashtree=PARTUUID=DC7DB0DC-DDCC-AA45-BAE3-A41CA1698E83 hashstart=4077568 alg=sha256 root_hexdigest=6d5887660805db1b366319bd1c2161600d11b9e53f059b0e44b760a7277e1b0a salt=f4a41993832655a00d48f5769351370bebafd7de906df068bc1b1929b175ee43,oemroot none ro 1, 0 1024000 verity payload=PARTUUID=fd5af56a-7b25-c448-a616-19eb240b3260 hashtree=PARTUUID=fd5af56a-7b25-c448-a616-19eb240b3260 hashstart=1024000 alg=sha256 root_hexdigest=50c406c129054649a432fa144eeff56aa8b707d4c86f3ab44edde589356e8b23 salt=2a3461269a26ad6247f4b64cacd84f64e5a3311cd4b2f742bab6442291bf4977\"",
+			true,
+		},
+		{
+			"has kernel arg confidential-space.hardened=false",
+			"BOOT_IMAGE=/syslinux/vmlinuz.B init=/usr/lib/systemd/systemd boot=local rootwait ro noresume loglevel=7 console=tty1 console=ttyS0 security=apparmor virtio_net.napi_tx=1 nmi_watchdog=0 csm.disabled=1 loadpin.exclude=kernel-module modules-load=loadpin_trigger module.sig_enforce=1 dm_verity.error_behavior=3 dm_verity.max_bios=-1 dm_verity.dev_wait=1 i915.modeset=1 cros_efi confidential-space.hardened=false cos.protected_stateful_partition=e systemd.mask=update-engine.service ds=nocloud;s=/usr/share/oem/ cros_debug root=/dev/dm-0 \"dm=2 vroot none ro 1,0 4077568 verity payload=PARTUUID=DC7DB0DC-DDCC-AA45-BAE3-A41CA1698E83 hashtree=PARTUUID=DC7DB0DC-DDCC-AA45-BAE3-A41CA1698E83 hashstart=4077568 alg=sha256 root_hexdigest=6d5887660805db1b366319bd1c2161600d11b9e53f059b0e44b760a7277e1b0a salt=f4a41993832655a00d48f5769351370bebafd7de906df068bc1b1929b175ee43,oemroot none ro 1, 0 1024000 verity payload=PARTUUID=fd5af56a-7b25-c448-a616-19eb240b3260 hashtree=PARTUUID=fd5af56a-7b25-c448-a616-19eb240b3260 hashstart=1024000 alg=sha256 root_hexdigest=50c406c129054649a432fa144eeff56aa8b707d4c86f3ab44edde589356e8b23 salt=2a3461269a26ad6247f4b64cacd84f64e5a3311cd4b2f742bab6442291bf4977\"",
+			false,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.testName, func(t *testing.T) {
+			hardened := isHardened(testCase.kernelCmd)
+			if testCase.expectHardened != hardened {
+				t.Errorf("expected %t, but got %t", testCase.expectHardened, hardened)
+			}
+		})
+	}
+}

--- a/launcher/spec/launch_spec_test.go
+++ b/launcher/spec/launch_spec_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 )
 
-func TestLauncherSpecUnmarshalJSONHappyCases(t *testing.T) {
+func TestLaunchSpecUnmarshalJSONHappyCases(t *testing.T) {
 	var testCases = []struct {
 		testName string
 		mdsJSON  string
@@ -35,7 +35,7 @@ func TestLauncherSpecUnmarshalJSONHappyCases(t *testing.T) {
 		},
 	}
 
-	want := &LauncherSpec{
+	want := &LaunchSpec{
 		ImageRef:                   "docker.io/library/hello-world:latest",
 		RestartPolicy:              Always,
 		Cmd:                        []string{"--foo", "--bar", "--baz"},
@@ -45,18 +45,18 @@ func TestLauncherSpecUnmarshalJSONHappyCases(t *testing.T) {
 
 	for _, testcase := range testCases {
 		t.Run(testcase.testName, func(t *testing.T) {
-			spec := &LauncherSpec{}
+			spec := &LaunchSpec{}
 			if err := spec.UnmarshalJSON([]byte(testcase.mdsJSON)); err != nil {
 				t.Fatal(err)
 			}
 			if !cmp.Equal(spec, want) {
-				t.Errorf("LauncherSpec UnmarshalJSON got %+v, want %+v", spec, want)
+				t.Errorf("LaunchSpec UnmarshalJSON got %+v, want %+v", spec, want)
 			}
 		})
 	}
 }
 
-func TestLauncherSpecUnmarshalJSONBadInput(t *testing.T) {
+func TestLaunchSpecUnmarshalJSONBadInput(t *testing.T) {
 	var testCases = []struct {
 		testName string
 		mdsJSON  string
@@ -92,7 +92,7 @@ func TestLauncherSpecUnmarshalJSONBadInput(t *testing.T) {
 
 	for _, testcase := range testCases {
 		t.Run(testcase.testName, func(t *testing.T) {
-			spec := &LauncherSpec{}
+			spec := &LaunchSpec{}
 			if err := spec.UnmarshalJSON([]byte(testcase.mdsJSON)); err == nil {
 				t.Fatal("expected JSON parsing err")
 			}
@@ -100,35 +100,35 @@ func TestLauncherSpecUnmarshalJSONBadInput(t *testing.T) {
 	}
 }
 
-func TestLauncherSpecUnmarshalJSONWithDefaultValue(t *testing.T) {
+func TestLaunchSpecUnmarshalJSONWithDefaultValue(t *testing.T) {
 	mdsJSON := `{
 		"tee-image-reference":"docker.io/library/hello-world:latest",
 		"tee-impersonate-service-accounts":""
 		}`
 
-	spec := &LauncherSpec{}
+	spec := &LaunchSpec{}
 	if err := spec.UnmarshalJSON([]byte(mdsJSON)); err != nil {
 		t.Fatal(err)
 	}
 
-	want := &LauncherSpec{
+	want := &LaunchSpec{
 		ImageRef:      "docker.io/library/hello-world:latest",
 		RestartPolicy: Never,
 	}
 
 	if !cmp.Equal(spec, want) {
-		t.Errorf("LauncherSpec UnmarshalJSON got %+v, want %+v", spec, want)
+		t.Errorf("LaunchSpec UnmarshalJSON got %+v, want %+v", spec, want)
 	}
 }
 
-func TestLauncherSpecUnmarshalJSONWithoutImageReference(t *testing.T) {
+func TestLaunchSpecUnmarshalJSONWithoutImageReference(t *testing.T) {
 	mdsJSON := `{
 		"tee-cmd":"[\"--foo\",\"--bar\",\"--baz\"]",
 		"tee-env-foo":"bar",
 		"tee-restart-policy":"Never"
 		}`
 
-	spec := &LauncherSpec{}
+	spec := &LaunchSpec{}
 	if err := spec.UnmarshalJSON([]byte(mdsJSON)); err == nil || err != errImageRefNotSpecified {
 		t.Fatalf("got %v error, but expected %v error", err, errImageRefNotSpecified)
 	}

--- a/simulator/internal/internal_cgo.go
+++ b/simulator/internal/internal_cgo.go
@@ -18,6 +18,8 @@ package internal
 // #cgo !windows CFLAGS: -fstack-protector-all
 // // Silence known warnings from the reference code and CGO code.
 // #cgo CFLAGS: -Wno-missing-braces -Wno-empty-body -Wno-unused-variable -Wno-uninitialized
+// // Silence openssl deprecation warnings for ms-tpm-20-ref
+// #cgo CFLAGS: -Wno-deprecated-declarations
 // // Link against the system OpenSSL
 // #cgo CFLAGS: -DDEBUG=YES
 // #cgo CFLAGS: -DSIMULATION=NO


### PR DESCRIPTION
~~* COS eventlog now can measure to a resettable PCR (in the debug image)~~
~~* Debug PCR will reset every time before launcher run in the debug image~~
* Added a kernel cmdline arg confidential-space.hardened=true to indicate hardened image
* Change LauncherSpec to LaunchSpec
* Add cgo flag to silence deprecate warning in openssl for ms-tpm-20-ref

Signed-off-by: Jiankun Lu <jiankun@google.com>