### PR TITLE
launcher: Retry OIDC token refresh with backoff

### DIFF
--- a/go.work.sum
+++ b/go.work.sum
@@ -1,2 +1,4 @@
+github.com/cenkalti/backoff/v4 v4.1.3 h1:cFAlzYUlVYDysBEH2T5hyJZMh3+5+WCBvSnK6Q8UtC4=
+github.com/cenkalti/backoff/v4 v4.1.3/go.mod h1:scbssz8iZGpm3xbr14ovlUdkxfGXNInqkPWOWmG2CLw=
 github.com/googleapis/gax-go v2.0.2+incompatible h1:silFMLAnr330+NRuag/VjIGF7TLp/LBrV2CJKFLWEww=
 golang.org/x/net v0.0.0-20211112202133-69e39bad7dc2/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=

--- a/launcher/container_runner.go
+++ b/launcher/container_runner.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"cloud.google.com/go/compute/metadata"
+	"github.com/cenkalti/backoff/v4"
 	"github.com/containerd/containerd"
 	"github.com/containerd/containerd/cio"
 	"github.com/containerd/containerd/content"
@@ -60,7 +61,35 @@ const (
 	snapshotID  = "tee-snapshot"
 )
 
-const defaultRefreshMultiplier = 0.9
+/*
+	Values for token refresh and retries.
+
+With a 60m token expiration, the refresher goroutine will refresh beginning at .9*60=54m.
+
+Given the following default arguments, the retry sequence will be,
+assuming we go over the MaxElapsedTime:
+
+	 RetryInterval = 30s
+	 RandomizationFactor = 0.5
+	 Multiplier = 1.5
+	 MaxInterval = 180s
+	 MaxElapsedTime = 600s
+
+	 Request #  RetryInterval (seconds)  Randomized Interval (seconds)
+										 RetryInterval*[1-RandFactor, 1+RandFactor]
+	  1          30                      [15,   45]
+	  2          60                      [30,   90]
+	  3          120                     [60,   180]
+	  4          180 (MaxInterval) 	     [90,   270]
+	  5          180 (MaxInterval) 	     [90,   270]
+	  reached MaxElapsedTime             backoff.Stop
+*/
+const (
+	defaultRefreshMultiplier = 0.9
+	defaultInitialInterval   = 30 * time.Second
+	defaultMaxInterval       = 3 * time.Minute
+	defaultMaxElapsedTime    = 10 * time.Minute
+)
 
 func fetchImpersonatedToken(ctx context.Context, serviceAccount string, audience string, opts ...option.ClientOption) ([]byte, error) {
 	config := impersonate.IDTokenConfig{
@@ -332,6 +361,7 @@ func (r *ContainerRunner) measureContainerClaims(ctx context.Context) error {
 // Retrieves an OIDC token from the attestation service, and returns how long
 // to wait before attemping to refresh it.
 func (r *ContainerRunner) refreshToken(ctx context.Context) (time.Duration, error) {
+	r.logger.Print("refreshing attestation verifier OIDC token")
 	token, err := r.attestAgent.Attest(ctx)
 	if err != nil {
 		return 0, fmt.Errorf("failed to retrieve attestation service token: %v", err)
@@ -371,6 +401,13 @@ func (r *ContainerRunner) refreshToken(ctx context.Context) (time.Duration, erro
 
 // ctx must be a cancellable context.
 func (r *ContainerRunner) fetchAndWriteToken(ctx context.Context) error {
+	return r.fetchAndWriteTokenWithRetry(ctx, defaultRetryPolicy())
+}
+
+// ctx must be a cancellable context.
+// retry specifies the refresher goroutine's retry policy.
+func (r *ContainerRunner) fetchAndWriteTokenWithRetry(ctx context.Context,
+	retry *backoff.ExponentialBackOff) error {
 	if err := os.MkdirAll(hostTokenPath, 0744); err != nil {
 		return err
 	}
@@ -389,10 +426,19 @@ func (r *ContainerRunner) fetchAndWriteToken(ctx context.Context) error {
 				r.logger.Printf("token refreshing stopped: %v", ctx.Err())
 				return
 			case <-timer.C:
-				// Refresh token.
-				duration, err := r.refreshToken(ctx)
+				var duration time.Duration
+				// Refresh token with default retry policy.
+				err := backoff.RetryNotify(
+					func() error {
+						duration, err = r.refreshToken(ctx)
+						return err
+					},
+					retry,
+					func(err error, t time.Duration) {
+						r.logger.Printf("failed to refresh attestation service token at time %v: %v", t, err)
+					})
 				if err != nil {
-					r.logger.Printf("failed to refresh attestation service token: %v", err)
+					r.logger.Printf("failed all attempts to refresh attestation service token, stopping refresher: %v", err)
 					return
 				}
 
@@ -402,6 +448,18 @@ func (r *ContainerRunner) fetchAndWriteToken(ctx context.Context) error {
 	}()
 
 	return nil
+}
+
+// defaultRetryPolicy retries with:
+// initial interval of 30s, multiplication factor of 1.5
+// randomization factor of 0.5, max interval of 3m, and
+// max elapsed time of 10m.
+func defaultRetryPolicy() *backoff.ExponentialBackOff {
+	expBack := backoff.NewExponentialBackOff()
+	expBack.InitialInterval = defaultInitialInterval
+	expBack.MaxInterval = defaultMaxInterval
+	expBack.MaxElapsedTime = defaultMaxElapsedTime
+	return expBack
 }
 
 // Run the container

--- a/launcher/go.mod
+++ b/launcher/go.mod
@@ -5,6 +5,7 @@ go 1.18
 require (
 	cloud.google.com/go/compute v1.7.0
 	cloud.google.com/go/logging v1.4.2
+	github.com/cenkalti/backoff/v4 v4.1.3
 	github.com/containerd/containerd v1.6.6
 	github.com/golang-jwt/jwt/v4 v4.4.1
 	github.com/google/go-cmp v0.5.8
@@ -23,6 +24,7 @@ require (
 	cloud.google.com/go v0.102.0 // indirect
 	github.com/Microsoft/go-winio v0.5.2 // indirect
 	github.com/Microsoft/hcsshim v0.9.3 // indirect
+	github.com/cenkalti/backoff v2.2.1+incompatible // indirect
 	github.com/containerd/cgroups v1.0.3 // indirect
 	github.com/containerd/continuity v0.3.0 // indirect
 	github.com/containerd/fifo v1.0.0 // indirect

--- a/launcher/go.sum
+++ b/launcher/go.sum
@@ -209,8 +209,11 @@ github.com/caarlos0/ctrlc v1.0.0/go.mod h1:CdXpj4rmq0q/1Eb44M9zi2nKB0QraNKuRGYGr
 github.com/campoy/unique v0.0.0-20180121183637-88950e537e7e/go.mod h1:9IOqJGCPMSc6E5ydlp5NIonxObaeu/Iub/X03EKPVYo=
 github.com/casbin/casbin/v2 v2.1.2/go.mod h1:YcPU1XXisHhLzuxH9coDNf2FbKpjGlbCg3n9yuLkIJQ=
 github.com/cavaliercoder/go-cpio v0.0.0-20180626203310-925f9528c45e/go.mod h1:oDpT4efm8tSYHXV5tHSdRvBet/b/QzxZ+XyyPehvm3A=
+github.com/cenkalti/backoff v2.2.1+incompatible h1:tNowT99t7UNflLxfYYSlKYsBpXdEet03Pg2g16Swow4=
 github.com/cenkalti/backoff v2.2.1+incompatible/go.mod h1:90ReRw6GdpyfrHakVjL/QHaoyV4aDUVVkXQJJJ3NXXM=
 github.com/cenkalti/backoff/v4 v4.1.1/go.mod h1:scbssz8iZGpm3xbr14ovlUdkxfGXNInqkPWOWmG2CLw=
+github.com/cenkalti/backoff/v4 v4.1.3 h1:cFAlzYUlVYDysBEH2T5hyJZMh3+5+WCBvSnK6Q8UtC4=
+github.com/cenkalti/backoff/v4 v4.1.3/go.mod h1:scbssz8iZGpm3xbr14ovlUdkxfGXNInqkPWOWmG2CLw=
 github.com/census-instrumentation/opencensus-proto v0.2.0/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/census-instrumentation/opencensus-proto v0.3.0/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=


### PR DESCRIPTION
Currently, the token refresher stops after one attempt at refreshing the attestation verifier OIDC token.

Here, we use exponential backoff to retry refreshing the attestation verifier.
After the retries, the refresher goroutine stops.