### PR TITLE
Add CloudBuild steps to run image tests against the signatures discovery feature

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -154,7 +154,34 @@ steps:
     gcloud builds submit --config=test_log_redirection.yaml --region us-west1 \
       --substitutions _HARDENED_IMAGE_NAME=${OUTPUT_IMAGE_PREFIX}-hardened-${OUTPUT_IMAGE_SUFFIX},_IMAGE_PROJECT=${PROJECT_ID}
     exit
-
+- name: 'gcr.io/cloud-builders/gcloud'
+  id: HardenedDiscoverContainerSignatureTests
+  waitFor: ['HardenedImageBuild']
+  env:
+  - 'OUTPUT_IMAGE_PREFIX=$_OUTPUT_IMAGE_PREFIX'
+  - 'OUTPUT_IMAGE_SUFFIX=$_OUTPUT_IMAGE_SUFFIX'
+  - 'PROJECT_ID=$PROJECT_ID'
+  script: |
+    #!/usr/bin/env bash
+    cd launcher/image/test
+    echo "running hardened image container signature tests on ${OUTPUT_IMAGE_PREFIX}-hardened-${OUTPUT_IMAGE_SUFFIX}"
+    gcloud builds submit --config=test_discover_signatures.yaml --region us-west1 \
+      --substitutions _IMAGE_NAME=${OUTPUT_IMAGE_PREFIX}-hardened-${OUTPUT_IMAGE_SUFFIX},_IMAGE_PROJECT=${PROJECT_ID},_SIGNATURE_REPO=us-docker.pkg.dev/confidential-space-images-dev/cs-cosign-tests/hardened
+    exit
+- name: 'gcr.io/cloud-builders/gcloud'
+  id: DebugDiscoverContainerSignatureTests
+  waitFor: ['DebugImageBuild']
+  env:
+  - 'OUTPUT_IMAGE_PREFIX=$_OUTPUT_IMAGE_PREFIX'
+  - 'OUTPUT_IMAGE_SUFFIX=$_OUTPUT_IMAGE_SUFFIX'
+  - 'PROJECT_ID=$PROJECT_ID'
+  script: |
+    #!/usr/bin/env bash
+    cd launcher/image/test
+    echo "running debug image container signature tests on ${OUTPUT_IMAGE_PREFIX}-debug-${OUTPUT_IMAGE_SUFFIX}"
+    gcloud builds submit --config=test_discover_signatures.yaml --region us-west1 \
+      --substitutions _IMAGE_NAME=${OUTPUT_IMAGE_PREFIX}-debug-${OUTPUT_IMAGE_SUFFIX},_IMAGE_PROJECT=${PROJECT_ID},_SIGNATURE_REPO=us-docker.pkg.dev/confidential-space-images-dev/cs-cosign-tests/debug
+    exit
 
 options:
   pool:

--- a/launcher/image/test/scripts/test_launcher_workload_discover_signatures.sh
+++ b/launcher/image/test/scripts/test_launcher_workload_discover_signatures.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+set -euxo pipefail
+source util/read_serial.sh
+
+# This test requires the workload to run and printing
+# corresponding messages to the serial console.
+SERIAL_OUTPUT=$(read_serial $1 $2) 
+print_serial=false
+
+if echo $SERIAL_OUTPUT | grep -q 'Found container image signatures'
+then
+    echo "- container image signatures found"
+else
+    echo "FAILED: container image signatures not found"
+    echo 'TEST FAILED.' > /workspace/status.txt
+    print_serial=true
+fi
+
+if $print_serial; then
+    echo $SERIAL_OUTPUT
+fi

--- a/launcher/image/test/test_discover_signatures.yaml
+++ b/launcher/image/test/test_discover_signatures.yaml
@@ -1,0 +1,69 @@
+substitutions:
+  '_IMAGE_NAME': ''
+  '_IMAGE_PROJECT': ''
+  '_CLEANUP': 'true'
+  '_VM_NAME_PREFIX': 'discover-signatures'
+  '_ZONE': 'us-west1-a'
+  '_WORKLOAD_IMAGE': 'us-west1-docker.pkg.dev/confidential-space-images-dev/cs-integ-test-images/basic-test:latest'
+  '_SIGNATURE_REPO': 'us-docker.pkg.dev/confidential-space-images-dev/cs-cosign-tests/hardened'
+
+steps:
+- name: 'gcr.io/projectsigstore/cosign:v2.2.0'
+  id: SignContainer
+  entrypoint: 'sh'
+  env:
+  - 'BUILD_ID=$BUILD_ID'
+  args:
+  - -c
+  - |
+    # Unpadded base64 encoding on the CloudKMS public key
+    pub=$(cosign public-key --key gcpkms://projects/confidential-space-images-dev/locations/global/keyRings/cosign-test/cryptoKeys/ecdsa/cryptoKeyVersions/1 | openssl base64)
+    pub=$(echo $pub | tr -d '[:space:]' | sed 's/[=]*$//')
+    # Use cosign sign
+    export COSIGN_REPOSITORY=${_SIGNATURE_REPO}
+    cosign sign --key gcpkms://projects/confidential-space-images-dev/locations/global/keyRings/cosign-test/cryptoKeys/ecdsa/cryptoKeyVersions/1 ${_WORKLOAD_IMAGE} -a dev.cosignproject.cosign/sigalg=ECDSA_P256_SHA256 -a dev.cosignproject.cosign/pub=$pub
+- name: 'gcr.io/cloud-builders/gcloud'
+  id: CreateVM
+  entrypoint: 'bash'
+  env:
+  - 'BUILD_ID=$BUILD_ID'
+  args: ['create_vm.sh','-i', '${_IMAGE_NAME}',
+          '-p', '${_IMAGE_PROJECT}',
+          '-m', 'tee-image-reference=${_WORKLOAD_IMAGE},tee-container-log-redirect=true,tee-signed-image-repos=${_SIGNATURE_REPO},tee-env-ALLOWED_OVERRIDE=overridden,tee-cmd=["newCmd"]',
+          '-n', '${_VM_NAME_PREFIX}-${BUILD_ID}',
+          '-z', '${_ZONE}',
+        ]
+- name: 'gcr.io/cloud-builders/gcloud'
+  id: BasicDiscoverSignaturesTest
+  entrypoint: 'bash'
+  args: ['scripts/test_launcher_workload_discover_signatures.sh', '${_VM_NAME_PREFIX}-${BUILD_ID}', '${_ZONE}']
+- name: 'gcr.io/cloud-builders/gcloud'
+  id: CleanUp
+  entrypoint: 'bash'
+  env:
+  - 'CLEANUP=$_CLEANUP'
+  args: ['cleanup.sh', '${_VM_NAME_PREFIX}-${BUILD_ID}', '${_ZONE}']
+- name: 'gcr.io/cloud-builders/gcloud'
+  id: DeleteContainerSignatures
+  env:
+  - 'BUILD_ID=$BUILD_ID'
+  entrypoint: 'bash'
+  args:
+  - -c
+  - |
+    echo "Deleting container signatures..."
+    digest=$(gcloud artifacts docker images describe ${_WORKLOAD_IMAGE} --format 'value(image_summary.digest)')
+    tag=${digest/":"/"-"}.sig
+    # Delete container signature by its tag
+    gcloud artifacts docker images delete -q ${_SIGNATURE_REPO}:${tag}
+# Must come after cleanup.
+- name: 'gcr.io/cloud-builders/gcloud'
+  id: CheckFailure
+  entrypoint: 'bash'
+  env:
+  - 'BUILD_ID=$BUILD_ID'
+  args: ['check_failure.sh']
+
+options:
+  pool:
+    name: 'projects/confidential-space-images-dev/locations/us-west1/workerPools/cs-image-build-vpc'


### PR DESCRIPTION
Added CloudBuild steps for both hardened image and debug image to run signature discovery tests:
1. use cosign to sign the container,
2. launch a VM with signed container image support,
3. check VM serial logs for any found signatures.