### PR TITLE
Revert "Decrease MaxElapsedTime for retry backoff in tests (#337)"

### DIFF
--- a/launcher/container_runner_test.go
+++ b/launcher/container_runner_test.go
@@ -261,7 +261,7 @@ func testRetryPolicyThreeTimes() *backoff.ExponentialBackOff {
 	expBack.RandomizationFactor = 0
 	expBack.Multiplier = 1.5
 	expBack.MaxInterval = 1 * time.Second
-	expBack.MaxElapsedTime = 1251 * time.Millisecond
+	expBack.MaxElapsedTime = 2249 * time.Millisecond
 	return expBack
 }
 


### PR DESCRIPTION
This reverts commit 4a3d6e75a009f647fdc6bb386111d950f2d5ccf3. This commit has made our CI flakey, and we do not need to enable this test internally in g3.