### PR TITLE
Add OS Policy assignment tests for both debug and hardened.

### DIFF
--- a/launcher/image/test/test_debug_unstable_cloudbuild.yaml
+++ b/launcher/image/test/test_debug_unstable_cloudbuild.yaml
@@ -1,0 +1,36 @@
+substitutions:
+  '_IMAGE_NAME': ''
+  '_IMAGE_PROJECT': ''
+  '_CLEANUP': 'true'
+  '_VM_NAME_PREFIX': 'cs-debug-test'
+  '_ZONE': 'us-central1-a'
+  '_WORKLOAD_IMAGE': 'us-west1-docker.pkg.dev/confidential-space-images-dev/cs-integ-test-images/basic-test:latest'
+steps:
+- name: 'gcr.io/cloud-builders/gcloud'
+  id: CreateVM
+  entrypoint: 'bash'
+  env:
+  - 'BUILD_ID=$BUILD_ID'
+  args: ['create_vm.sh','-i', '${_IMAGE_NAME}',
+          '-p', '${_IMAGE_PROJECT}',
+          '-m', 'tee-image-reference=${_WORKLOAD_IMAGE},tee-container-log-redirect=true,tee-cmd=["newCmd"],tee-env-ALLOWED_OVERRIDE=overridden,enable-osconfig=TRUE',
+          '-n', '${_VM_NAME_PREFIX}-${BUILD_ID}',
+          '-z', '${_ZONE}',
+        ]
+- name: 'gcr.io/cloud-builders/gcloud'
+  id: OsConfigOsPolicyEnabledTest
+  entrypoint: 'bash'
+  args: ['test_os_config_os_policy.sh', 'debug', '${_VM_NAME_PREFIX}-${BUILD_ID}', '${_ZONE}']
+- name: 'gcr.io/cloud-builders/gcloud'
+  id: CleanUp
+  entrypoint: 'bash'
+  env:
+  - 'CLEANUP=$_CLEANUP'
+  args: ['cleanup.sh', '${_VM_NAME_PREFIX}-${BUILD_ID}', '${_ZONE}']
+# Must come after cleanup.
+- name: 'gcr.io/cloud-builders/gcloud'
+  id: CheckFailure
+  entrypoint: 'bash'
+  env:
+  - 'BUILD_ID=$BUILD_ID'
+  args: ['check_failure.sh']

--- a/launcher/image/test/test_debug_unstable_cloudbuild.yaml
+++ b/launcher/image/test/test_debug_unstable_cloudbuild.yaml
@@ -34,3 +34,4 @@ steps:
   env:
   - 'BUILD_ID=$BUILD_ID'
   args: ['check_failure.sh']
+  

--- a/launcher/image/test/test_hardened_unstable_cloudbuild.yaml
+++ b/launcher/image/test/test_hardened_unstable_cloudbuild.yaml
@@ -1,0 +1,36 @@
+substitutions:
+  '_IMAGE_NAME': ''
+  '_IMAGE_PROJECT': ''
+  '_CLEANUP': 'true'
+  '_VM_NAME_PREFIX': 'cs-hardened-test'
+  '_ZONE': 'us-central1-a'
+  '_WORKLOAD_IMAGE': 'us-west1-docker.pkg.dev/confidential-space-images-dev/cs-integ-test-images/basic-test:latest'
+steps:
+- name: 'gcr.io/cloud-builders/gcloud'
+  id: CreateVM
+  entrypoint: 'bash'
+  env:
+  - 'BUILD_ID=$BUILD_ID'
+  args: ['create_vm.sh','-i', '${_IMAGE_NAME}',
+          '-p', '${_IMAGE_PROJECT}',
+          '-m', 'tee-image-reference=${_WORKLOAD_IMAGE},tee-container-log-redirect=true,tee-cmd=["newCmd"],tee-env-ALLOWED_OVERRIDE=overridden,enable-osconfig=TRUE',
+          '-n', '${_VM_NAME_PREFIX}-${BUILD_ID}',
+          '-z', '${_ZONE}',
+        ]
+- name: 'gcr.io/cloud-builders/gcloud'
+  id: OsConfigOsPolicyDisabledTest
+  entrypoint: 'bash'
+  args: ['test_os_config_os_policy.sh', 'hardened', '${_VM_NAME_PREFIX}-${BUILD_ID}', '${_ZONE}']
+- name: 'gcr.io/cloud-builders/gcloud'
+  id: CleanUp
+  entrypoint: 'bash'
+  env:
+  - 'CLEANUP=$_CLEANUP'
+  args: ['cleanup.sh', '${_VM_NAME_PREFIX}-${BUILD_ID}', '${_ZONE}']
+# Must come after cleanup.
+- name: 'gcr.io/cloud-builders/gcloud'
+  id: CheckFailure
+  entrypoint: 'bash'
+  env:
+  - 'BUILD_ID=$BUILD_ID'
+  args: ['check_failure.sh']

--- a/launcher/image/test/test_hardened_unstable_cloudbuild.yaml
+++ b/launcher/image/test/test_hardened_unstable_cloudbuild.yaml
@@ -34,3 +34,4 @@ steps:
   env:
   - 'BUILD_ID=$BUILD_ID'
   args: ['check_failure.sh']
+  

--- a/launcher/image/test/test_os_config_os_policy.sh
+++ b/launcher/image/test/test_os_config_os_policy.sh
@@ -1,0 +1,66 @@
+#!/bin/bash
+set -euo pipefail
+
+if $1 == 'debug'
+then
+    echo 'Running OS Config OS Policy enabled test'
+else
+    echo 'Running OS Config OS Policy disabled test'
+fi
+
+cat <<EOT >> shutdown-ospolicy.yaml
+osPolicies:
+  - id: shutdown-policy
+    mode: ENFORCEMENT
+    resourceGroups:
+      - resources:
+          id: shutdown-vm
+          exec:
+            validate:
+              interpreter: SHELL
+              script: if true; then sudo shutdown now; else exit 101; fi
+            enforce:
+              interpreter: SHELL
+              script: exit 100
+instanceFilter:
+  inclusionLabels:
+    - labels:
+        shutdown-label: $2
+rollout:
+  disruptionBudget:
+    percent: 100
+  minWaitDuration: 1s
+EOT
+
+gcloud compute instances add-labels $2 --labels=shutdown-label=$2 --zone=$3 || true
+GCLOUD_OUTPUT=$(gcloud compute os-config os-policy-assignments create shutdown-policy --location=$3 --file=shutdown-ospolicy.yaml | tail -1 || true)
+
+if echo $GCLOUD_OUTPUT | grep -q 'Created OS policy assignment [shutdown-policy]'
+then
+    GCLOUD_OUTPUT=$(gcloud compute instances describe $2 --zone=$3 --format="value(status)" || true)
+else
+    echo 'TEST FAILED: OS policy assignment could not be created'
+    echo 'TEST FAILED.' > /workspace/status.txt
+    exit 1
+fi
+
+if $1 == 'debug'
+then
+    if echo $GCLOUD_OUTPUT | grep -q 'TERMINATED'
+    then
+        echo 'Success: OS policy assignment stops the VM'
+    else
+        echo 'TEST FAILED: VM did not terminate'
+        echo 'TEST FAILED.' > /workspace/status.txt
+    fi
+else
+    if echo $GCLOUD_OUTPUT | grep -q 'TERMINATED'
+    then
+        echo 'TEST FAILED: VM incorrectly terminated'
+        echo 'TEST FAILED.' > /workspace/status.txt
+    else
+        echo 'Success: OS policy assignment does not affect VM'
+    fi
+fi
+
+gcloud compute os-config os-policy-assignments delete shutdown-policy --location=$3 --quiet || true


### PR DESCRIPTION
Currently, OS Policy assignment rollout does not finish in a timely manner. These tests are part of "unstable" cloudbuilds until this is resolved.