### PR TITLE
Add a wrapper for ExternalTPM

### DIFF
--- a/cmd/open.go
+++ b/cmd/open.go
@@ -3,6 +3,8 @@ package cmd
 import (
 	"fmt"
 	"io"
+
+	"github.com/google/go-tpm-tools/client"
 )
 
 // ExternalTPM can be set to run tests against an TPM initialized by an
@@ -10,19 +12,29 @@ import (
 // gotpm commands run against it, and will prevent the cmd package from
 // closing the TPM. Setting this value and closing the TPM must be managed
 // by the external package.
+// ExternalTPM can have a TPM simulator or a real TPM.
 var ExternalTPM io.ReadWriter
 
-type ignoreClose struct {
+// extTPMWrapper is designed to wrap the ExternalTPM to provide some overriding
+// functions.
+type extTPMWrapper struct {
 	io.ReadWriter
 }
 
-func (ic ignoreClose) Close() error {
+// Close is no-op for extTPMWrapper to prevent it closing the underlying simulator.
+func (et extTPMWrapper) Close() error {
 	return nil
+}
+
+// EventLog is a workaround so the caller can call the underlying EventLogGetter function
+// of the underlying TPM.
+func (et extTPMWrapper) EventLog() ([]byte, error) {
+	return client.GetEventLog(et.ReadWriter)
 }
 
 func openTpm() (io.ReadWriteCloser, error) {
 	if ExternalTPM != nil {
-		return ignoreClose{ExternalTPM}, nil
+		return extTPMWrapper{ExternalTPM}, nil
 	}
 	rwc, err := openImpl()
 	if err != nil {


### PR DESCRIPTION
Add extTPMWrapper so the CMD package can call EventLog() in a test.