### PR TITLE
Add staticcheck linter to match google3 closer

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,6 +101,10 @@ jobs:
             --max-same-issues=0
             --max-issues-per-linter=0
             --timeout 2m
+      - name: Run staticcheck
+        uses: dominikh/staticcheck-action@v1.2.0
+        with:
+          version: "2022.1.1"
 
   lintc:
     strategy:


### PR DESCRIPTION
Importing this repo into google3 often raises linter issues. The recommended OSS equivalent is staticcheck, so we try to use that to catch issues before import.