### PR TITLE
Export attestation token filepath and filename

### DIFF
--- a/launcher/container_runner.go
+++ b/launcher/container_runner.go
@@ -50,9 +50,10 @@ type ContainerRunner struct {
 const (
 	// hostTokenPath defined the directory in the host that will store attestation tokens
 	hostTokenPath = "/tmp/container_launcher/"
-	// containerTokenMountPath defined the directory in the container stores attestation tokens
-	containerTokenMountPath      = "/run/container_launcher/"
-	attestationVerifierTokenFile = "attestation_verifier_claims_token"
+	// ContainerTokenMountPath defined the directory in the container stores attestation tokens
+	ContainerTokenMountPath = "/run/container_launcher/"
+	// AttestationVerifierTokenFile defines the name of the file the attestation token is stored in.
+	AttestationVerifierTokenFile = "attestation_verifier_claims_token"
 	tokenFileTmp                 = ".token.tmp"
 )
 
@@ -268,7 +269,7 @@ func formatEnvVars(envVars []spec.EnvVar) ([]string, error) {
 // appendTokenMounts appends the default mount specs for the OIDC token
 func appendTokenMounts(mounts []specs.Mount) []specs.Mount {
 	m := specs.Mount{}
-	m.Destination = containerTokenMountPath
+	m.Destination = ContainerTokenMountPath
 	m.Type = "bind"
 	m.Source = hostTokenPath
 	m.Options = []string{"rbind", "ro"}
@@ -365,7 +366,7 @@ func (r *ContainerRunner) refreshToken(ctx context.Context) (time.Duration, erro
 	}
 
 	// Rename the temp file to the token file (to avoid race conditions).
-	if err = os.Rename(tmpTokenPath, path.Join(hostTokenPath, attestationVerifierTokenFile)); err != nil {
+	if err = os.Rename(tmpTokenPath, path.Join(hostTokenPath, AttestationVerifierTokenFile)); err != nil {
 		return 0, fmt.Errorf("failed to rename the token file: %v", err)
 	}
 

--- a/launcher/container_runner_test.go
+++ b/launcher/container_runner_test.go
@@ -117,7 +117,7 @@ func TestRefreshToken(t *testing.T) {
 		t.Fatalf("refreshToken returned with error: %v", err)
 	}
 
-	filepath := path.Join(hostTokenPath, attestationVerifierTokenFile)
+	filepath := path.Join(hostTokenPath, AttestationVerifierTokenFile)
 	data, err := os.ReadFile(filepath)
 	if err != nil {
 		t.Fatalf("Failed to read from %s: %v", filepath, err)
@@ -194,7 +194,7 @@ func TestFetchAndWriteTokenSucceeds(t *testing.T) {
 		t.Fatalf("fetchAndWriteToken failed: %v", err)
 	}
 
-	filepath := path.Join(hostTokenPath, attestationVerifierTokenFile)
+	filepath := path.Join(hostTokenPath, AttestationVerifierTokenFile)
 	data, err := os.ReadFile(filepath)
 	if err != nil {
 		t.Fatalf("Failed to read from %s: %v", filepath, err)
@@ -228,7 +228,7 @@ func TestTokenIsNotChangedIfRefreshFails(t *testing.T) {
 		t.Fatalf("fetchAndWriteToken failed: %v", err)
 	}
 
-	filepath := path.Join(hostTokenPath, attestationVerifierTokenFile)
+	filepath := path.Join(hostTokenPath, AttestationVerifierTokenFile)
 	data, err := os.ReadFile(filepath)
 	if err != nil {
 		t.Fatalf("Failed to read from %s: %v", filepath, err)
@@ -306,7 +306,7 @@ func testRetryPolicyWithNTries(t *testing.T, numTries int, expectRefresh bool) {
 	if err := runner.fetchAndWriteTokenWithRetry(ctx, testRetryPolicyThreeTimes()); err != nil {
 		t.Fatalf("fetchAndWriteTokenWithRetry failed: %v", err)
 	}
-	filepath := path.Join(hostTokenPath, attestationVerifierTokenFile)
+	filepath := path.Join(hostTokenPath, AttestationVerifierTokenFile)
 	data, err := os.ReadFile(filepath)
 	if err != nil {
 		t.Fatalf("failed to read from %s: %v", filepath, err)
@@ -360,7 +360,7 @@ func TestFetchAndWriteTokenWithTokenRefresh(t *testing.T) {
 		t.Fatalf("fetchAndWriteToken failed: %v", err)
 	}
 
-	filepath := path.Join(hostTokenPath, attestationVerifierTokenFile)
+	filepath := path.Join(hostTokenPath, AttestationVerifierTokenFile)
 	data, err := os.ReadFile(filepath)
 	if err != nil {
 		t.Fatalf("Failed to read from %s: %v", filepath, err)


### PR DESCRIPTION
Exporting the filepath and filename will allow the attestation token file to be referenced by other libraries that need it (ex. STET)