### PR TITLE
Skip tests that call setGCEAKTemplate

### DIFF
--- a/cmd/attest_test.go
+++ b/cmd/attest_test.go
@@ -55,6 +55,8 @@ func GCEAKTemplateRSA() tpm2.Public {
 // Need to call tpm2.NVUndefinespace on the handle with authHandle tpm2.HandlePlatform.
 // e.g defer tpm2.NVUndefineSpace(rwc, "", tpm2.HandlePlatform, tpmutil.Handle(client.GceAKTemplateNVIndexRSA))
 func setGCEAKTemplate(tb testing.TB, rwc io.ReadWriteCloser, algo string, data []byte) error {
+	// Since this mutates the TPM, any tests using real TPMs must skip.
+	test.SkipForRealTPM(tb)
 	var err error
 	idx := tpmutil.Handle(getIndex[algo])
 	if err := tpm2.NVDefineSpace(rwc, tpm2.HandlePlatform, idx,


### PR DESCRIPTION
This resulted in failing tests on real GCE VMs that already have the AK template. A real testcase is a better suited for integration tests instead of unit tests anyway.

# Tested manually on GCE VM:
Failure:
```
sudo /var/lib/google/cmd_nocgo.test -tpm-path /dev/tpmrm0
Error: failed to collect attestation report : provided nonce must not be empty
...
Error: verifying attestation: failed to verify quote: quote extraData [18 52] did not match expected extraData [67 33]
--- FAIL: TestVerifyWithGCEAK (0.01s)
    --- FAIL: TestVerifyWithGCEAK/gceAK:RSA (0.00s)
        attest_test.go:65: NVDefineSpace failed: error code 0x4c : NV Index or persistent object already defined
    --- FAIL: TestVerifyWithGCEAK/gceAK:ECC (0.00s)
        attest_test.go:65: NVDefineSpace failed: error code 0x4c : NV Index or persistent object already defined
Error: failed to open tdx device: could not open Intel TDX guest device at "/dev/tdx_guest": no such file or directory
Error: failed to open sev-snp device: could not open AMD SEV guest device at /dev/sev-guest (see https://github.com/google/go-sev-guest/blob/main/INSTALL.md): no such file or directory
FAIL
```

Passed:
```
sudo /var/lib/google/cmd_fix.test -tpm-path /dev/tpmrm0
Error: failed to collect attestation report : provided nonce must not be empty
Error: invalid argument "12345" for "--nonce" flag: encoding/hex: odd length hex string
Error: fail to unmarshal attestation report: proto: (line 2:1): unknown field: X
Error: fail to unmarshal attestation report: proto: cannot parse invalid wire-format data
Error: format should be either binarypb or textproto
Error: format should be either binarypb or textproto
Error: format should be either binarypb or textproto
Error: format should be either binarypb or textproto
Error: failed to open tdx device: could not open Intel TDX guest device at "/dev/tdx_guest": no such file or directory
Error: failed to open sev-snp device: could not open AMD SEV guest device at /dev/sev-guest (see https://github.com/google/go-sev-guest/blob/main/INSTALL.md): no such file or directory
Error: unsealing data: session 1, error code 0x1d : a policy check failed
Error: unsealing data: failed to certify PCRs: PCR 23 mismatch: expected 12a0883f16abf44dcc4cac1dec108eb99c652fed124c6989eddc811fe8effb64, got ff16f4da375b3138821644093863ead8b357020880335256855afce000eed831
Error: unsealing data: failed to certify PCRs: PCR 23 mismatch: expected ff16f4da375b3138821644093863ead8b357020880335256855afce000eed831, got ed0a8c8c1d22f773942429a11196ff45571ea7a6f51e7909bbc56e89e4457c10
Error: verifying attestation: failed to verify quote: quote extraData [18 52] did not match expected extraData [67 33]
Error: failed to open tdx device: could not open Intel TDX guest device at "/dev/tdx_guest": no such file or directory
Error: failed to open sev-snp device: could not open AMD SEV guest device at /dev/sev-guest (see https://github.com/google/go-sev-guest/blob/main/INSTALL.md): no such file or directory
PASS
```