### PR TITLE
test: Override test workload env vars and cmd

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -4,6 +4,7 @@ substitutions:
   '_BASE_IMAGE': 'cos-dev-105-17234-0-0'
   '_OUTPUT_IMAGE_PREFIX': 'confidential-space'
   '_OUTPUT_IMAGE_SUFFIX': ''
+  '_BUCKET_NAME': '${PROJECT_ID}_cloudbuild'
 
 steps:
 # determine the base image
@@ -30,6 +31,7 @@ steps:
   env:
   - 'OUTPUT_IMAGE_PREFIX=$_OUTPUT_IMAGE_PREFIX'
   - 'OUTPUT_IMAGE_SUFFIX=$_OUTPUT_IMAGE_SUFFIX'
+  - 'BUCKET_NAME=$_BUCKET_NAME'
   script: |
     #!/usr/bin/env bash
     set -exuo pipefail
@@ -37,7 +39,7 @@ steps:
     base_image=$(cat /workspace/base_image.txt)
     echo "building the debug image: ${OUTPUT_IMAGE_PREFIX}-debug-${OUTPUT_IMAGE_SUFFIX} with the base image: ${base_image}"
     gcloud builds submit --config=launcher/image/cloudbuild.yaml \
-      --substitutions _BASE_IMAGE=${base_image},_OUTPUT_IMAGE_NAME=${OUTPUT_IMAGE_PREFIX}-debug-${OUTPUT_IMAGE_SUFFIX},_IMAGE_ENV=debug,_CS_LICENSE=projects/confidential-space-images/global/licenses/confidential-space-debug
+      --substitutions _BASE_IMAGE=${base_image},_OUTPUT_IMAGE_NAME=${OUTPUT_IMAGE_PREFIX}-debug-${OUTPUT_IMAGE_SUFFIX},_IMAGE_ENV=debug,_CS_LICENSE=projects/confidential-space-images/global/licenses/confidential-space-debug,_BUCKET_NAME=${BUCKET_NAME}
     exit
 
 - name: 'gcr.io/cloud-builders/gcloud'
@@ -46,6 +48,7 @@ steps:
   env:
   - 'OUTPUT_IMAGE_PREFIX=$_OUTPUT_IMAGE_PREFIX'
   - 'OUTPUT_IMAGE_SUFFIX=$_OUTPUT_IMAGE_SUFFIX'
+  - 'BUCKET_NAME=$_BUCKET_NAME'
   script: |
     #!/usr/bin/env bash
     set -exuo pipefail
@@ -53,7 +56,7 @@ steps:
     base_image=$(cat /workspace/base_image.txt)
     echo "building the hardened image: ${OUTPUT_IMAGE_PREFIX}-hardened-${OUTPUT_IMAGE_SUFFIX} with the base image: ${base_image}"
     gcloud builds submit --config=launcher/image/cloudbuild.yaml \
-      --substitutions _BASE_IMAGE=${base_image},_OUTPUT_IMAGE_NAME=${OUTPUT_IMAGE_PREFIX}-hardened-${OUTPUT_IMAGE_SUFFIX},_IMAGE_ENV=hardened,_CS_LICENSE=projects/confidential-space-images/global/licenses/confidential-space
+      --substitutions _BASE_IMAGE=${base_image},_OUTPUT_IMAGE_NAME=${OUTPUT_IMAGE_PREFIX}-hardened-${OUTPUT_IMAGE_SUFFIX},_IMAGE_ENV=hardened,_CS_LICENSE=projects/confidential-space-images/global/licenses/confidential-space,_BUCKET_NAME=${BUCKET_NAME}
     exit
 
 - name: 'gcr.io/cloud-builders/gcloud'

--- a/launcher/image/test/test_debug_cloudbuild.yaml
+++ b/launcher/image/test/test_debug_cloudbuild.yaml
@@ -4,7 +4,7 @@ substitutions:
   '_CLEANUP': 'true'
   '_VM_NAME_PREFIX': 'cs-debug-test'
   '_ZONE': 'us-central1-a'
-  '_WORKLOAD_IMAGE': 'us-west1-docker.pkg.dev/confidential-space-images-dev/cs-integ-test-images/basic-test:latest'
+  '_WORKLOAD_IMAGE': 'us-west1-docker.pkg.dev/confidential-space-images-dev/cs-integ-test-images/basic-test:latest,tee-cmd=["newCmd"],tee-env-ALLOWED_OVERRIDE=overridden'
 steps:
 - name: 'gcr.io/cloud-builders/gcloud'
   id: CreateVM

--- a/launcher/image/test/test_hardened_cloudbuild.yaml
+++ b/launcher/image/test/test_hardened_cloudbuild.yaml
@@ -18,7 +18,7 @@ steps:
   args: ['create_vm.sh','-i', '${_IMAGE_NAME}',
           '-p', '${_IMAGE_PROJECT}',
           '-f', '${_METADATA_FILE}',
-          '-m', 'tee-image-reference=${_WORKLOAD_IMAGE},tee-container-log-redirect=true',
+          '-m', 'tee-image-reference=${_WORKLOAD_IMAGE},tee-container-log-redirect=true,tee-cmd=["newCmd"],tee-env-ALLOWED_OVERRIDE=overridden',
           '-n', '${_VM_NAME_PREFIX}-${BUILD_ID}',
           '-z', '${_ZONE}',
         ]

--- a/launcher/image/test/test_launcher_workload.sh
+++ b/launcher/image/test/test_launcher_workload.sh
@@ -16,7 +16,7 @@ else
     print_serial=true
 fi
 
-if echo $SERIAL_OUTPUT | grep -q 'workload args: \[/main arg_foo\]'
+if echo $SERIAL_OUTPUT | grep -q 'workload args: \[/main newCmd\]'
 then
     echo "- arguments verified"
 else
@@ -27,12 +27,22 @@ fi
 
 if echo $SERIAL_OUTPUT | grep -q 'env_bar=val_bar'
 then
-    echo "- env vars verified"
+    echo "- env_bar var verified"
 else
-    echo "FAILED: env var not verified"
+    echo "FAILED: env_bar env not verified"
     echo 'TEST FAILED.' > /workspace/status.txt
     print_serial=true
 fi
+
+if echo $SERIAL_OUTPUT | grep -q 'ALLOWED_OVERRIDE=overridden'
+then
+    echo "- ALLOWED_OVERRIDE var verified"
+else
+    echo "FAILED: ALLOWED_OVERRIDE env not verified"
+    echo 'TEST FAILED.' > /workspace/status.txt
+    print_serial=true
+fi
+
 
 if echo $SERIAL_OUTPUT | grep -q 'token looks okay'
 then


### PR DESCRIPTION
This allows us to verify the test workload is properly seeing the env and cmds the operator passes in.