### PR TITLE
Fix teeserver context reset issue & add container signature cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,8 +72,11 @@ jobs:
         run: |
           GO_EXECUTABLE_PATH=$(which go)
           sudo $GO_EXECUTABLE_PATH test -v -run "TestFetchImageSignaturesDockerPublic" ./launcher
+      - name: Run specific tests to capture potential data race
+        run: go test ./launcher/agent -race -run TestCacheConcurrentSetGet
+        if: (runner.os == 'Linux' || runner.os == 'macOS') && matrix.architecture == 'x64'
       - name: Test all modules
-        run: go test -v ./... ./cmd/... ./launcher/...
+        run: go test -v ./... ./cmd/... ./launcher/... -skip=TestCacheConcurrentSetGet
 
   lint:
     strategy:

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -228,7 +228,20 @@ steps:
     gcloud builds submit --config=test_memory_monitoring.yaml --region us-west1 \
       --substitutions _IMAGE_NAME=${OUTPUT_IMAGE_PREFIX}-hardened-${OUTPUT_IMAGE_SUFFIX},_IMAGE_PROJECT=${PROJECT_ID}
     exit
-
+- name: 'gcr.io/cloud-builders/gcloud'
+  id: ODAWithSignedContainerTest
+  waitFor: ['HardenedImageBuild']
+  env:
+  - 'OUTPUT_IMAGE_PREFIX=$_OUTPUT_IMAGE_PREFIX'
+  - 'OUTPUT_IMAGE_SUFFIX=$_OUTPUT_IMAGE_SUFFIX'
+  - 'PROJECT_ID=$PROJECT_ID'
+  script: |
+    #!/usr/bin/env bash
+    cd launcher/image/test
+    echo "running ODA and signed container tests on ${OUTPUT_IMAGE_PREFIX}-hardened-${OUTPUT_IMAGE_SUFFIX}"
+    gcloud builds submit --config=test_oda_with_signed_container.yaml --region us-west1 \
+      --substitutions _IMAGE_NAME=${OUTPUT_IMAGE_PREFIX}-hardened-${OUTPUT_IMAGE_SUFFIX},_IMAGE_PROJECT=${PROJECT_ID}
+    exit
 options:
   pool:
     name: 'projects/confidential-space-images-dev/locations/us-west1/workerPools/cs-image-build-vpc'

--- a/launcher/container_runner.go
+++ b/launcher/container_runner.go
@@ -502,7 +502,7 @@ func (r *ContainerRunner) Run(ctx context.Context) error {
 	// create and start the TEE server behind the experiment
 	if r.launchSpec.Experiments.EnableOnDemandAttestation {
 		r.logger.Println("EnableOnDemandAttestation is enabled: initializing TEE server.")
-		teeServer, err := teeserver.New(path.Join(launcherfile.HostTmpPath, teeServerSocket), r.attestAgent, r.logger)
+		teeServer, err := teeserver.New(ctx, path.Join(launcherfile.HostTmpPath, teeServerSocket), r.attestAgent, r.logger)
 		if err != nil {
 			return fmt.Errorf("failed to create the TEE server: %v", err)
 		}

--- a/launcher/container_runner.go
+++ b/launcher/container_runner.go
@@ -346,6 +346,9 @@ func (r *ContainerRunner) measureContainerClaims(ctx context.Context) error {
 // The token file will be written to a tmp file and then renamed.
 func (r *ContainerRunner) refreshToken(ctx context.Context) (time.Duration, error) {
 	r.logger.Print("refreshing attestation verifier OIDC token")
+	if err := r.attestAgent.Refresh(ctx); err != nil {
+		return 0, fmt.Errorf("failed to refresh attestation agent: %v", err)
+	}
 	// request a default token
 	token, err := r.attestAgent.Attest(ctx, agent.AttestAgentOpts{})
 	if err != nil {

--- a/launcher/image/test/scripts/test_launcher_workload_discover_signatures.sh
+++ b/launcher/image/test/scripts/test_launcher_workload_discover_signatures.sh
@@ -7,11 +7,12 @@ source util/read_serial.sh
 SERIAL_OUTPUT=$(read_serial $1 $2) 
 print_serial=false
 
-if echo $SERIAL_OUTPUT | grep -q 'Found container image signatures'
-then
-    echo "- container image signatures found"
+# Check how many times "Found container image signatures" is being logged.
+counts=$(echo $SERIAL_OUTPUT | grep -o 'Found container image signatures' | wc -l)
+if [ $counts -eq $3 ]; then
+    echo "- container image signatures found with expected counts: $3"
 else
-    echo "FAILED: container image signatures not found"
+    echo "FAILED: container image signatures want $3 counts, but got $counts"
     echo 'TEST FAILED.' > /workspace/status.txt
     print_serial=true
 fi

--- a/launcher/image/test/scripts/test_launcher_workload_discover_signatures.sh
+++ b/launcher/image/test/scripts/test_launcher_workload_discover_signatures.sh
@@ -8,11 +8,11 @@ SERIAL_OUTPUT=$(read_serial $1 $2)
 print_serial=false
 
 # Check how many times "Found container image signatures" is being logged.
-counts=$(echo $SERIAL_OUTPUT | grep -o 'Found container image signatures' | wc -l)
-if [ $counts -eq $3 ]; then
-    echo "- container image signatures found with expected counts: $3"
+counts=$(echo $SERIAL_OUTPUT | grep -o "$3" | wc -l)
+if [ $counts -eq $4 ]; then
+    echo "- container image signatures pattern [$3] found with expected counts: $4"
 else
-    echo "FAILED: container image signatures want $3 counts, but got $counts"
+    echo "FAILED: container image signatures want $4 counts, but got $counts"
     echo 'TEST FAILED.' > /workspace/status.txt
     print_serial=true
 fi

--- a/launcher/image/test/test_discover_signatures.yaml
+++ b/launcher/image/test/test_discover_signatures.yaml
@@ -36,7 +36,7 @@ steps:
 - name: 'gcr.io/cloud-builders/gcloud'
   id: BasicDiscoverSignaturesTest
   entrypoint: 'bash'
-  args: ['scripts/test_launcher_workload_discover_signatures.sh', '${_VM_NAME_PREFIX}-${BUILD_ID}', '${_ZONE}', '1']
+  args: ['scripts/test_launcher_workload_discover_signatures.sh', '${_VM_NAME_PREFIX}-${BUILD_ID}', '${_ZONE}', 'Found container image signatures', '1']
 - name: 'gcr.io/cloud-builders/gcloud'
   id: CleanUp
   entrypoint: 'bash'

--- a/launcher/image/test/test_oda_with_signed_container.yaml
+++ b/launcher/image/test/test_oda_with_signed_container.yaml
@@ -2,9 +2,9 @@ substitutions:
   '_IMAGE_NAME': ''
   '_IMAGE_PROJECT': ''
   '_CLEANUP': 'true'
-  '_VM_NAME_PREFIX': 'discover-signatures'
-  '_ZONE': 'us-west1-a'
-  '_WORKLOAD_IMAGE': 'us-west1-docker.pkg.dev/confidential-space-images-dev/cs-integ-test-images/basic-test:latest'
+  '_VM_NAME_PREFIX': 'oda-signedcontainer'
+  '_ZONE': 'us-east1-b'
+  '_WORKLOAD_IMAGE': 'us-west1-docker.pkg.dev/confidential-space-images-dev/cs-integ-test-images/ipc/happypath:latest'
   '_SIGNATURE_REPO': 'us-docker.pkg.dev/confidential-space-images-dev/cs-cosign-tests/hardened'
 
 steps:
@@ -34,9 +34,15 @@ steps:
           '-z', '${_ZONE}',
         ]
 - name: 'gcr.io/cloud-builders/gcloud'
+  id: TestCustomToken
+  entrypoint: 'bash'
+  args: ['scripts/test_custom_token.sh', "true", '${_VM_NAME_PREFIX}-${BUILD_ID}', '${_ZONE}']
+- name: 'gcr.io/cloud-builders/gcloud'
   id: BasicDiscoverSignaturesTest
   entrypoint: 'bash'
-  args: ['scripts/test_launcher_workload_discover_signatures.sh', '${_VM_NAME_PREFIX}-${BUILD_ID}', '${_ZONE}', '1']
+  # Check how many times `Found container image signatures` is being logged. 
+  # Since signature discovery will occur on refresh the default token, and on teeserver receiving ODA requests, so the expected number should be 2.
+  args: ['scripts/test_launcher_workload_discover_signatures.sh', '${_VM_NAME_PREFIX}-${BUILD_ID}', '${_ZONE}', '2']
 - name: 'gcr.io/cloud-builders/gcloud'
   id: CleanUp
   entrypoint: 'bash'

--- a/launcher/image/test/test_oda_with_signed_container.yaml
+++ b/launcher/image/test/test_oda_with_signed_container.yaml
@@ -4,24 +4,12 @@ substitutions:
   '_CLEANUP': 'true'
   '_VM_NAME_PREFIX': 'oda-signedcontainer'
   '_ZONE': 'us-east1-b'
-  '_WORKLOAD_IMAGE': 'us-west1-docker.pkg.dev/confidential-space-images-dev/cs-integ-test-images/ipc/happypath:latest'
-  '_SIGNATURE_REPO': 'us-docker.pkg.dev/confidential-space-images-dev/cs-cosign-tests/hardened'
+  # If the workload image changes, the commit author should change the cosign signature as well to not break tests.
+  '_WORKLOAD_IMAGE': 'us-west1-docker.pkg.dev/confidential-space-images-dev/cs-integ-test-images/ipc/happypath@sha256:999831a7b8f8afd323e2359f3c1192206be2aa1d4f3b19f0739eff5f01f83b9e'
+  '_SIGNATURE_REPO': 'us-docker.pkg.dev/confidential-space-images-dev/cs-cosign-tests/oda'
+  '_EXPECTED_SIG': 'EQCIBIEAGtAqxzhMqq2jhs76KJZaD5VXvKV93yotPUtD7yDAiAFS4zFyiRicrhzeS1nmb9SpuAtDRSwv1lWaSWxWiwLTw=='
 
 steps:
-- name: 'gcr.io/projectsigstore/cosign:v2.2.0'
-  id: SignContainer
-  entrypoint: 'sh'
-  env:
-  - 'BUILD_ID=$BUILD_ID'
-  args:
-  - -c
-  - |
-    # Unpadded base64 encoding on the CloudKMS public key
-    pub=$(cosign public-key --key gcpkms://projects/confidential-space-images-dev/locations/global/keyRings/cosign-test/cryptoKeys/ecdsa/cryptoKeyVersions/1 | openssl base64)
-    pub=$(echo $pub | tr -d '[:space:]' | sed 's/[=]*$//')
-    # Use cosign sign
-    export COSIGN_REPOSITORY=${_SIGNATURE_REPO}
-    cosign sign --key gcpkms://projects/confidential-space-images-dev/locations/global/keyRings/cosign-test/cryptoKeys/ecdsa/cryptoKeyVersions/1 ${_WORKLOAD_IMAGE} -a dev.cosignproject.cosign/sigalg=ECDSA_P256_SHA256 -a dev.cosignproject.cosign/pub=$pub
 - name: 'gcr.io/cloud-builders/gcloud'
   id: CreateVM
   entrypoint: 'bash'
@@ -40,28 +28,16 @@ steps:
 - name: 'gcr.io/cloud-builders/gcloud'
   id: BasicDiscoverSignaturesTest
   entrypoint: 'bash'
-  # Check how many times `Found container image signatures` is being logged. 
-  # Since signature discovery will occur on refresh the default token, and on teeserver receiving ODA requests, so the expected number should be 2.
-  args: ['scripts/test_launcher_workload_discover_signatures.sh', '${_VM_NAME_PREFIX}-${BUILD_ID}', '${_ZONE}', '2']
+  # Check how many times container image signatures is being logged. 
+  # Since signature logging will occur on refresh the default token, and on attest agent calling the `Attest` method, so the expected number should be 3.
+  # This also checks the fetched signatures are the same.
+  args: ['scripts/test_launcher_workload_discover_signatures.sh', '${_VM_NAME_PREFIX}-${BUILD_ID}', '${_ZONE}', '${_EXPECTED_SIG}', '3']
 - name: 'gcr.io/cloud-builders/gcloud'
   id: CleanUp
   entrypoint: 'bash'
   env:
   - 'CLEANUP=$_CLEANUP'
   args: ['cleanup.sh', '${_VM_NAME_PREFIX}-${BUILD_ID}', '${_ZONE}']
-- name: 'gcr.io/cloud-builders/gcloud'
-  id: DeleteContainerSignatures
-  env:
-  - 'BUILD_ID=$BUILD_ID'
-  entrypoint: 'bash'
-  args:
-  - -c
-  - |
-    echo "Deleting container signatures..."
-    digest=$(gcloud artifacts docker images describe ${_WORKLOAD_IMAGE} --format 'value(image_summary.digest)')
-    tag=${digest/":"/"-"}.sig
-    # Delete container signature by its tag
-    gcloud artifacts docker images delete -q ${_SIGNATURE_REPO}:${tag}
 # Must come after cleanup.
 - name: 'gcr.io/cloud-builders/gcloud'
   id: CheckFailure

--- a/launcher/internal/experiments/experiments.go
+++ b/launcher/internal/experiments/experiments.go
@@ -15,6 +15,7 @@ type Experiments struct {
 	EnableSignedContainerImage bool
 	EnableOnDemandAttestation  bool
 	EnableMemoryMonitoring     bool
+	EnableSignedContainerCache bool
 }
 
 // New takes a filepath, opens the file, and calls ReadJsonInput with the contents

--- a/launcher/teeserver/tee_server_test.go
+++ b/launcher/teeserver/tee_server_test.go
@@ -30,6 +30,10 @@ func (f fakeAttestationAgent) MeasureEvent(c cel.Content) error {
 	return f.measureEventFunc(c)
 }
 
+func (f fakeAttestationAgent) Refresh(_ context.Context) error {
+	return nil
+}
+
 func TestGetDefaultToken(t *testing.T) {
 	tmpDir := t.TempDir()
 	tmpToken := path.Join(tmpDir, launcherfile.AttestationVerifierTokenFilename)


### PR DESCRIPTION
Discussed offline, we decide to introduce container signatures cache to attestation agent.
So we should refresh the signatures cache every time the token refresher goroutine runs (~1/hr), and ODA will only read from the cache.
This PR also includes the following changes:
- fixes teeserver context reset issue
- removes the existing experiment flag `EnableSignedContainerImage`, add a new flag `EnableSignedContainerCache`
