### PR TITLE
Measure LaunchSeparator event

### DIFF
--- a/launcher/container_runner.go
+++ b/launcher/container_runner.go
@@ -321,7 +321,11 @@ func (r *ContainerRunner) measureContainerClaims(ctx context.Context) error {
 		}
 	}
 
-	return nil
+	separator := cel.CosTlv{
+		EventType:    cel.LaunchSeparatorType,
+		EventContent: nil, // Success
+	}
+	return r.attestAgent.MeasureEvent(separator)
 }
 
 // Retrieves an OIDC token from the attestation service, and returns how long


### PR DESCRIPTION
Depends on #246 

Actually measures in the launch separator event.

We probably want to rework when in the container creation/launch process we actually do our measurements, but that can wait for a followup CL, as it isn't security critical, just a defense-in-depth.