### PR TITLE
Temporarily remove Windows from .goreleaser.yaml

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,7 +1,8 @@
 builds:
   - goos:
       - linux
-      - windows
+      # Windows is currently broken since the go-tdx-guest dependency doesn't implement OpenDevice for Windows.
+      # - windows
       - darwin
     goarch:
       - amd64


### PR DESCRIPTION
The releaser is failing for v0.4.1: https://github.com/google/go-tpm-tools/actions/runs/6192784267/job/16813522908.

This is because go-tdx-guest doesn't have a Windows implementation (client_windows.go) here: https://github.com/google/go-tdx-guest/tree/944015509c8414790e385d97e6506cd35d66f763/client.