### PR TITLE
[launcher] Fix image pulling in launcher

### DIFF
--- a/launcher/auth.go
+++ b/launcher/auth.go
@@ -2,6 +2,7 @@ package launcher
 
 import (
 	"encoding/json"
+	"strings"
 
 	"cloud.google.com/go/compute/metadata"
 	"github.com/containerd/containerd/remotes"
@@ -31,7 +32,11 @@ func Resolver(token string) remotes.Resolver {
 	options := docker.ResolverOptions{}
 
 	credentials := func(host string) (string, string, error) {
-		return "_token", token, nil
+		// append the token if is talking to Artifact Registry or GCR Registry
+		if strings.HasSuffix(host, "docker.pkg.dev") || strings.HasSuffix(host, "gcr.io") {
+			return "_token", token, nil
+		}
+		return "", "", nil
 	}
 	authOpts := []docker.AuthorizerOpt{docker.WithAuthCreds(credentials)}
 	options.Authorizer = docker.NewDockerAuthorizer(authOpts...)

--- a/launcher/container_runner_test.go
+++ b/launcher/container_runner_test.go
@@ -18,8 +18,13 @@ import (
 	"time"
 
 	"github.com/cenkalti/backoff/v4"
+	"github.com/containerd/containerd"
+	"github.com/containerd/containerd/defaults"
+	"github.com/containerd/containerd/namespaces"
 	"github.com/golang-jwt/jwt/v4"
 	"github.com/google/go-tpm-tools/cel"
+	"github.com/google/go-tpm-tools/launcher/spec"
+	"golang.org/x/oauth2"
 	"google.golang.org/api/option"
 )
 
@@ -461,6 +466,34 @@ func TestGetNextRefresh(t *testing.T) {
 				t.Errorf("getNextRefreshFromExpiration(%v, %v) = %v next refresh. expected %v (next refresh) < %v (expiration)",
 					expDuration, randNum, next, next, expDuration)
 			}
+		}
+	}
+}
+
+func TestInitImageDockerPublic(t *testing.T) {
+	// testing image fetching using a dummy token and a docker repo url
+	containerdClient, err := containerd.New(defaults.DefaultAddress)
+	if err != nil {
+		t.Skipf("test needs containerd daemon: %v", err)
+	}
+
+	ctx := namespaces.WithNamespace(context.Background(), "test")
+	// This is a "valid" token (formatwise)
+	validToken := oauth2.Token{AccessToken: "000000", Expiry: time.Now().Add(time.Hour)}
+	if _, err := initImage(ctx, containerdClient, spec.LaunchSpec{ImageRef: "docker.io/library/hello-world:latest"}, validToken, log.Default()); err != nil {
+		t.Error(err)
+	} else {
+		if err := containerdClient.ImageService().Delete(ctx, "docker.io/library/hello-world:latest"); err != nil {
+			t.Error(err)
+		}
+	}
+
+	invalidToken := oauth2.Token{}
+	if _, err := initImage(ctx, containerdClient, spec.LaunchSpec{ImageRef: "docker.io/library/hello-world:latest"}, invalidToken, log.Default()); err != nil {
+		t.Error(err)
+	} else {
+		if err := containerdClient.ImageService().Delete(ctx, "docker.io/library/hello-world:latest"); err != nil {
+			t.Error(err)
 		}
 	}
 }

--- a/launcher/launcher/main.go
+++ b/launcher/launcher/main.go
@@ -168,7 +168,7 @@ func startLauncher() error {
 
 	token, err := launcher.RetrieveAuthToken(mdsClient)
 	if err != nil {
-		logger.Printf("failed to retrieve auth token: %v, using empty auth", err)
+		logger.Printf("failed to retrieve auth token: %v, using empty auth for image pulling\n", err)
 	}
 
 	ctx := namespaces.WithNamespace(context.Background(), namespaces.Default)


### PR DESCRIPTION
Now can pull images with an access token from GCP gcr.io or artifact registries.
Also can pull images without a token from the public docker.io registry.

Signed-off-by: Jiankun Lu <jiankun@google.com>