### PR TITLE
Update go-sev-guest to v0.9.2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.20
 require (
 	github.com/google/go-attestation v0.5.0
 	github.com/google/go-cmp v0.5.9
-	github.com/google/go-sev-guest v0.8.0
+	github.com/google/go-sev-guest v0.9.2
 	github.com/google/go-tdx-guest v0.2.3-0.20231011100059-4cf02bed9d33
 	github.com/google/go-tpm v0.9.0
 	github.com/google/logger v1.1.1

--- a/go.sum
+++ b/go.sum
@@ -308,8 +308,8 @@ github.com/google/go-licenses v0.0.0-20210329231322-ce1d9163b77d/go.mod h1:+TYOm
 github.com/google/go-querystring v1.0.0/go.mod h1:odCYkC5MyYFN7vkCjXpyrEuKhc/BUO6wN/zVPAxq5ck=
 github.com/google/go-replayers/grpcreplay v0.1.0/go.mod h1:8Ig2Idjpr6gifRd6pNVggX6TC1Zw6Jx74AKp7QNH2QE=
 github.com/google/go-replayers/httpreplay v0.1.0/go.mod h1:YKZViNhiGgqdBlUbI2MwGpq4pXxNmhJLPHQ7cv2b5no=
-github.com/google/go-sev-guest v0.8.0 h1:IIZIqdcMJXgTm1nMvId442OUpYebbWDWa9bi9/lUUwc=
-github.com/google/go-sev-guest v0.8.0/go.mod h1:hc1R4R6f8+NcJwITs0L90fYWTsBpd1Ix+Gur15sqHDs=
+github.com/google/go-sev-guest v0.9.2 h1:GrExeOl8V8cs/2fXWYoAtG3Bh+Mvz3ilqHlv4H034p8=
+github.com/google/go-sev-guest v0.9.2/go.mod h1:hc1R4R6f8+NcJwITs0L90fYWTsBpd1Ix+Gur15sqHDs=
 github.com/google/go-tdx-guest v0.2.3-0.20231011100059-4cf02bed9d33 h1:lRlUusuieEuqljjihCXb+Mr73VNitOYPJYWXzJKtBWs=
 github.com/google/go-tdx-guest v0.2.3-0.20231011100059-4cf02bed9d33/go.mod h1:84ut3oago/BqPXD4ppiGXdkZNW3WFPkcyAO4my2hXdY=
 github.com/google/go-tpm v0.9.0 h1:sQF6YqWMi+SCXpsmS3fd21oPy/vSddwZry4JnmltHVk=

--- a/launcher/spec/launch_policy.go
+++ b/launcher/spec/launch_policy.go
@@ -26,13 +26,14 @@ func toLogRedirectPolicy(s string) (logRedirectPolicy, error) {
 	s = strings.ToLower(s)
 	s = strings.TrimSpace(s)
 
-	if s == "always" {
+	switch s {
+	case "always":
 		return always, nil
-	} else if s == "never" {
+	case "never":
 		return never, nil
-	} else if s == "debugonly" {
+	case "debugonly":
 		return debugOnly, nil
-	} else {
+	default:
 		return 0, fmt.Errorf("not a valid LogRedirectPolicy %s (must be one of [always, never, debugonly])", s)
 	}
 }

--- a/server/verify_test.go
+++ b/server/verify_test.go
@@ -17,6 +17,7 @@ import (
 	"time"
 
 	"github.com/google/go-cmp/cmp"
+	sabi "github.com/google/go-sev-guest/abi"
 	sgclient "github.com/google/go-sev-guest/client"
 	sgtest "github.com/google/go-sev-guest/testing"
 	testclient "github.com/google/go-sev-guest/testing/client"
@@ -1050,6 +1051,7 @@ func TestVerifyAttestationWithSevSnp(t *testing.T) {
 		opts    VerifyOpts
 		wantErr string
 	}
+	milanB1 := sabi.DefaultSevProduct()
 	tcs := []testCase{
 		{
 			name: "Happy path",
@@ -1061,6 +1063,7 @@ func TestVerifyAttestationWithSevSnp(t *testing.T) {
 					Verification: &sv.Options{
 						Getter:       kdsGetter,
 						TrustedRoots: goodSnpRoot,
+						Product:      milanB1,
 					},
 				},
 			},
@@ -1075,6 +1078,7 @@ func TestVerifyAttestationWithSevSnp(t *testing.T) {
 					Verification: &sv.Options{
 						Getter:       kdsGetter,
 						TrustedRoots: goodSnpRoot,
+						Product:      milanB1,
 					},
 				},
 			},
@@ -1090,6 +1094,7 @@ func TestVerifyAttestationWithSevSnp(t *testing.T) {
 					Verification: &sv.Options{
 						Getter:       kdsGetter,
 						TrustedRoots: badSnpRoot,
+						Product:      milanB1,
 					},
 				},
 			},
@@ -1112,6 +1117,7 @@ func TestVerifyAttestationWithSevSnp(t *testing.T) {
 					Verification: &sv.Options{
 						Getter:       kdsGetter,
 						TrustedRoots: goodSnpRoot,
+						Product:      milanB1,
 					},
 				},
 			},


### PR DESCRIPTION
This release includes improved validation support for machine stepping validation against the VCEK certificate.