### PR TITLE
Fix flakey cloud logging test

### DIFF
--- a/launcher/image/test/scripts/test_launcher_workload_cloudlogging.sh
+++ b/launcher/image/test/scripts/test_launcher_workload_cloudlogging.sh
@@ -2,6 +2,9 @@
 set -euo pipefail
 source util/read_cloud_logging.sh
 
+# Allow VM some time to boot and write to cloud logging.
+sleep 120
+
 # This test requires the workload to run and print
 # corresponding messages to cloud logging.
 CLOUD_LOGGING_OUTPUT=$(read_cloud_logging $1) 


### PR DESCRIPTION
The basic workload cloud logging test does not have some wait time for the workload to write to cloud logging, so it consistently fails.