### PR TITLE
Customize node-problem-detector for CS

### DIFF
--- a/launcher/image/entrypoint.sh
+++ b/launcher/image/entrypoint.sh
@@ -6,6 +6,8 @@ main() {
   # Override default fluent-bit config.
   cp /usr/share/oem/confidential_space/fluent-bit-cs.conf /etc/fluent-bit/fluent-bit.conf
 
+  # Override default system-stats-monitor.json for node-problem-detector.
+  cp /usr/share/oem/confidential_space/system-stats-monitor-cs.json /etc/node_problem_detector/system-stats-monitor.json
   systemctl daemon-reload
   systemctl enable container-runner.service
   systemctl start container-runner.service

--- a/launcher/image/preload.sh
+++ b/launcher/image/preload.sh
@@ -66,12 +66,19 @@ configure_cloud_logging() {
   cp fluent-bit-cs.conf "${CS_PATH}"
 }
 
+configure_node_problem_detector() {
+  # Copy CS-specific node-problem-detector config to OEM partition.
+  cp system-stats-monitor-cs.json "${CS_PATH}"
+}
+
 configure_systemd_units_for_debug() {
   configure_cloud_logging
+  configure_node_problem_detector
 }
 configure_systemd_units_for_hardened() {
   configure_necessary_systemd_units
   configure_cloud_logging
+  configure_node_problem_detector
   # Make entrypoint (via cloud-init) the default unit.
   set_default_boot_target "cloud-final.service"
 
@@ -85,7 +92,6 @@ configure_systemd_units_for_hardened() {
   disable_unit "konlet-startup.service"
   disable_unit "crash-reporter.service"
   disable_unit "device_policy_manager.service"
-  disable_unit "node-problem-detector.service"
   disable_unit "docker-events-collector-fluent-bit.service"
   disable_unit "sshd.service"
   disable_unit "var-lib-toolbox.mount"

--- a/launcher/image/system-stats-monitor-cs.json
+++ b/launcher/image/system-stats-monitor-cs.json
@@ -1,0 +1,10 @@
+{
+  "memory": {
+    "metricsConfigs": {
+      "memory/bytes_used": {
+        "displayName": "memory/bytes_used"
+      }
+    }
+  },
+  "invokeInterval": "60s"
+}


### PR DESCRIPTION
The first step to enable memory monitoring in CS (see [go/monitoring-enablement-in-hardened-image-1-pager](http://goto.google.com/monitoring-enablement-in-hardened-image-1-pager)).
This PR includes changes to:
1. Unmask `node-problem-detector.service` for hardened image.
2. Override the default config file [system-stats-monitor.json](https://cos.googlesource.com/cos/overlays/board-overlays/+/refs/heads/master/project-lakitu/app-admin/node-problem-detector/files/system-stats-monitor.json) to collect `memory/bytes_used` metrics only for CS.
3. Configure `preload.sh` to allow hardened/debug images have this change. 