### PR TITLE
Be much stricter when processing Attested COS State

### DIFF
--- a/cel/cos_tlv.go
+++ b/cel/cos_tlv.go
@@ -9,9 +9,11 @@ import (
 )
 
 const (
-	// CosEventType indicate the CELR event is a COS content
+	// CosEventType indicates the CELR event is a COS content
 	// TODO: the value needs to be reserved in the CEL spec
 	CosEventType uint8 = 80
+	// CosEventPCR is the PCR which should be used for CosEventType events.
+	CosEventPCR = 13
 )
 
 // CosType represent a COS content type in a CEL record content.
@@ -27,6 +29,8 @@ const (
 	EnvVarType
 	OverrideArgType
 	OverrideEnvType
+	// EventContent is empty on success, or contains an error message on failure.
+	LaunchSeparatorType
 )
 
 // CosTlv is a specific event type created for the COS (Google Container-Optimized OS),

--- a/internal/test/test_tpm.go
+++ b/internal/test/test_tpm.go
@@ -85,6 +85,14 @@ func GetTPM(tb testing.TB) io.ReadWriteCloser {
 	return noClose{tpm}
 }
 
+// SkipForRealTPM causes a test or benchmark to be skipped if we are not using
+// a test TPM. This lets us avoid clobbering important PCRs on a real machine.
+func SkipForRealTPM(tb testing.TB) {
+	if useRealTPM() {
+		tb.Skip("Running against a real TPM, Skipping Test")
+	}
+}
+
 // GetSimulatorWithLog returns a simulated TPM with PCRs that match the events
 // of the passed in eventlog. This allows for testing attestation flows.
 func GetSimulatorWithLog(tb testing.TB, eventLog []byte) io.ReadWriteCloser {

--- a/launcher/agent/agent.go
+++ b/launcher/agent/agent.go
@@ -19,8 +19,6 @@ import (
 	pb "github.com/google/go-tpm-tools/proto/attest"
 )
 
-const defaultCELPCR = 13
-
 var defaultCELHashAlgo = []crypto.Hash{crypto.SHA256, crypto.SHA1}
 
 type tpmKeyFetcher func(rw io.ReadWriter) (*client.Key, error)
@@ -61,7 +59,7 @@ func CreateAttestationAgent(tpm io.ReadWriteCloser, akFetcher tpmKeyFetcher, ver
 // MeasureEvent takes in a cel.Content and appends it to the CEL eventlog
 // under the attestation agent.
 func (a *agent) MeasureEvent(event cel.Content) error {
-	return a.cosCel.AppendEvent(a.tpm, defaultCELPCR, defaultCELHashAlgo, event)
+	return a.cosCel.AppendEvent(a.tpm, cel.CosEventPCR, defaultCELHashAlgo, event)
 }
 
 // Attest fetches the nonce and connection ID from the Attestation Service,

--- a/server/eventlog.go
+++ b/server/eventlog.go
@@ -123,7 +123,7 @@ func getVerifiedCosState(coscel cel.CEL, pcrs *tpmpb.PCRs) (*pb.AttestedCosState
 	for _, record := range coscel.Records {
 		// COS State only comes from the CosEventPCR
 		if record.PCR != cel.CosEventPCR {
-			continue
+			return nil, fmt.Errorf("found unexpected PCR %d in CEL log", record.PCR)
 		}
 
 		// The Content.Type is not verified at this point, so we have to fail

--- a/server/eventlog.go
+++ b/server/eventlog.go
@@ -119,12 +119,18 @@ func getVerifiedCosState(coscel cel.CEL, pcrs *tpmpb.PCRs) (*pb.AttestedCosState
 	cosState.Container.EnvVars = make(map[string]string)
 	cosState.Container.OverriddenEnvVars = make(map[string]string)
 
+	seenSeparator := false
 	for _, record := range coscel.Records {
-		// ignore non COS CEL events
-		if !record.Content.IsCosTlv() {
+		// COS State only comes from the CosEventPCR
+		if record.PCR != cel.CosEventPCR {
 			continue
 		}
 
+		// The Content.Type is not verified at this point, so we have to fail
+		// if we see any events that we do not understand. This ensures that
+		// we either verify the digest of event event in this PCR, or we fail
+		// to replay the event log.
+		// TODO: See if we can fix this to have the Content Type be verified.
 		cosTlv, err := record.Content.ParseToCosTlv()
 		if err != nil {
 			return nil, err
@@ -135,11 +141,22 @@ func getVerifiedCosState(coscel cel.CEL, pcrs *tpmpb.PCRs) (*pb.AttestedCosState
 			return nil, err
 		}
 
+		// TODO: Add support for post-separator container data
+		if seenSeparator {
+			return nil, fmt.Errorf("found COS Event Type %v after LaunchSeparator event", cosTlv.EventType)
+		}
+
 		switch cosTlv.EventType {
 		case cel.ImageRefType:
+			if cosState.Container.GetImageReference() != "" {
+				return nil, fmt.Errorf("found duplicate ImageRef event")
+			}
 			cosState.Container.ImageReference = string(cosTlv.EventContent)
 
 		case cel.ImageDigestType:
+			if cosState.Container.GetImageDigest() != "" {
+				return nil, fmt.Errorf("found duplicate ImageDigest event")
+			}
 			cosState.Container.ImageDigest = string(cosTlv.EventContent)
 
 		case cel.RestartPolicyType:
@@ -150,6 +167,9 @@ func getVerifiedCosState(coscel cel.CEL, pcrs *tpmpb.PCRs) (*pb.AttestedCosState
 			cosState.Container.RestartPolicy = pb.RestartPolicy(restartPolicy)
 
 		case cel.ImageIDType:
+			if cosState.Container.GetImageId() != "" {
+				return nil, fmt.Errorf("found duplicate ImageId event")
+			}
 			cosState.Container.ImageId = string(cosTlv.EventContent)
 
 		case cel.EnvVarType:
@@ -171,6 +191,10 @@ func getVerifiedCosState(coscel cel.CEL, pcrs *tpmpb.PCRs) (*pb.AttestedCosState
 				return nil, err
 			}
 			cosState.Container.OverriddenEnvVars[envName] = envVal
+		case cel.LaunchSeparatorType:
+			seenSeparator = true
+		default:
+			return nil, fmt.Errorf("found unknown COS Event Type %v", cosTlv.EventType)
 		}
 
 	}

--- a/server/eventlog.go
+++ b/server/eventlog.go
@@ -149,13 +149,13 @@ func getVerifiedCosState(coscel cel.CEL, pcrs *tpmpb.PCRs) (*pb.AttestedCosState
 		switch cosTlv.EventType {
 		case cel.ImageRefType:
 			if cosState.Container.GetImageReference() != "" {
-				return nil, fmt.Errorf("found duplicate ImageRef event")
+				return nil, fmt.Errorf("found more than one ImageRef event")
 			}
 			cosState.Container.ImageReference = string(cosTlv.EventContent)
 
 		case cel.ImageDigestType:
 			if cosState.Container.GetImageDigest() != "" {
-				return nil, fmt.Errorf("found duplicate ImageDigest event")
+				return nil, fmt.Errorf("found more than one ImageDigest event")
 			}
 			cosState.Container.ImageDigest = string(cosTlv.EventContent)
 
@@ -168,7 +168,7 @@ func getVerifiedCosState(coscel cel.CEL, pcrs *tpmpb.PCRs) (*pb.AttestedCosState
 
 		case cel.ImageIDType:
 			if cosState.Container.GetImageId() != "" {
-				return nil, fmt.Errorf("found duplicate ImageId event")
+				return nil, fmt.Errorf("found more than one ImageId event")
 			}
 			cosState.Container.ImageId = string(cosTlv.EventContent)
 

--- a/server/eventlog_test.go
+++ b/server/eventlog_test.go
@@ -527,14 +527,14 @@ func TestParsingCELEventLog(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	implmentedHash := []crypto.Hash{}
+	implementedHashes := []crypto.Hash{}
 	// get all implmented hash algo in the TPM
 	for _, h := range banks {
 		hsh, err := tpm2.Algorithm(h.Hash).Hash()
 		if err != nil {
 			t.Fatal(err)
 		}
-		implmentedHash = append(implmentedHash, crypto.Hash(hsh))
+		implementedHashes = append(implementedHashes, crypto.Hash(hsh))
 	}
 
 	for _, bank := range banks {
@@ -583,7 +583,7 @@ func TestParsingCELEventLog(t *testing.T) {
 	}
 	for _, testEvent := range testCELEvents {
 		cos := cel.CosTlv{EventType: testEvent.cosNestedEventType, EventContent: testEvent.eventPayload}
-		if err := coscel.AppendEvent(tpm, testEvent.pcr, implmentedHash, cos); err != nil {
+		if err := coscel.AppendEvent(tpm, testEvent.pcr, implementedHashes, cos); err != nil {
 			t.Fatal(err)
 		}
 	}
@@ -608,7 +608,7 @@ func TestParsingCELEventLog(t *testing.T) {
 	// Thirdly, append a random non-COS event, encode and try to parse it.
 	// Because there is no COS TLV event, attestation should fail as we do not
 	// understand the content type.
-	event, err := generateNonCosCelEvent(implmentedHash)
+	event, err := generateNonCosCelEvent(implementedHashes)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -618,7 +618,7 @@ func TestParsingCELEventLog(t *testing.T) {
 		t.Fatal(err)
 	}
 	// extend digests to the PCR
-	for _, hash := range implmentedHash {
+	for _, hash := range implementedHashes {
 		algo, err := tpm2.HashToAlgorithm(hash)
 		if err != nil {
 			t.Fatal(err)

--- a/server/eventlog_test.go
+++ b/server/eventlog_test.go
@@ -510,13 +510,9 @@ func TestParseSecureBootState(t *testing.T) {
 }
 
 func TestParsingCELEventLog(t *testing.T) {
+	test.SkipForRealTPM(t)
 	tpm := test.GetTPM(t)
 	defer client.CheckedClose(t, tpm)
-
-	err := tpm2.PCRReset(tpm, tpmutil.Handle(test.DebugPCR))
-	if err != nil {
-		t.Fatal(err)
-	}
 
 	coscel := &cel.CEL{}
 	emptyCosState := attestpb.ContainerState{}
@@ -552,59 +548,23 @@ func TestParsingCELEventLog(t *testing.T) {
 		}
 	}
 
-	// Secondly, append a random non-COS event, encode and try to parse it. Because there is no COS TLV event,
-	// we should get an empty/default CosState in the MachineState.
-	event, err := generateNonCosCelEvent(implmentedHash)
-	if err != nil {
-		t.Fatal(err)
-	}
-	coscel.Records = append(coscel.Records, event)
-	buf = bytes.Buffer{}
-	if err := coscel.EncodeCEL(&buf); err != nil {
-		t.Fatal(err)
-	}
-	// extend digests to the PCR
-	for _, hash := range implmentedHash {
-		algo, err := tpm2.HashToAlgorithm(hash)
-		if err != nil {
-			t.Fatal(err)
-		}
-		if err := tpm2.PCRExtend(tpm, tpmutil.Handle(test.DebugPCR), algo, event.Digests[hash], ""); err != nil {
-			t.Fatal(err)
-		}
-	}
-	banks, err = client.ReadAllPCRs(tpm)
-	if err != nil {
-		t.Fatal(err)
-	}
-	for _, bank := range banks {
-		msState, err := parseCanonicalEventLog(buf.Bytes(), bank)
-		if err != nil {
-			t.Errorf("expecting no error from parseCanonicalEventLog(), but get %v", err)
-		}
-		// expect nothing in the CosState
-		if diff := cmp.Diff(msState.Cos.Container, &emptyCosState, protocmp.Transform()); diff != "" {
-			t.Errorf("unexpected difference:\n%v", diff)
-		}
-	}
-
-	// Thirdly, append some real COS events to the CEL. This time we should get content in the CosState.
+	// Secondly, append some real COS events to the CEL. This time we should get content in the CosState.
 	testCELEvents := []struct {
 		cosNestedEventType cel.CosType
 		pcr                int
 		eventPayload       []byte
 	}{
-		{cel.ImageRefType, test.DebugPCR, []byte("docker.io/bazel/experimental/test:latest")},
-		{cel.ImageDigestType, test.DebugPCR, []byte("sha256:781d8dfdd92118436bd914442c8339e653b83f6bf3c1a7a98efcfb7c4fed7483")},
-		{cel.RestartPolicyType, test.DebugPCR, []byte(attestpb.RestartPolicy_Always.String())},
-		{cel.ImageIDType, test.DebugPCR, []byte("sha256:5DF4A1AC347DCF8CF5E9D0ABC04B04DB847D1B88D3B1CC1006F0ACB68E5A1F4B")},
-		{cel.EnvVarType, test.DebugPCR, []byte("foo=bar")},
-		{cel.EnvVarType, test.DebugPCR, []byte("bar=baz")},
-		{cel.EnvVarType, test.DebugPCR, []byte("baz=foo=bar")},
-		{cel.EnvVarType, test.DebugPCR, []byte("empty=")},
-		{cel.ArgType, test.DebugPCR, []byte("--x")},
-		{cel.ArgType, test.DebugPCR, []byte("--y")},
-		{cel.ArgType, test.DebugPCR, []byte("")},
+		{cel.ImageRefType, cel.CosEventPCR, []byte("docker.io/bazel/experimental/test:latest")},
+		{cel.ImageDigestType, cel.CosEventPCR, []byte("sha256:781d8dfdd92118436bd914442c8339e653b83f6bf3c1a7a98efcfb7c4fed7483")},
+		{cel.RestartPolicyType, cel.CosEventPCR, []byte(attestpb.RestartPolicy_Always.String())},
+		{cel.ImageIDType, cel.CosEventPCR, []byte("sha256:5DF4A1AC347DCF8CF5E9D0ABC04B04DB847D1B88D3B1CC1006F0ACB68E5A1F4B")},
+		{cel.EnvVarType, cel.CosEventPCR, []byte("foo=bar")},
+		{cel.EnvVarType, cel.CosEventPCR, []byte("bar=baz")},
+		{cel.EnvVarType, cel.CosEventPCR, []byte("baz=foo=bar")},
+		{cel.EnvVarType, cel.CosEventPCR, []byte("empty=")},
+		{cel.ArgType, cel.CosEventPCR, []byte("--x")},
+		{cel.ArgType, cel.CosEventPCR, []byte("--y")},
+		{cel.ArgType, cel.CosEventPCR, []byte("")},
 	}
 
 	expectedEnvVars := make(map[string]string)
@@ -644,12 +604,45 @@ func TestParsingCELEventLog(t *testing.T) {
 			}
 		}
 	}
+
+	// Thirdly, append a random non-COS event, encode and try to parse it.
+	// Because there is no COS TLV event, attestation should fail as we do not
+	// understand the content type.
+	event, err := generateNonCosCelEvent(implmentedHash)
+	if err != nil {
+		t.Fatal(err)
+	}
+	coscel.Records = append(coscel.Records, event)
+	buf = bytes.Buffer{}
+	if err := coscel.EncodeCEL(&buf); err != nil {
+		t.Fatal(err)
+	}
+	// extend digests to the PCR
+	for _, hash := range implmentedHash {
+		algo, err := tpm2.HashToAlgorithm(hash)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := tpm2.PCRExtend(tpm, tpmutil.Handle(cel.CosEventPCR), algo, event.Digests[hash], ""); err != nil {
+			t.Fatal(err)
+		}
+	}
+	banks, err = client.ReadAllPCRs(tpm)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, bank := range banks {
+		_, err := parseCanonicalEventLog(buf.Bytes(), bank)
+		if err == nil {
+			t.Errorf("expected error when parsing event log with unknown content type")
+		}
+	}
 }
 
 func generateNonCosCelEvent(hashAlgoList []crypto.Hash) (cel.Record, error) {
 	randRecord := cel.Record{}
 	randRecord.RecNum = 0
-	randRecord.PCR = uint8(test.DebugPCR)
+	randRecord.PCR = cel.CosEventPCR
 	contentValue := make([]byte, 10)
 	rand.Read(contentValue)
 	randRecord.Content = cel.TLV{Type: 250, Value: contentValue}


### PR DESCRIPTION
Currently in `getVerifiedCosState` we do two things that are bad from a security perspective:
  1. We do not require the CEL events to use PCR 13
  2. We skip events that we do not understand (`record.Content.Type != cel.CosEventType`)

(1) is an issue because after a container launchers, we assume that a breakout is possible. So a malicious user can:
  - Breakout of a container
  - Extend fake events to PCR 14
  - Create their own fake CEL eventlog matching the PCR 14 extensions
  - Verify an attestation using PCR 14 and this fake CEL eventlog
  - Get fake container state to appear in the `MachineState`.

(2) is an issue because the `record.Content.Type` hasn't (yet) been verified in the loop. This means that a malicious user can:
  - Breakout of a container
  - Modify the CEL log to change the content type
  - Our processing will then skip this valid event
  - This causes data to be omitted from the `MachineState`

This change:
  - Adds the concept of a "launch separator" event that is measured right before a container is launched
  - Only creates `AttestedCosState` from PCR 13 data
  - Fails processing if we encounter any CEL events we don't understand (COS or otherwise)
  - Will not accept any `AttestedCosState` after a separator event is seen.
  - Will not accept duplicate `ImageRefType`, `ImageDigestType`, or `ImageIDType`
    - We can't do this for other events, as having multiple events for the other types isn't an error.
    - For example: multiple `EnvVarType` events are present if multiple environment variables are overridden.

This fixes the worst of the issues described above. Note, this doesn't change the client-side launcher at all. #247 will change the launcher code to actually measure in the `LaunchSeparator` event. Until then, a container breakout can cause some of the `AttestedCosState` to be wrong, but it cannot modify `image_reference`, `image_digest`, or `image_id`.

I also had to modify our tests somewhat, including adding `test.SkipForRealTPM(t)` as we can only run some of our tests against PCR13, which cannot be reset on a Real TPM.

Signed-off-by: Joe Richey <joerichey@google.com>