### PR TITLE
Increase default systemd wait timeout to 900s

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,5 +1,5 @@
 substitutions:
-  '_BASE_IMAGE': ''
+  '_BASE_IMAGE': 'cos-dev-105-17234-0-0'
   '_OUTPUT_IMAGE_PREFIX': 'confidential-space'
   '_OUTPUT_IMAGE_SUFFIX': ''
 

--- a/launcher/image/preload.sh
+++ b/launcher/image/preload.sh
@@ -84,6 +84,8 @@ main() {
   copy_launcher
   setup_launcher_systemd_unit
   append_cmdline "cos.protected_stateful_partition=e"
+  # Increase wait timeout of the protected stateful partition.
+  append_cmdline "systemd.default_timeout_start_sec=900s"
 
   if [[ "${IMAGE_ENV}" == "debug" ]]; then
     configure_systemd_units_for_debug


### PR DESCRIPTION
The systemd default timeout is 90s. This is often insufficient for standing up the protected stateful partition, which relies on writing dm-integrity tags for integrity protection. This can fail due to PD throttling on smaller disks and a machine that reboots multiple times. Additionally, this makes the debug image more usable on non-Confidential VM machines (which often have fewer/timeshared vCPUs).

We benchmarked an upper bound for the timeout on GCE, around 900s.

This also pins the COS version to an older version of cos-dev, as the current version is broken.


# Testing
tested on GCE with a workload that continues to restart. left it running for several hours without observing an issue (booted >90 times).