### PR TITLE
Add a new metadata flag of signedImageRepos

### DIFF
--- a/launcher/spec/launch_spec.go
+++ b/launcher/spec/launch_spec.go
@@ -33,6 +33,7 @@ const (
 // Metadata variable names.
 const (
 	imageRefKey                = "tee-image-reference"
+	signedImageRepos           = "tee-signed-image-repos"
 	restartPolicyKey           = "tee-restart-policy"
 	cmdKey                     = "tee-cmd"
 	envKeyPrefix               = "tee-env-"
@@ -58,6 +59,7 @@ type EnvVar struct {
 type LaunchSpec struct {
 	// MDS-based values.
 	ImageRef                   string
+	SignedImageRepos           []string
 	RestartPolicy              RestartPolicy
 	Cmd                        []string
 	Envs                       []EnvVar
@@ -94,6 +96,11 @@ func (s *LaunchSpec) UnmarshalJSON(b []byte) error {
 	if val, ok := unmarshaledMap[impersonateServiceAccounts]; ok && val != "" {
 		impersonateAccounts := strings.Split(val, ",")
 		s.ImpersonateServiceAccounts = append(s.ImpersonateServiceAccounts, impersonateAccounts...)
+	}
+
+	if val, ok := unmarshaledMap[signedImageRepos]; ok && val != "" {
+		imageRepos := strings.Split(val, ",")
+		s.SignedImageRepos = append(s.SignedImageRepos, imageRepos...)
 	}
 
 	// populate cmd override

--- a/launcher/spec/launch_spec_test.go
+++ b/launcher/spec/launch_spec_test.go
@@ -17,6 +17,7 @@ func TestLaunchSpecUnmarshalJSONHappyCases(t *testing.T) {
 				"tee-cmd":"[\"--foo\",\"--bar\",\"--baz\"]",
 				"tee-env-foo":"bar",
 				"tee-image-reference":"docker.io/library/hello-world:latest",
+				"tee-signed-image-repos":"docker.io/library/hello-world,gcr.io/cloudrun/hello",
 				"tee-restart-policy":"Always",
 				"tee-impersonate-service-accounts":"sv1@developer.gserviceaccount.com,sv2@developer.gserviceaccount.com",
 				"tee-container-log-redirect":"true"
@@ -30,6 +31,7 @@ func TestLaunchSpecUnmarshalJSONHappyCases(t *testing.T) {
 				"tee-unknown":"unknown",
 				"unknown":"unknown",
 				"tee-image-reference":"docker.io/library/hello-world:latest",
+				"tee-signed-image-repos":"docker.io/library/hello-world,gcr.io/cloudrun/hello",
 				"tee-restart-policy":"Always",
 				"tee-impersonate-service-accounts":"sv1@developer.gserviceaccount.com,sv2@developer.gserviceaccount.com",
 				"tee-container-log-redirect":"true"
@@ -39,6 +41,7 @@ func TestLaunchSpecUnmarshalJSONHappyCases(t *testing.T) {
 
 	want := &LaunchSpec{
 		ImageRef:                   "docker.io/library/hello-world:latest",
+		SignedImageRepos:           []string{"docker.io/library/hello-world", "gcr.io/cloudrun/hello"},
 		RestartPolicy:              Always,
 		Cmd:                        []string{"--foo", "--bar", "--baz"},
 		Envs:                       []EnvVar{{"foo", "bar"}},
@@ -106,7 +109,8 @@ func TestLaunchSpecUnmarshalJSONBadInput(t *testing.T) {
 func TestLaunchSpecUnmarshalJSONWithDefaultValue(t *testing.T) {
 	mdsJSON := `{
 		"tee-image-reference":"docker.io/library/hello-world:latest",
-		"tee-impersonate-service-accounts":""
+		"tee-impersonate-service-accounts":"",
+		"tee-signed-image-repos":""
 		}`
 
 	spec := &LaunchSpec{}


### PR DESCRIPTION
Add a new metadata flag to launchSpec such that container launcher knows the locations of signed container images.