### PR TITLE
Fix: Don't add empty PCR selections to list of implemented PCRs

### DIFF
--- a/client/pcr.go
+++ b/client/pcr.go
@@ -33,7 +33,7 @@ func min(a, b int) int {
 	return b
 }
 
-// Get a list of selections corresponding to the TPM's implemented PCRs
+// implementedPCRs returns a list of selections corresponding to the TPM's implemented PCRs.
 func implementedPCRs(rw io.ReadWriter) ([]tpm2.PCRSelection, error) {
 	caps, moreData, err := tpm2.GetCapability(rw, tpm2.CapabilityPCRs, math.MaxUint32, 0)
 	if err != nil {
@@ -42,13 +42,17 @@ func implementedPCRs(rw io.ReadWriter) ([]tpm2.PCRSelection, error) {
 	if moreData {
 		return nil, fmt.Errorf("extra data from GetCapability")
 	}
-	sels := make([]tpm2.PCRSelection, len(caps))
-	for i, cap := range caps {
+	var sels []tpm2.PCRSelection
+	for _, cap := range caps {
 		sel, ok := cap.(tpm2.PCRSelection)
 		if !ok {
 			return nil, fmt.Errorf("unexpected data from GetCapability")
 		}
-		sels[i] = sel
+		// skip empty PCR selections
+		if len(sel.PCRs) == 0 {
+			continue
+		}
+		sels = append(sels, sel)
 	}
 	return sels, nil
 }


### PR DESCRIPTION
### Proposed change

Only consider a PCRSelection "implemented" if the list of supported PCRs for a given hash algorithm is not an empty list.

Fixes https://github.com/google/go-tpm-tools/issues/257