### PR TITLE
Add GoReleaser release action for gotpm CLI

### DIFF
--- a/.github/workflows/releaser.yaml
+++ b/.github/workflows/releaser.yaml
@@ -1,0 +1,52 @@
+name: release
+
+on:
+  push:
+    branches:
+    tags:
+      - 'v*'
+  pull_request:
+
+jobs:
+  release:
+    strategy:
+      matrix:
+        go-version: [1.20.x]
+        os: [macos-latest, ubuntu-latest]
+
+    name: Release (${{ matrix.os}}, Go ${{ matrix.go-version }})
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-go@v3
+        with:
+          go-version: ${{ matrix.go-version }}
+          cache: true
+      - shell: bash
+        run: echo "sha_short=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
+      - id: cache
+        uses: actions/cache@v3
+        with:
+          path: dist/${{ matrix.os }}
+          key: ${{ matrix.go }}-${{ env.sha_short }}
+      - name: Install Linux packages
+        run: sudo apt-get -y install libssl-dev
+        if: runner.os == 'Linux'
+      - name: Install Mac packages
+        run: brew install openssl
+        if: runner.os == 'macOS'
+      - name: Install Windows packages
+        run: choco install openssl
+        if: runner.os == 'Windows'
+      - name: Build all modules
+        run: go build -v ./... ./cmd/... ./launcher/...
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v3
+        if: success() && startsWith(github.ref, 'refs/tags/') && steps.cache.outputs.cache-hit != 'true'
+        with:
+          version: latest
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,39 @@
+builds:
+  - goos:
+      - linux
+      - windows
+      - darwin
+    goarch:
+      - amd64
+      - arm64
+    id: "gotpm"
+    main: ./cmd/gotpm
+    binary: gotpm
+
+archives:
+  - format: tar.gz
+    # this name template makes the OS and Arch compatible with the results of uname.
+    name_template: >-
+      {{ .ProjectName }}_
+      {{- title .Os }}_
+      {{- if eq .Arch "amd64" }}x86_64
+      {{- else if eq .Arch "386" }}i386
+      {{- else }}{{ .Arch }}{{ end }}
+      {{- if .Arm }}v{{ .Arm }}{{ end }}
+    # use zip for windows archives
+    format_overrides:
+    - goos: windows
+      format: zip
+checksum:
+  name_template: 'checksums.txt'
+snapshot:
+  name_template: "{{ incpatch .Version }}-next"
+changelog:
+  sort: asc
+  filters:
+    exclude:
+      - '^docs:'
+      - '^test:'
+
+# yaml-language-server: $schema=https://goreleaser.com/static/schema.json
+# vim: set ts=2 sw=2 tw=0 fo=cnqoj


### PR DESCRIPTION
The CLI binary is a useful artifact to have prebuilt and ready to use. This action ensures that all new releases that get cut will have the binary artifacts ready for download for the tableau of supported OSes and architectures.