### PR TITLE
[launcher] Add test to check VM alive

### DIFF
--- a/launcher/image/exit_script.sh
+++ b/launcher/image/exit_script.sh
@@ -11,4 +11,3 @@ then
 	# poweroff after 2 min
 	shutdown --poweroff +2
 fi
-

--- a/launcher/image/test/scripts/test_mds_var_change.sh
+++ b/launcher/image/test/scripts/test_mds_var_change.sh
@@ -4,9 +4,9 @@ source util/read_serial.sh
 
 SERIAL_OUTPUT=$(read_serial $1 $2) 
 # Check MDS variables haven't been changed to use the wrong workload image.
-if echo $SERIAL_OUTPUT | grep -v 'Hello from Cloud Run!' 
+if echo $SERIAL_OUTPUT | grep -v 'Hello from Cloud Run!'
 then 
-    echo "- verified changed MDS vars have no effect" 
+    echo "- verified changed MDS vars have no effect"
 else
     echo "FAILED: MDS variables changed"
     echo 'TEST FAILED' > /workspace/status.txt

--- a/launcher/image/test/test_debug_cloudbuild.yaml
+++ b/launcher/image/test/test_debug_cloudbuild.yaml
@@ -40,6 +40,27 @@ steps:
   entrypoint: 'bash'
   args: ['scripts/test_mds_var_change.sh', '${_VM_NAME_PREFIX}-${BUILD_ID}', '${_ZONE}']
 - name: 'gcr.io/cloud-builders/gcloud'
+  id: CheckDebugVMAliveAfterLauncherExits
+  script: |
+    #!/usr/bin/env bash
+    set -euo pipefail
+
+    # Waiting for 2.5 mins, after the workload is finished.
+    # If using a debug image, the VM should still be accessible after
+    # the workload exit normally.
+    # Check the script: launcher/image/exit_script.sh for detail logic.
+    sleep 150
+
+    result=$(gcloud compute instances list --filter="name=(${_VM_NAME_PREFIX}-${BUILD_ID})" --zones=${_ZONE} --format="value(STATUS)")
+
+    if [[ "${result}" == "RUNNING" ]]; then
+        echo "verified debug VM is still running after 2.5 mins"
+    else
+        echo "FAILED: expect debug VM to be still running"
+        echo "TEST FAILED. Expect debug VM to be still running" > /workspace/status.txt
+    fi
+  automapSubstitutions: true
+- name: 'gcr.io/cloud-builders/gcloud'
   id: CleanUp
   entrypoint: 'bash'
   env:

--- a/launcher/image/test/util/read_serial.sh
+++ b/launcher/image/test/util/read_serial.sh
@@ -14,7 +14,7 @@ read_serial() {
   echo "Reading serial console..."
   while [ -s /workspace/next_start.txt ]; do
     if [[ $(date -u +%s) -ge $endtime ]]; then
-      echo "timed out reading serial console" 
+      echo "timed out reading serial console, or the workload is running more than ${timeout}"
       break
     fi
 


### PR DESCRIPTION
Add a test to check VM remain alive after workload exit in a CS debug VM.

The test currently is failing as expected. Once #392 is merged, the new test here should pass.