### PR TITLE
Upgrade to go-sev-guest v0.5.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ go 1.19
 require (
 	github.com/google/go-attestation v0.4.4-0.20220404204839-8820d49b18d9
 	github.com/google/go-cmp v0.5.8
-	github.com/google/go-sev-guest v0.4.5
+	github.com/google/go-sev-guest v0.5.0
 	github.com/google/go-tpm v0.3.3
 	github.com/google/logger v1.1.1
 	google.golang.org/protobuf v1.28.0

--- a/go.sum
+++ b/go.sum
@@ -322,8 +322,8 @@ github.com/google/go-licenses v0.0.0-20210329231322-ce1d9163b77d/go.mod h1:+TYOm
 github.com/google/go-querystring v1.0.0/go.mod h1:odCYkC5MyYFN7vkCjXpyrEuKhc/BUO6wN/zVPAxq5ck=
 github.com/google/go-replayers/grpcreplay v0.1.0/go.mod h1:8Ig2Idjpr6gifRd6pNVggX6TC1Zw6Jx74AKp7QNH2QE=
 github.com/google/go-replayers/httpreplay v0.1.0/go.mod h1:YKZViNhiGgqdBlUbI2MwGpq4pXxNmhJLPHQ7cv2b5no=
-github.com/google/go-sev-guest v0.4.5 h1:3KrKU9JCuz5QDU+wF8nMwRizk1mlpLaXBc/UnXPdtak=
-github.com/google/go-sev-guest v0.4.5/go.mod h1:UEi9uwoPbLdKGl1QHaq1G8pfCbQ4QP0swWX4J0k6r+Q=
+github.com/google/go-sev-guest v0.5.0 h1:nCd3QVZLIhrSb5/tqQhcj1GuXCVR+wzlG1oNAYGzS5I=
+github.com/google/go-sev-guest v0.5.0/go.mod h1:UEi9uwoPbLdKGl1QHaq1G8pfCbQ4QP0swWX4J0k6r+Q=
 github.com/google/go-tpm v0.1.2-0.20190725015402-ae6dd98980d4/go.mod h1:H9HbmUG2YgV/PHITkO7p6wxEEj/v5nlsVWIwumwH2NI=
 github.com/google/go-tpm v0.3.0/go.mod h1:iVLWvrPp/bHeEkxTFi9WG6K9w0iy2yIszHwZGHPbzAw=
 github.com/google/go-tpm v0.3.2/go.mod h1:j71sMBTfp3X5jPHz852ZOfQMUOf65Gb/Th8pRmp7fvg=

--- a/server/verify.go
+++ b/server/verify.go
@@ -333,8 +333,7 @@ func VerifyGceTechnology(attestation *pb.Attestation, tech pb.GCEConfidentialTec
 		case *pb.Attestation_SevSnpAttestation:
 			var snpOpts *VerifySnpOpts
 			if opts.TEEOpts == nil {
-				snpOpts = &VerifySnpOpts{}
-				copy(snpOpts.ReportData[:], opts.Nonce)
+				snpOpts = SevSnpDefaultOptions(opts.Nonce)
 			} else {
 				switch teeopts := opts.TEEOpts.(type) {
 				case *VerifySnpOpts:

--- a/server/verify_sev.go
+++ b/server/verify_sev.go
@@ -5,22 +5,44 @@ import (
 	spb "github.com/google/go-sev-guest/proto/sevsnp"
 	"github.com/google/go-sev-guest/validate"
 	sv "github.com/google/go-sev-guest/verify"
-	"github.com/google/go-sev-guest/verify/trust"
 )
+
+// The policy on GCE is to allow SMT, and eventually MigrateMA, but no debug bit.
+var defaultSevSnpGuestPolicy = sabi.SnpPolicy{
+	SMT:       true,
+	MigrateMA: true,
+}
 
 // VerifySnpOpts allows for customizing the functionality of VerifyAttestation's SEV-SNP verification.
 type VerifySnpOpts struct {
-	// ReportData is the expected REPORT_DATA field of the attestation report.
-	ReportData [sabi.ReportDataSize]byte
-	// TrustedRoots defines which AMD root (ARK) and intermediate (ASK) keys to trust
-	// to verify a versioned chip endorsement key (VCEK) that signs attestation reports.
-	// If nil, falls back on go-sev-guest's embedded root certs. Maps a product name
-	// to an array of allowed roots.
-	TrustedRoots map[string][]*trust.AMDRootCerts
-	// Allow the debug bit to be set (should only be used for testing).
-	AllowDebugTestOnly bool
-	// Getter is the object that will fetch files from URLs.
-	Getter trust.HTTPSGetter
+	Validation   *validate.Options
+	Verification *sv.Options
+}
+
+// SevSnpDefaultValidateOpts returns a default validation policy for SEV-SNP attestation reports on GCE.
+func SevSnpDefaultValidateOpts(tpmNonce []byte) *validate.Options {
+	policy := &validate.Options{GuestPolicy: defaultSevSnpGuestPolicy}
+	policy.ReportData = make([]byte, sabi.ReportDataSize)
+	copy(policy.ReportData, tpmNonce)
+	return policy
+}
+
+// SevSnpDefaultValidateOptsForTest is a non-production policy only meant for testing. It is more
+// permissive in the kinds of reports it validates, including whether the host is allowed to
+// forcibly decrypt data (for debugging purposes).
+func SevSnpDefaultValidateOptsForTest(tpmNonce []byte) *validate.Options {
+	policy := SevSnpDefaultValidateOpts(tpmNonce)
+	policy.GuestPolicy.Debug = true
+	return policy
+}
+
+// SevSnpDefaultOptions returns a default validation policy and verification options for SEV-SNP
+// attestation reports on GCE.
+func SevSnpDefaultOptions(tpmNonce []byte) *VerifySnpOpts {
+	return &VerifySnpOpts{
+		Validation:   SevSnpDefaultValidateOpts(tpmNonce),
+		Verification: &sv.Options{},
+	}
 }
 
 // VerifySevSnpAttestation checks that the SEV-SNP attestation report matches expectations for the
@@ -28,15 +50,9 @@ type VerifySnpOpts struct {
 func VerifySevSnpAttestation(attestation *spb.Attestation, opts *VerifySnpOpts) error {
 	// Check that the report is signed by a valid AMD key. Do not check revocations. This must be
 	// done before validation to ensure the certificates are filled in by the verify library.
-	if err := sv.SnpAttestation(attestation, &sv.Options{
-		TrustedRoots: opts.TrustedRoots,
-		Getter:       opts.Getter,
-	}); err != nil {
+	if err := sv.SnpAttestation(attestation, opts.Verification); err != nil {
 		return err
 	}
 	// Check that the fields of the report are acceptable.
-	return validate.SnpAttestation(attestation, &validate.Options{
-		ReportData:  opts.ReportData[:],
-		GuestPolicy: sabi.SnpPolicy{Debug: opts.AllowDebugTestOnly},
-	})
+	return validate.SnpAttestation(attestation, opts.Validation)
 }


### PR DESCRIPTION
The trust API has changed a little to allow the fake KDS implementation to work appropriately. The "bad root" tests that swap around certs were broken since the default root didn't have any x509 certs to swap. That has been fixed in v0.5.0.
