### PR TITLE
Add launcherfile package for path and file consts

### DIFF
--- a/launcher/container_runner_test.go
+++ b/launcher/container_runner_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/containerd/containerd/namespaces"
 	"github.com/golang-jwt/jwt/v4"
 	"github.com/google/go-tpm-tools/cel"
+	"github.com/google/go-tpm-tools/launcher/launcherfile"
 	"github.com/google/go-tpm-tools/launcher/spec"
 	"golang.org/x/oauth2"
 	"google.golang.org/api/option"
@@ -108,7 +109,7 @@ func TestRefreshToken(t *testing.T) {
 		logger: log.Default(),
 	}
 
-	if err := os.MkdirAll(hostTokenPath, 0744); err != nil {
+	if err := os.MkdirAll(launcherfile.HostTmpPath, 0744); err != nil {
 		t.Fatalf("Error creating host token path directory: %v", err)
 	}
 
@@ -117,7 +118,7 @@ func TestRefreshToken(t *testing.T) {
 		t.Fatalf("refreshToken returned with error: %v", err)
 	}
 
-	filepath := path.Join(hostTokenPath, AttestationVerifierTokenFile)
+	filepath := path.Join(launcherfile.HostTmpPath, launcherfile.AttestationVerifierTokenFilename)
 	data, err := os.ReadFile(filepath)
 	if err != nil {
 		t.Fatalf("Failed to read from %s: %v", filepath, err)
@@ -134,7 +135,7 @@ func TestRefreshToken(t *testing.T) {
 }
 
 func TestRefreshTokenError(t *testing.T) {
-	if err := os.MkdirAll(hostTokenPath, 0744); err != nil {
+	if err := os.MkdirAll(launcherfile.HostTmpPath, 0744); err != nil {
 		t.Fatalf("Error creating host token path directory: %v", err)
 	}
 
@@ -194,7 +195,7 @@ func TestFetchAndWriteTokenSucceeds(t *testing.T) {
 		t.Fatalf("fetchAndWriteToken failed: %v", err)
 	}
 
-	filepath := path.Join(hostTokenPath, AttestationVerifierTokenFile)
+	filepath := path.Join(launcherfile.HostTmpPath, launcherfile.AttestationVerifierTokenFilename)
 	data, err := os.ReadFile(filepath)
 	if err != nil {
 		t.Fatalf("Failed to read from %s: %v", filepath, err)
@@ -228,7 +229,7 @@ func TestTokenIsNotChangedIfRefreshFails(t *testing.T) {
 		t.Fatalf("fetchAndWriteToken failed: %v", err)
 	}
 
-	filepath := path.Join(hostTokenPath, AttestationVerifierTokenFile)
+	filepath := path.Join(launcherfile.HostTmpPath, launcherfile.AttestationVerifierTokenFilename)
 	data, err := os.ReadFile(filepath)
 	if err != nil {
 		t.Fatalf("Failed to read from %s: %v", filepath, err)
@@ -306,7 +307,7 @@ func testRetryPolicyWithNTries(t *testing.T, numTries int, expectRefresh bool) {
 	if err := runner.fetchAndWriteTokenWithRetry(ctx, testRetryPolicyThreeTimes()); err != nil {
 		t.Fatalf("fetchAndWriteTokenWithRetry failed: %v", err)
 	}
-	filepath := path.Join(hostTokenPath, AttestationVerifierTokenFile)
+	filepath := path.Join(launcherfile.HostTmpPath, launcherfile.AttestationVerifierTokenFilename)
 	data, err := os.ReadFile(filepath)
 	if err != nil {
 		t.Fatalf("failed to read from %s: %v", filepath, err)
@@ -360,7 +361,7 @@ func TestFetchAndWriteTokenWithTokenRefresh(t *testing.T) {
 		t.Fatalf("fetchAndWriteToken failed: %v", err)
 	}
 
-	filepath := path.Join(hostTokenPath, AttestationVerifierTokenFile)
+	filepath := path.Join(launcherfile.HostTmpPath, launcherfile.AttestationVerifierTokenFilename)
 	data, err := os.ReadFile(filepath)
 	if err != nil {
 		t.Fatalf("Failed to read from %s: %v", filepath, err)

--- a/launcher/launcherfile/launcherfile.go
+++ b/launcher/launcherfile/launcherfile.go
@@ -1,0 +1,12 @@
+// Package launcherfile contains functions and constants for interacting with
+// launcher files.
+package launcherfile
+
+const (
+	// HostTmpPath defined the directory in the host that will store attestation tokens
+	HostTmpPath = "/tmp/container_launcher/"
+	// ContainerRuntimeMountPath defined the directory in the container stores attestation tokens
+	ContainerRuntimeMountPath = "/run/container_launcher/"
+	// AttestationVerifierTokenFilename defines the name of the file the attestation token is stored in.
+	AttestationVerifierTokenFilename = "attestation_verifier_claims_token"
+)


### PR DESCRIPTION
This pulls out consts in container_runner.go used by different packages.