### PR TITLE
Handle launcher exit code checking during deferral evaluation

### DIFF
--- a/launcher/launcher/main.go
+++ b/launcher/launcher/main.go
@@ -57,7 +57,9 @@ func main() {
 	logger = log.Default()
 	// log.Default() outputs to stderr; change to stdout.
 	log.SetOutput(os.Stdout)
-	defer os.Exit(exitCode)
+	defer func() {
+		os.Exit(exitCode)
+	}()
 
 	serialConsole, err := os.OpenFile("/dev/console", os.O_WRONLY, 0)
 	if err != nil {


### PR DESCRIPTION
The previous fix in https://github.com/google/go-tpm-tools/pull/384 was incomplete due to variable scoping. Moving OS exit into a function to be called at exit allows exitCode variable to be referenced at that time, instead of when the defer statement was called.