### PR TITLE
[launcher] Fix token directory permission

### DIFF
--- a/launcher/container_runner.go
+++ b/launcher/container_runner.go
@@ -406,7 +406,7 @@ func (r *ContainerRunner) fetchAndWriteToken(ctx context.Context) error {
 // retry specifies the refresher goroutine's retry policy.
 func (r *ContainerRunner) fetchAndWriteTokenWithRetry(ctx context.Context,
 	retry *backoff.ExponentialBackOff) error {
-	if err := os.MkdirAll(hostTokenPath, 0744); err != nil {
+	if err := os.MkdirAll(hostTokenPath, 0755); err != nil {
 		return err
 	}
 	duration, err := r.refreshToken(ctx)


### PR DESCRIPTION
Current token directory has permission "drw-r--r--", so only root can access the token file inside. This is fine if the container process is run as root. But if the container process is run as a non-root user, it won't be able to access the token file.

Change the permission so any process can access the token file.

Changing the permission of "/tmp/container_runner" directory "drw-r-xr-x"