### PR TITLE
launcher: Print kernel cmdline on builds 

### DIFF
--- a/launcher/image/fixup_oem.sh
+++ b/launcher/image/fixup_oem.sh
@@ -14,7 +14,16 @@ main() {
     sed -i -e 's|,oemroot|;oemroot|g' /mnt/disks/efi/efi/boot/grub.cfg
   fi
 
-  cat /mnt/disks/efi/efi/boot/grub.cfg
+  # Print grub.cfg's kernel command line.
+  grep -i '^\s*linux' /mnt/disks/efi/efi/boot/grub.cfg | \
+    sed -e 's|.*|[BEGIN_CS_GRUB_CMDLINE]&[END_CS_GRUB_CMDLINE]|g'
+
+  # Convert grub.cfg's kernel command line into what GRUB passes to the kernel.
+  grep -i '^\s*linux' /mnt/disks/efi/efi/boot/grub.cfg | \
+    sed -e "s|'ds=nocloud;s=/usr/share/oem/'|ds=nocloud;s=/usr/share/oem/|g" | \
+    sed -e 's|\\"|"|g' | \
+    sed -e 's|dm-mod.create="|"dm-mod.create=|g' | \
+    sed -e 's|.*|[BEGIN_CS_CMDLINE]&[END_CS_CMDLINE]|g'
 
   umount /mnt/disks/efi
 }

--- a/launcher/image/preload.sh
+++ b/launcher/image/preload.sh
@@ -108,10 +108,10 @@ main() {
 
   if [[ "${IMAGE_ENV}" == "debug" ]]; then
     configure_systemd_units_for_debug
-    append_cmdline "'confidential-space.hardened=false'"
+    append_cmdline "confidential-space.hardened=false"
   elif [[ "${IMAGE_ENV}" == "hardened" ]]; then
     configure_systemd_units_for_hardened
-    append_cmdline "'confidential-space.hardened=true'"
+    append_cmdline "confidential-space.hardened=true"
   else
     echo "Unknown image env: ${IMAGE_ENV}." \
          "Only 'debug' and 'hardened' are supported."


### PR DESCRIPTION
Previously, we would need to pull logs from the server to see how exactly the cmdline gets passed through. This is because the cmdline passed by GRUB, and as a result, measured in the TCG event log, has surrounding quotes stripped out.  So, we mutate the existing command line to what GRUB passes to the kernel.