### PR TITLE
add tee_technology flag and test for tee_technology flag

### DIFF
--- a/cmd/attest.go
+++ b/cmd/attest.go
@@ -175,7 +175,7 @@ func addKeyFlag(cmd *cobra.Command) {
 }
 
 func addTeeTechnology(cmd *cobra.Command) {
-	cmd.PersistentFlags().StringVar(&teeTechnology, "tee_technology", "", "indicates the type of TEE hardware <sev-snp>")
+	cmd.PersistentFlags().StringVar(&teeTechnology, "tee_technology", "", "indicates the type of TEE hardware. Should be empty or sev-snp")
 }
 
 func init() {

--- a/cmd/attest.go
+++ b/cmd/attest.go
@@ -18,6 +18,11 @@ var (
 	teeTechnology string
 )
 
+const (
+	// Add constants for other devices when required
+	SevSnp = "sev-snp"
+)
+
 var attestationKeys = map[string]map[tpm2.Algorithm]func(rw io.ReadWriter) (*client.Key, error){
 	"AK": {
 		tpm2.AlgRSA: client.AttestationKeyRSA,
@@ -73,22 +78,20 @@ hardware and guarantees a fresh quote.
 		if len(teeTechnology) != 0 {
 			// Add logic to open other hardware devices when required.
 			switch teeTechnology {
-			case "sev-snp":
+			case SevSnp:
 				attestOpts.TEEDevice, err = client.CreateSevSnpDevice()
 				if err != nil {
-					return fmt.Errorf("failed to open sev-snp device: %v", err)
+					return fmt.Errorf("failed to open %s device: %v", SevSnp, err)
 				}
 			default:
 				// Change the return statement when more devices are added
-				return fmt.Errorf("tee_technology should be sev-snp")
+				return fmt.Errorf("tee_technology should be empty or %s", SevSnp)
 			}
 			if len(teeNonce) != 0 {
 				attestOpts.TEENonce = teeNonce
 			}
-		} else {
-			if len(teeNonce) != 0 {
-				return fmt.Errorf("use of --teenonce requires specifying TEE hardware type with --tee_technology")
-			}
+		} else if len(teeNonce) != 0 {
+			return fmt.Errorf("use of --teenonce requires specifying TEE hardware type with --tee_technology")
 		}
 
 		attestOpts.TCGEventLog, err = client.GetEventLog(rwc)

--- a/cmd/attest.go
+++ b/cmd/attest.go
@@ -18,8 +18,9 @@ var (
 	teeTechnology string
 )
 
+// Add constants for other devices when required
 const (
-	// Add constants for other devices when required
+	// SevSnp is a constant denotes device name for teeTechnology
 	SevSnp = "sev-snp"
 )
 

--- a/cmd/attest_test.go
+++ b/cmd/attest_test.go
@@ -280,12 +280,24 @@ func TestAttestWithGCEAK(t *testing.T) {
 	}
 }
 
+func TestTeeTechnologyFail(t *testing.T) {
+	rwc := test.GetTPM(t)
+	defer client.CheckedClose(t, rwc)
+	ExternalTPM = rwc
+
+	// value of tee_technology flag should be sev-snp
+	RootCmd.SetArgs([]string{"attest", "--nonce", "1234", "--key", "AK", "--teenonce", "12345678", "--tee_technology", "sgx"})
+	if err := RootCmd.Execute(); err == nil {
+		t.Error("expected not-nil error")
+	}
+}
+
 func TestAttestTeeNonceFail(t *testing.T) {
 	rwc := test.GetTPM(t)
 	defer client.CheckedClose(t, rwc)
 	ExternalTPM = rwc
 	// non-nil TEENonce when TEEDevice is nil
-	RootCmd.SetArgs([]string{"attest", "--nonce", "1234", "--key", "AK", "--teenonce", "12345678"})
+	RootCmd.SetArgs([]string{"attest", "--nonce", "1234", "--key", "AK", "--teenonce", "12345678", "--tee_technology", ""})
 	if err := RootCmd.Execute(); err == nil {
 		t.Error("expected not-nil error")
 	}
@@ -302,6 +314,7 @@ func TestAttestTeeNonceFail(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
+	defer ak.Close()
 	attestopts := client.AttestOpts{
 		Nonce:     []byte{1, 2, 3, 4},
 		TEENonce:  []byte{1, 2, 3, 4},

--- a/cmd/attest_test.go
+++ b/cmd/attest_test.go
@@ -285,8 +285,8 @@ func TestTeeTechnologyFail(t *testing.T) {
 	defer client.CheckedClose(t, rwc)
 	ExternalTPM = rwc
 
-	// value of tee_technology flag should be sev-snp
-	RootCmd.SetArgs([]string{"attest", "--nonce", "1234", "--key", "AK", "--teenonce", "12345678", "--tee_technology", "sgx"})
+	// value of tee-technology flag should be sev-snp
+	RootCmd.SetArgs([]string{"attest", "--nonce", "1234", "--key", "AK", "--tee-nonce", "12345678", "--tee-technology", "sgx"})
 	if err := RootCmd.Execute(); err == nil {
 		t.Error("expected not-nil error")
 	}
@@ -297,7 +297,7 @@ func TestAttestTeeNonceFail(t *testing.T) {
 	defer client.CheckedClose(t, rwc)
 	ExternalTPM = rwc
 	// non-nil TEENonce when TEEDevice is nil
-	RootCmd.SetArgs([]string{"attest", "--nonce", "1234", "--key", "AK", "--teenonce", "12345678", "--tee_technology", ""})
+	RootCmd.SetArgs([]string{"attest", "--nonce", "1234", "--key", "AK", "--tee-nonce", "12345678", "--tee-technology", ""})
 	if err := RootCmd.Execute(); err == nil {
 		t.Error("expected not-nil error")
 	}

--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -155,7 +155,7 @@ func addFormatFlag(cmd *cobra.Command) {
 }
 
 func addTeeNonceflag(cmd *cobra.Command) {
-	cmd.PersistentFlags().BytesHexVar(&teeNonce, "teenonce", []byte{}, "hex encoded teenonce for hardware attestation, can be empty")
+	cmd.PersistentFlags().BytesHexVar(&teeNonce, "tee-nonce", []byte{}, "hex encoded teenonce for hardware attestation, can be empty")
 }
 
 // alwaysError implements io.ReadWriter by always returning an error

--- a/cmd/verify_test.go
+++ b/cmd/verify_test.go
@@ -20,7 +20,7 @@ func TestVerifyNoncePass(t *testing.T) {
 	defer os.RemoveAll(file1)
 	defer os.RemoveAll(file2)
 
-	RootCmd.SetArgs([]string{"attest", "--nonce", "1234", "--key", "AK", "--teenonce", "", "--output", file1})
+	RootCmd.SetArgs([]string{"attest", "--nonce", "1234", "--key", "AK", "--tee-nonce", "", "--output", file1})
 	if err := RootCmd.Execute(); err != nil {
 		t.Error(err)
 	}


### PR DESCRIPTION
Added --tee_technology flag in attest CLI that specifies the type of hardware the user wants to use for attestation.  