### PR TITLE
Changed name of Tdx Test in verify_test.go

### DIFF
--- a/server/verify_test.go
+++ b/server/verify_test.go
@@ -348,7 +348,7 @@ func TestVerifyBasicAttestationWithSevSnp(t *testing.T) {
 	}
 }
 
-func TestVerifyBasicAttestationWithTdx(t *testing.T) {
+func TestBasicAttestationWithTdx(t *testing.T) {
 	rwc := test.GetTPM(t)
 	defer client.CheckedClose(t, rwc)
 


### PR DESCRIPTION
This test should be skipped when snp staging tests are triggered.