### PR TITLE
Return the actual number of bytes written to through command buffer

### DIFF
--- a/simulator/simulator.go
+++ b/simulator/simulator.go
@@ -109,7 +109,14 @@ func (s *Simulator) Write(commandBuffer []byte) (int, error) {
 	if err != nil {
 		return 0, err
 	}
-	return s.buf.Write(resp)
+	n, err := s.buf.Write(resp)
+	if err != nil {
+		return 0, err
+	}
+	if n != len(resp) {
+		return 0, fmt.Errorf("expected %d bytes to be written to command response buffer, but actual number is %d", len(resp), n)
+	}
+	return len(commandBuffer), nil
 }
 
 // Read gets the response of a command previously issued by calling Write().

--- a/simulator/simulator.go
+++ b/simulator/simulator.go
@@ -109,13 +109,8 @@ func (s *Simulator) Write(commandBuffer []byte) (int, error) {
 	if err != nil {
 		return 0, err
 	}
-	n, err := s.buf.Write(resp)
-	if err != nil {
-		return 0, err
-	}
-	if n != len(resp) {
-		return 0, fmt.Errorf("expected %d bytes to be written to command response buffer, but actual number is %d", len(resp), n)
-	}
+	// write response to the internal response buffer.
+	_, _ = s.buf.Write(resp)
 	return len(commandBuffer), nil
 }
 


### PR DESCRIPTION
The `Write` function returned the number of bytes written to the internal command response buffer. Depending on the type of command executed against the TPM, this would usually result in a different number of bytes being written than the original input.

The fix is useful if one wants to wrap the `io.ReadWriterCloser` functions with implementations that perform strict checks. An example is using an `io.MultiWriter` to capture the bytes sent to the TPM for debugging purposes, which will fail if the number of bytes written does not equal the original length of the input bytes.