### PR TITLE
test: Add test workload code, check OIDC claims, and validate launch policy checks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,4 +10,4 @@ files/go-tpm-tools
 *.pkg.tar.xz
 .vscode*
 *.code-workspace
-
+main

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -90,3 +90,19 @@ steps:
     gcloud builds submit --config=test_hardened_cloudbuild.yaml \
       --substitutions _IMAGE_NAME=${OUTPUT_IMAGE_PREFIX}-hardened-${OUTPUT_IMAGE_SUFFIX},_IMAGE_PROJECT=${PROJECT_ID}
     exit
+- name: 'gcr.io/cloud-builders/gcloud'
+  id: LaunchPolicyTests
+  waitFor: ['HardenedImageBuild']
+  env:
+  - 'OUTPUT_IMAGE_PREFIX=$_OUTPUT_IMAGE_PREFIX'
+  - 'OUTPUT_IMAGE_SUFFIX=$_OUTPUT_IMAGE_SUFFIX'
+  - 'PROJECT_ID=$PROJECT_ID'
+  script: |
+    #!/usr/bin/env bash
+
+    cd launcher/image/test
+    echo "running launch policy tests on ${OUTPUT_IMAGE_PREFIX}-hardened-${OUTPUT_IMAGE_SUFFIX}"
+    gcloud builds submit --config=test_launchpolicy_cloudbuild.yaml \
+      --substitutions _IMAGE_NAME=${OUTPUT_IMAGE_PREFIX}-hardened-${OUTPUT_IMAGE_SUFFIX},_IMAGE_PROJECT=${PROJECT_ID}
+    exit
+

--- a/launcher/image/test/scripts/test_launchpolicy_cmd.sh
+++ b/launcher/image/test/scripts/test_launchpolicy_cmd.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+set -euo pipefail
+source util/read_serial.sh
+
+# Allow VM some time to boot and write to serial console.
+sleep 120
+
+SERIAL_OUTPUT=$(read_serial $1 $2)
+if echo $SERIAL_OUTPUT | grep -q 'CMD is not allowed to be overridden on this image'
+then
+    echo "- CMD launch policy verified"
+else
+    echo "FAILED: CMD launch policy verification"
+    echo 'TEST FAILED' > /workspace/status.txt
+    echo $SERIAL_OUTPUT
+fi

--- a/launcher/image/test/scripts/test_launchpolicy_env.sh
+++ b/launcher/image/test/scripts/test_launchpolicy_env.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+set -euo pipefail
+source util/read_serial.sh
+
+# Allow VM some time to boot and write to serial console.
+sleep 120
+
+SERIAL_OUTPUT=$(read_serial $1 $2)
+if echo $SERIAL_OUTPUT | grep -q --fixed-strings 'env var {OUT a} is not allowed to be overridden on this image; allowed envs to be overridden: [ALLOWED_OVERRIDE]'
+then
+    echo "- Env launch policy verified"
+else
+    echo "FAILED: Env launch policy verification"
+    echo 'TEST FAILED' > /workspace/status.txt
+    echo $SERIAL_OUTPUT
+fi

--- a/launcher/image/test/scripts/test_launchpolicy_log.sh
+++ b/launcher/image/test/scripts/test_launchpolicy_log.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+set -euo pipefail
+source util/read_serial.sh
+
+# Allow VM some time to boot and write to serial console.
+sleep 120
+
+SERIAL_OUTPUT=$(read_serial $1 $2)
+if echo $SERIAL_OUTPUT | grep -q 'logging redirection not allowed by image'
+then
+    echo "- Log launch policy verified"
+else
+    echo "FAILED: Log launch policy verification"
+    echo 'TEST FAILED' > /workspace/status.txt
+    echo $SERIAL_OUTPUT
+fi

--- a/launcher/image/test/test_debug_cloudbuild.yaml
+++ b/launcher/image/test/test_debug_cloudbuild.yaml
@@ -22,6 +22,18 @@ steps:
   entrypoint: 'bash'
   args: ['test_launcher_workload.sh', '${_VM_NAME_PREFIX}-${BUILD_ID}', '${_ZONE}']
 - name: 'gcr.io/cloud-builders/gcloud'
+  id: ChangeMDSVariables
+  entrypoint: 'bash'
+  args: ['util/change_metadata_vars.sh',
+          '-n', '${_VM_NAME_PREFIX}-${BUILD_ID}',
+          '-z', '${_ZONE}',
+          '-m', 'tee-image-reference=gcr.io/cloudrun/hello:latest',
+        ]
+- name: 'gcr.io/cloud-builders/gcloud'
+  id: ChangeMDSVariablesTest
+  entrypoint: 'bash'
+  args: ['test_mds_var_change.sh', '${_VM_NAME_PREFIX}-${BUILD_ID}', '${_ZONE}']
+- name: 'gcr.io/cloud-builders/gcloud'
   id: CleanUp
   entrypoint: 'bash'
   env:

--- a/launcher/image/test/test_hardened_cloudbuild.yaml
+++ b/launcher/image/test/test_hardened_cloudbuild.yaml
@@ -27,6 +27,18 @@ steps:
   entrypoint: 'bash'
   args: ['test_launcher_workload.sh', '${_VM_NAME_PREFIX}-${BUILD_ID}', '${_ZONE}']
 - name: 'gcr.io/cloud-builders/gcloud'
+  id: ChangeMDSVariables
+  entrypoint: 'bash'
+  args: ['util/change_metadata_vars.sh',
+          '-n', '${_VM_NAME_PREFIX}-${BUILD_ID}',
+          '-z', '${_ZONE}',
+          '-m', 'tee-image-reference=gcr.io/cloudrun/hello:latest',
+        ]
+- name: 'gcr.io/cloud-builders/gcloud'
+  id: ChangeMDSVariablesTest
+  entrypoint: 'bash'
+  args: ['test_mds_var_change.sh', '${_VM_NAME_PREFIX}-${BUILD_ID}', '${_ZONE}']
+- name: 'gcr.io/cloud-builders/gcloud'
   id: MultiWriterPDTest
   entrypoint: 'bash'
   env:

--- a/launcher/image/test/test_launcher_workload.sh
+++ b/launcher/image/test/test_launcher_workload.sh
@@ -7,7 +7,7 @@ source util/read_serial.sh
 SERIAL_OUTPUT=$(read_serial $1 $2) 
 print_serial=false
 
-if echo $SERIAL_OUTPUT | grep -q 'workload running'
+if echo $SERIAL_OUTPUT | grep -q 'Workload running'
 then
     echo "- workload running verified"
 else
@@ -16,7 +16,7 @@ else
     print_serial=true
 fi
 
-if echo $SERIAL_OUTPUT | grep -q 'workload args: \[/main newCmd\]'
+if echo $SERIAL_OUTPUT | grep -q 'Workload args: \[/main newCmd\]'
 then
     echo "- arguments verified"
 else
@@ -27,7 +27,7 @@ fi
 
 if echo $SERIAL_OUTPUT | grep -q 'env_bar=val_bar'
 then
-    echo "- env_bar var verified"
+    echo "- env_bar env var verified"
 else
     echo "FAILED: env_bar env not verified"
     echo 'TEST FAILED.' > /workspace/status.txt
@@ -36,15 +36,68 @@ fi
 
 if echo $SERIAL_OUTPUT | grep -q 'ALLOWED_OVERRIDE=overridden'
 then
-    echo "- ALLOWED_OVERRIDE var verified"
+    echo "- ALLOWED_OVERRIDE env var verified"
 else
     echo "FAILED: ALLOWED_OVERRIDE env not verified"
     echo 'TEST FAILED.' > /workspace/status.txt
     print_serial=true
 fi
 
+if echo $SERIAL_OUTPUT | grep -q 'aud: https://sts.googleapis.com'
+then
+    echo "- token aud verified"
+else
+    echo "FAILED: token aud not verified"
+    echo 'TEST FAILED.' > /workspace/status.txt
+    print_serial=true
+fi
 
-if echo $SERIAL_OUTPUT | grep -q 'token looks okay'
+if echo $SERIAL_OUTPUT | grep -q 'iss: https://confidentialcomputing.googleapis.com'
+then
+    echo "- token iss verified"
+else
+    echo "FAILED: token iss not verified"
+    echo 'TEST FAILED.' > /workspace/status.txt
+    print_serial=true
+fi
+
+if echo $SERIAL_OUTPUT | grep -q 'secboot: true'
+then
+    echo "- token secboot verified"
+else
+    echo "FAILED: token secboot not verified"
+    echo 'TEST FAILED.' > /workspace/status.txt
+    print_serial=true
+fi
+
+if echo $SERIAL_OUTPUT | grep -q 'oemid: 11129'
+then
+    echo "- token oemid verified"
+else
+    echo "FAILED: token oemid not verified"
+    echo 'TEST FAILED.' > /workspace/status.txt
+    print_serial=true
+fi
+
+if echo $SERIAL_OUTPUT | grep -q 'hwmodel: GCP_AMD_SEV'
+then
+    echo "- token hwmodel verified"
+else
+    echo "FAILED: token hwmodel not verified"
+    echo 'TEST FAILED.' > /workspace/status.txt
+    print_serial=true
+fi
+
+if echo $SERIAL_OUTPUT | grep -q 'swname: GCE'
+then
+    echo "- token swname verified"
+else
+    echo "FAILED: token swname not verified"
+    echo 'TEST FAILED.' > /workspace/status.txt
+    print_serial=true
+fi
+
+if echo $SERIAL_OUTPUT | grep -q 'Token looks okay'
 then
     echo "- OIDC token accessible"
 else

--- a/launcher/image/test/test_launchpolicy_cloudbuild.yaml
+++ b/launcher/image/test/test_launchpolicy_cloudbuild.yaml
@@ -1,0 +1,98 @@
+substitutions:
+  # Expects hardened image (not debug) and should have startup-script service
+  # disabled. google-startup-scripts.service is only enabled with multi-user.target.
+  '_IMAGE_NAME': ''
+  '_IMAGE_PROJECT': ''
+  # Add user-data in the metadata to test if it is disabled.
+  '_METADATA_FILE': 'startup-script=data/echo_startupscript.sh,user-data=data/cloud-init-config.yaml'
+  '_CLEANUP': 'true'
+  '_VM_NAME_PREFIX': 'cs-hardened-test'
+  '_ZONE': 'us-central1-a'
+  '_WORKLOAD_IMAGE_LOG': 'us-west1-docker.pkg.dev/confidential-space-images-dev/cs-integ-test-images/launchpolicylog:latest'
+  '_WORKLOAD_IMAGE_ENV': 'us-west1-docker.pkg.dev/confidential-space-images-dev/cs-integ-test-images/basic-test:latest'
+  '_WORKLOAD_IMAGE_CMD': 'us-west1-docker.pkg.dev/confidential-space-images-dev/cs-integ-test-images/launchpolicycmd:latest'
+steps:
+- name: 'gcr.io/cloud-builders/gcloud'
+  id: CreateVMLogOverride
+  entrypoint: 'bash'
+  env:
+  - 'BUILD_ID=$BUILD_ID'
+  args: ['create_vm.sh','-i', '${_IMAGE_NAME}',
+          '-p', '${_IMAGE_PROJECT}',
+          '-f', '${_METADATA_FILE}',
+          '-m', 'tee-image-reference=${_WORKLOAD_IMAGE_LOG},tee-container-log-redirect=true',
+          '-n', '${_VM_NAME_PREFIX}-log-${BUILD_ID}',
+          '-z', '${_ZONE}',
+        ]
+- name: 'gcr.io/cloud-builders/gcloud'
+  id: LogOverrideTest
+  entrypoint: 'bash'
+  args: ['scripts/test_launchpolicy_log.sh', '${_VM_NAME_PREFIX}-log-${BUILD_ID}', '${_ZONE}']
+  waitFor: ['CreateVMLogOverride']
+- name: 'gcr.io/cloud-builders/gcloud'
+  id: CleanUpLogOverride
+  entrypoint: 'bash'
+  env:
+  - 'CLEANUP=$_CLEANUP'
+  args: ['cleanup.sh', '${_VM_NAME_PREFIX}-log-${BUILD_ID}', '${_ZONE}']
+  waitFor: ['LogOverrideTest']
+
+- name: 'gcr.io/cloud-builders/gcloud'
+  id: CreateVMEnvOverride
+  entrypoint: 'bash'
+  env:
+  - 'BUILD_ID=$BUILD_ID'
+  args: ['create_vm.sh','-i', '${_IMAGE_NAME}',
+          '-p', '${_IMAGE_PROJECT}',
+          '-f', '${_METADATA_FILE}',
+          '-m', 'tee-image-reference=${_WORKLOAD_IMAGE_ENV},tee-env-OUT=a',
+          '-n', '${_VM_NAME_PREFIX}-env-${BUILD_ID}',
+          '-z', '${_ZONE}',
+        ]
+  waitFor: ['-']  # The '-' indicates that this step begins immediately.
+- name: 'gcr.io/cloud-builders/gcloud'
+  id: EnvOverrideTest
+  entrypoint: 'bash'
+  args: ['scripts/test_launchpolicy_env.sh', '${_VM_NAME_PREFIX}-env-${BUILD_ID}', '${_ZONE}']
+  waitFor: ['CreateVMEnvOverride']
+- name: 'gcr.io/cloud-builders/gcloud'
+  id: CleanUpEnvOverride
+  entrypoint: 'bash'
+  env:
+  - 'CLEANUP=$_CLEANUP'
+  args: ['cleanup.sh', '${_VM_NAME_PREFIX}-env-${BUILD_ID}', '${_ZONE}']
+  waitFor: ['EnvOverrideTest']
+
+- name: 'gcr.io/cloud-builders/gcloud'
+  id: CreateVMCmdOverride
+  entrypoint: 'bash'
+  env:
+  - 'BUILD_ID=$BUILD_ID'
+  args: ['create_vm.sh','-i', '${_IMAGE_NAME}',
+          '-p', '${_IMAGE_PROJECT}',
+          '-f', '${_METADATA_FILE}',
+          '-m', 'tee-image-reference=${_WORKLOAD_IMAGE_CMD},tee-cmd=["newCmd"]',
+          '-n', '${_VM_NAME_PREFIX}-cmd-${BUILD_ID}',
+          '-z', '${_ZONE}',
+        ]
+  waitFor: ['-']  # The '-' indicates that this step begins immediately.
+- name: 'gcr.io/cloud-builders/gcloud'
+  id: CmdOverrideTest
+  entrypoint: 'bash'
+  args: ['scripts/test_launchpolicy_cmd.sh', '${_VM_NAME_PREFIX}-cmd-${BUILD_ID}', '${_ZONE}']
+  waitFor: ['CreateVMCmdOverride']
+- name: 'gcr.io/cloud-builders/gcloud'
+  id: CleanUpCmdOverride
+  entrypoint: 'bash'
+  env:
+  - 'CLEANUP=$_CLEANUP'
+  args: ['cleanup.sh', '${_VM_NAME_PREFIX}-cmd-${BUILD_ID}', '${_ZONE}']
+  waitFor: ['CmdOverrideTest']
+
+# Must come after cleanup.
+- name: 'gcr.io/cloud-builders/gcloud'
+  id: CheckFailure
+  entrypoint: 'bash'
+  env:
+  - 'BUILD_ID=$BUILD_ID'
+  args: ['check_failure.sh']

--- a/launcher/image/test/test_mds_var_change.sh
+++ b/launcher/image/test/test_mds_var_change.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+set -euo pipefail
+source util/read_serial.sh
+
+SERIAL_OUTPUT=$(read_serial $1 $2) 
+# Check MDS variables haven't been changed to use the wrong workload image.
+if echo $SERIAL_OUTPUT | grep -v 'Hello from Cloud Run!' 
+then 
+    echo "- verified changed MDS vars have no effect" 
+else
+    echo "FAILED: MDS variables changed"
+    echo 'TEST FAILED' > /workspace/status.txt
+fi

--- a/launcher/image/test/util/change_metadata_vars.sh
+++ b/launcher/image/test/util/change_metadata_vars.sh
@@ -1,0 +1,66 @@
+#!/bin/bash
+set -euxo pipefail
+
+print_usage() {
+    echo "usage: change_metadata_vars.sh -n instanceName -z instanceZone [-m metadata] [-f metadataFromFile]"
+    echo "  -m <metadata>: metadata variables on VM creation; passed directly into gcloud"
+    echo "  -f <metadataFromFile>: read a metadata value from a file; specified in format key=filePath"
+    echo "  -n <instanceName>: instance name"
+    echo "  -z <instanceZone>: instance zone"
+    exit 1
+}
+
+update_metadata() {
+  if [ -z "${VM_NAME}" ]; then
+    echo "Empty VM name supplied."
+    exit 1
+  fi
+
+  if [ -z "${ZONE}" ]; then
+    echo "Empty zone supplied."
+    exit 1
+  fi
+  APPEND_ZONE="--zone ${ZONE}"
+
+  if [ -z "${METADATA}${METADATA_FILE}" ]; then
+    echo "Empty metadata supplied."
+    exit 1
+  fi
+
+  APPEND_METADATA=''
+  if ! [ -z "${METADATA}" ]; then
+    APPEND_METADATA="--metadata ${METADATA}"
+  fi
+
+  APPEND_METADATA_FILE=''
+  if ! [ -z "${METADATA_FILE}" ]; then
+    APPEND_METADATA_FILE="--metadata-from-file ${METADATA_FILE}"
+  fi
+
+  echo "Updating VM ${VM_NAME} in ${ZONE} with metadata: ${METADATA_FILE} ${METADATA}"
+
+  # check the active account
+  gcloud auth list
+
+  gcloud compute instances add-metadata $VM_NAME \
+    $APPEND_ZONE $APPEND_METADATA $APPEND_METADATA_FILE
+}
+
+METADATA_FILE=''
+METADATA=''
+VM_NAME=''
+ZONE=''
+
+# In getopts, a ':' following a letter means that that flag takes an argument.
+# For example, i: means -i takes an additional argument.
+while getopts 'f:m:n:z:' flag; do
+  case "${flag}" in
+    f) METADATA_FILE=${OPTARG} ;;
+    m) METADATA=${OPTARG} ;;
+    n) VM_NAME=${OPTARG} ;;
+    z) ZONE=${OPTARG} ;;
+    *) print_usage ;;
+  esac
+done
+
+update_metadata

--- a/launcher/image/testworkloads/basic/Dockerfile
+++ b/launcher/image/testworkloads/basic/Dockerfile
@@ -1,0 +1,17 @@
+# From current directory:
+# GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -o main .
+# gcloud builds submit --tag us-west1-docker.pkg.dev/confidential-space-images-dev/cs-integ-test-images/basic_test:latest
+FROM alpine
+
+COPY main /
+
+ENV env_bar="val_bar"
+
+LABEL "tee.launch_policy.allow_env_override"="ALLOWED_OVERRIDE"
+LABEL "tee.launch_policy.allow_cmd_override"="true"
+LABEL "tee.launch_policy.log_redirect"="always"
+
+ENTRYPOINT ["/main"]
+
+# Can be overridden because of the launch policy.
+CMD ["arg_foo"]

--- a/launcher/image/testworkloads/basic/main.go
+++ b/launcher/image/testworkloads/basic/main.go
@@ -1,0 +1,46 @@
+// package main is a binary that will print out the MDS vars and check the token.
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/golang-jwt/jwt/v4"
+)
+
+const tokendir = "/run/container_launcher/attestation_verifier_claims_token"
+
+func main() {
+	fmt.Println("Workload running")
+	fmt.Println("Workload args:", os.Args)
+	fmt.Println("Workload env vars:")
+	for _, e := range os.Environ() {
+		fmt.Println(e)
+	}
+
+	filedata, err := os.ReadFile(tokendir)
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+
+	token, _, err := new(jwt.Parser).ParseUnverified(string(filedata), jwt.MapClaims{})
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+
+	claims, ok := token.Claims.(jwt.MapClaims)
+	if !ok {
+		fmt.Println(err)
+		return
+	}
+	fmt.Println("aud: ", claims["aud"])
+	fmt.Println("iss: ", claims["iss"])
+	fmt.Println("secboot: ", claims["secboot"])
+	fmt.Println("oemid: ", claims["oemid"])
+	fmt.Println("hwmodel: ", claims["hwmodel"])
+	fmt.Println("swname: ", claims["swname"])
+
+	fmt.Println("Token looks okay")
+}

--- a/launcher/image/testworkloads/launchpolicycmd/Dockerfile
+++ b/launcher/image/testworkloads/launchpolicycmd/Dockerfile
@@ -1,0 +1,14 @@
+# From current directory:
+# GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -o main ../basic
+# gcloud builds submit --tag us-west1-docker.pkg.dev/confidential-space-images-dev/cs-integ-test-images/launchpolicycmd:latest --project confidential-space-images-dev
+FROM alpine
+
+COPY main /
+
+ENV env_bar="val_bar"
+
+LABEL "tee.launch_policy.log_redirect"="always"
+
+ENTRYPOINT ["/main"]
+
+CMD ["arg_foo"]

--- a/launcher/image/testworkloads/launchpolicylog/Dockerfile
+++ b/launcher/image/testworkloads/launchpolicylog/Dockerfile
@@ -1,0 +1,14 @@
+# From current directory:
+# GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -o main ../basic
+# gcloud builds submit --tag us-west1-docker.pkg.dev/confidential-space-images-dev/cs-integ-test-images/launchpolicylog:latest --project confidential-space-images-dev
+FROM alpine
+
+COPY main /
+
+ENV env_bar="val_bar"
+
+LABEL "tee.launch_policy.log_redirect"="never"
+
+ENTRYPOINT ["/main"]
+
+CMD ["arg_foo"]


### PR DESCRIPTION
* Add the source for the basic-test image used in our integ tests.
* Check the OIDC claims in the token match what we expect.
* Check MDS variable change has no effect once the workload kicks off.
* Add launch policy tests against: cmd overrides, environment variable overrides, and logging redirection.