### PR TITLE
Update to go-sev-guest v0.6.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ go 1.19
 require (
 	github.com/google/go-attestation v0.4.4-0.20220404204839-8820d49b18d9
 	github.com/google/go-cmp v0.5.8
-	github.com/google/go-sev-guest v0.5.2
+	github.com/google/go-sev-guest v0.6.0
 	github.com/google/go-tpm v0.3.3
 	github.com/google/logger v1.1.1
 	google.golang.org/protobuf v1.28.0

--- a/go.sum
+++ b/go.sum
@@ -322,8 +322,8 @@ github.com/google/go-licenses v0.0.0-20210329231322-ce1d9163b77d/go.mod h1:+TYOm
 github.com/google/go-querystring v1.0.0/go.mod h1:odCYkC5MyYFN7vkCjXpyrEuKhc/BUO6wN/zVPAxq5ck=
 github.com/google/go-replayers/grpcreplay v0.1.0/go.mod h1:8Ig2Idjpr6gifRd6pNVggX6TC1Zw6Jx74AKp7QNH2QE=
 github.com/google/go-replayers/httpreplay v0.1.0/go.mod h1:YKZViNhiGgqdBlUbI2MwGpq4pXxNmhJLPHQ7cv2b5no=
-github.com/google/go-sev-guest v0.5.2 h1:dlCehnxU9aJWEIcTb0j7oZ/yM4qeno7AO6zWokb4mu0=
-github.com/google/go-sev-guest v0.5.2/go.mod h1:UEi9uwoPbLdKGl1QHaq1G8pfCbQ4QP0swWX4J0k6r+Q=
+github.com/google/go-sev-guest v0.6.0 h1:PPKmzbHoTRunhlrKieDVtigFwdCvZbw3aEnklPGwbHk=
+github.com/google/go-sev-guest v0.6.0/go.mod h1:UEi9uwoPbLdKGl1QHaq1G8pfCbQ4QP0swWX4J0k6r+Q=
 github.com/google/go-tpm v0.1.2-0.20190725015402-ae6dd98980d4/go.mod h1:H9HbmUG2YgV/PHITkO7p6wxEEj/v5nlsVWIwumwH2NI=
 github.com/google/go-tpm v0.3.0/go.mod h1:iVLWvrPp/bHeEkxTFi9WG6K9w0iy2yIszHwZGHPbzAw=
 github.com/google/go-tpm v0.3.2/go.mod h1:j71sMBTfp3X5jPHz852ZOfQMUOf65Gb/Th8pRmp7fvg=

--- a/server/verify_sev.go
+++ b/server/verify_sev.go
@@ -41,7 +41,7 @@ func SevSnpDefaultValidateOptsForTest(tpmNonce []byte) *validate.Options {
 func SevSnpDefaultOptions(tpmNonce []byte) *VerifySnpOpts {
 	return &VerifySnpOpts{
 		Validation:   SevSnpDefaultValidateOpts(tpmNonce),
-		Verification: &sv.Options{},
+		Verification: sv.DefaultOptions(),
 	}
 }
 


### PR DESCRIPTION
This new version includes more reliability measures with respect to host throttling and AMD KDS clock drift causing certificate verification failure.