### PR TITLE
Add container log stdout/err redirect policy

### DIFF
--- a/launcher/container_runner.go
+++ b/launcher/container_runner.go
@@ -418,7 +418,16 @@ func (r *ContainerRunner) Run(ctx context.Context) error {
 	}
 
 	for {
-		task, err := r.container.NewTask(ctx, cio.NewCreator(cio.WithStreams(nil, r.logger.Writer(), r.logger.Writer())))
+		var streamOpt cio.Opt
+		if r.launchSpec.LogRedirect {
+			streamOpt = cio.WithStreams(nil, r.logger.Writer(), r.logger.Writer())
+			r.logger.Println("container stdout/stderr will be redirected")
+		} else {
+			streamOpt = cio.WithStreams(nil, nil, nil)
+			r.logger.Println("container stdout/stderr will not be redirected")
+		}
+
+		task, err := r.container.NewTask(ctx, cio.NewCreator(streamOpt))
 		if err != nil {
 			return err
 		}

--- a/launcher/spec/launch_policy_test.go
+++ b/launcher/spec/launch_policy_test.go
@@ -76,14 +76,16 @@ func TestVerify(t *testing.T) {
 		expectErr bool
 	}{
 		{
-			"allow everything",
+			"allows everything",
 			LaunchPolicy{
 				AllowedEnvOverride: []string{"foo"},
 				AllowedCmdOverride: true,
+				AllowedLogRedirect: always,
 			},
 			LaunchSpec{
-				Envs: []EnvVar{{Name: "foo", Value: "foo"}},
-				Cmd:  []string{"foo"},
+				Envs:        []EnvVar{{Name: "foo", Value: "foo"}},
+				Cmd:         []string{"foo"},
+				LogRedirect: true,
 			},
 			false,
 		},
@@ -114,14 +116,134 @@ func TestVerify(t *testing.T) {
 			true,
 		},
 		{
-			"allow everything",
+			"log redirect (never) test 1",
 			LaunchPolicy{
-				AllowedEnvOverride: []string{"foo"},
-				AllowedCmdOverride: true,
+				AllowedLogRedirect: never,
 			},
 			LaunchSpec{
-				Envs: []EnvVar{{Name: "foo", Value: "foo"}},
-				Cmd:  []string{"foo"},
+				LogRedirect: true,
+				Hardened:    true,
+			},
+			true,
+		},
+		{
+			"log redirect (never) test 2",
+			LaunchPolicy{
+				AllowedLogRedirect: never,
+			},
+			LaunchSpec{
+				LogRedirect: true,
+				Hardened:    false,
+			},
+			true,
+		},
+		{
+			"log redirect (never) test 3",
+			LaunchPolicy{
+				AllowedLogRedirect: never,
+			},
+			LaunchSpec{
+				LogRedirect: false,
+				Hardened:    true,
+			},
+			false,
+		},
+		{
+			"log redirect (never) test 4",
+			LaunchPolicy{
+				AllowedLogRedirect: never,
+			},
+			LaunchSpec{
+				LogRedirect: false,
+				Hardened:    false,
+			},
+			false,
+		},
+		{
+			"log redirect (debugOnly) test 1",
+			LaunchPolicy{
+				AllowedLogRedirect: debugOnly,
+			},
+			LaunchSpec{
+				LogRedirect: true,
+				Hardened:    true,
+			},
+			true,
+		},
+		{
+			"log redirect (debugOnly) test 2",
+			LaunchPolicy{
+				AllowedLogRedirect: debugOnly,
+			},
+			LaunchSpec{
+				LogRedirect: true,
+				Hardened:    false,
+			},
+			false,
+		},
+		{
+			"log redirect (debugOnly) test 3",
+			LaunchPolicy{
+				AllowedLogRedirect: debugOnly,
+			},
+			LaunchSpec{
+				LogRedirect: false,
+				Hardened:    true,
+			},
+			false,
+		},
+		{
+			"log redirect (debugOnly) test 4",
+			LaunchPolicy{
+				AllowedLogRedirect: debugOnly,
+			},
+			LaunchSpec{
+				LogRedirect: false,
+				Hardened:    false,
+			},
+			false,
+		},
+		{
+			"log redirect (always) test 1",
+			LaunchPolicy{
+				AllowedLogRedirect: always,
+			},
+			LaunchSpec{
+				LogRedirect: true,
+				Hardened:    true,
+			},
+			false,
+		},
+		{
+			"log redirect (always) test 2",
+			LaunchPolicy{
+				AllowedLogRedirect: always,
+			},
+			LaunchSpec{
+				LogRedirect: true,
+				Hardened:    false,
+			},
+			false,
+		},
+		{
+			"log redirect (always) test 3",
+			LaunchPolicy{
+				AllowedLogRedirect: always,
+			},
+			LaunchSpec{
+				LogRedirect: false,
+				Hardened:    true,
+			},
+			false,
+		},
+		{
+			"log redirect (always) test 4",
+			LaunchPolicy{
+				AllowedLogRedirect: always,
+			},
+			LaunchSpec{
+				LogRedirect: false,
+				Hardened:    false,
 			},
 			false,
 		},

--- a/launcher/spec/launch_spec_test.go
+++ b/launcher/spec/launch_spec_test.go
@@ -18,7 +18,8 @@ func TestLaunchSpecUnmarshalJSONHappyCases(t *testing.T) {
 				"tee-env-foo":"bar",
 				"tee-image-reference":"docker.io/library/hello-world:latest",
 				"tee-restart-policy":"Always",
-				"tee-impersonate-service-accounts":"sv1@developer.gserviceaccount.com,sv2@developer.gserviceaccount.com"
+				"tee-impersonate-service-accounts":"sv1@developer.gserviceaccount.com,sv2@developer.gserviceaccount.com",
+				"tee-container-log-redirect":"true"
 			}`,
 		},
 		{
@@ -30,7 +31,8 @@ func TestLaunchSpecUnmarshalJSONHappyCases(t *testing.T) {
 				"unknown":"unknown",
 				"tee-image-reference":"docker.io/library/hello-world:latest",
 				"tee-restart-policy":"Always",
-				"tee-impersonate-service-accounts":"sv1@developer.gserviceaccount.com,sv2@developer.gserviceaccount.com"
+				"tee-impersonate-service-accounts":"sv1@developer.gserviceaccount.com,sv2@developer.gserviceaccount.com",
+				"tee-container-log-redirect":"true"
 			}`,
 		},
 	}
@@ -41,6 +43,7 @@ func TestLaunchSpecUnmarshalJSONHappyCases(t *testing.T) {
 		Cmd:                        []string{"--foo", "--bar", "--baz"},
 		Envs:                       []EnvVar{{"foo", "bar"}},
 		ImpersonateServiceAccounts: []string{"sv1@developer.gserviceaccount.com", "sv2@developer.gserviceaccount.com"},
+		LogRedirect:                true,
 	}
 
 	for _, testcase := range testCases {


### PR DESCRIPTION
Operator can pass an MDS variable to turn on/off log redirect
`tee-container-log-redirect`:`true`/`false`


Image author can set a policy to allow/disallow log redirect based on the enviornment (hardened/debug).
`tee.launch_policy.log_redirect`:`debugonly`/`always`/`never`



Signed-off-by: Jiankun Lu <jiankun@google.com>