### PR TITLE
Set all unused parameters as `_` to fix CI lint failure

### DIFF
--- a/client/attest_test.go
+++ b/client/attest_test.go
@@ -63,7 +63,7 @@ func getTestCert(t *testing.T, issuingURL []string, parentCert *x509.Certificate
 func TestFetchIssuingCertificateSucceeds(t *testing.T) {
 	testCA, caKey := getTestCert(t, nil, nil, nil)
 
-	ts := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
+	ts := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, _ *http.Request) {
 		rw.WriteHeader(http.StatusOK)
 		rw.Write(testCA.Raw)
 	}))
@@ -78,7 +78,7 @@ func TestFetchIssuingCertificateSucceeds(t *testing.T) {
 }
 
 func TestFetchIssuingCertificateReturnsErrorIfMalformedCertificateFound(t *testing.T) {
-	ts := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
+	ts := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, _ *http.Request) {
 		rw.WriteHeader(http.StatusOK)
 		rw.Write([]byte("these are some random bytes"))
 	}))
@@ -97,7 +97,7 @@ func TestGetCertificateChainSucceeds(t *testing.T) {
 	// Create CA and corresponding server.
 	testCA, caKey := getTestCert(t, nil, nil, nil)
 
-	caServer := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
+	caServer := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, _ *http.Request) {
 		rw.WriteHeader(http.StatusOK)
 		rw.Write(testCA.Raw)
 	}))
@@ -107,7 +107,7 @@ func TestGetCertificateChainSucceeds(t *testing.T) {
 	// Create intermediate cert and corresponding server.
 	intermediateCert, intermediateKey := getTestCert(t, []string{caServer.URL}, testCA, caKey)
 
-	intermediateServer := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
+	intermediateServer := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, _ *http.Request) {
 		rw.WriteHeader(http.StatusOK)
 		rw.Write(intermediateCert.Raw)
 	}))
@@ -130,7 +130,7 @@ func TestGetCertificateChainSucceeds(t *testing.T) {
 func TestKeyAttestSucceedsWithCertChainRetrieval(t *testing.T) {
 	testCA, caKey := getTestCert(t, nil, nil, nil)
 
-	caServer := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
+	caServer := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, _ *http.Request) {
 		rw.WriteHeader(http.StatusOK)
 		rw.Write(testCA.Raw)
 	}))

--- a/cmd/attest.go
+++ b/cmd/attest.go
@@ -52,7 +52,7 @@ by default rsa is used.
 hardware and guarantees a fresh quote.
 `,
 	Args: cobra.NoArgs,
-	RunE: func(cmd *cobra.Command, args []string) error {
+	RunE: func(*cobra.Command, []string) error {
 
 		rwc, err := openTpm()
 		if err != nil {

--- a/cmd/flush.go
+++ b/cmd/flush.go
@@ -48,7 +48,7 @@ Which handles are flushed depends on the argument passed:
 		return keys
 	}(),
 	Args: cobra.ExactValidArgs(1),
-	RunE: func(cmd *cobra.Command, args []string) error {
+	RunE: func(_ *cobra.Command, args []string) error {
 		rwc, err := openTpm()
 		if err != nil {
 			return err

--- a/cmd/pubkey.go
+++ b/cmd/pubkey.go
@@ -45,7 +45,7 @@ NVDATA instead (and --algo is ignored).`,
 		return keys
 	}(),
 	Args: cobra.ExactValidArgs(1),
-	RunE: func(cmd *cobra.Command, args []string) error {
+	RunE: func(_ *cobra.Command, args []string) error {
 		rwc, err := openTpm()
 		if err != nil {
 			return err

--- a/cmd/read.go
+++ b/cmd/read.go
@@ -30,7 +30,7 @@ Based on --hash-algo and --pcrs flags, read the contents of the TPM's PCRs.
 If --hash-algo is not provided, all banks of PCRs will be read.
 If --pcrs is not provided, all PCRs are read for that hash algorithm.`,
 	Args: cobra.NoArgs,
-	RunE: func(cmd *cobra.Command, args []string) error {
+	RunE: func(*cobra.Command, []string) error {
 		rwc, err := openTpm()
 		if err != nil {
 			return err
@@ -77,7 +77,7 @@ var nvReadCmd = &cobra.Command{
 Based on the --index flag, this reads all of the NVData present at that NVIndex.
 The read is authenticated with the owner hierarchy and an empty password.`,
 	Args: cobra.NoArgs,
-	RunE: func(cmd *cobra.Command, args []string) error {
+	RunE: func(*cobra.Command, []string) error {
 		rwc, err := openTpm()
 		if err != nil {
 			return err

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -17,7 +17,7 @@ var RootCmd = &cobra.Command{
 
 This tool allows performing TPM2 operations from the command line.
 See the per-command documentation for more information.`,
-	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+	PersistentPreRunE: func(cmd *cobra.Command, _ []string) error {
 		if quiet && verbose {
 			return fmt.Errorf("cannot specify both --quiet and --verbose")
 		}

--- a/cmd/seal.go
+++ b/cmd/seal.go
@@ -27,7 +27,7 @@ only work if certain Platform Control Registers (PCRs) are in the correct state.
 This allows a key (i.e. a disk encryption key) to be bound to specific machine
 state (like Secure Boot).`,
 	Args: cobra.NoArgs,
-	RunE: func(cmd *cobra.Command, args []string) error {
+	RunE: func(*cobra.Command, []string) error {
 		rwc, err := openTpm()
 		if err != nil {
 			return err
@@ -87,7 +87,7 @@ sealing differ from the current PCR values. This allows for verification of the
 machine state when sealing took place.
 `,
 	Args: cobra.NoArgs,
-	RunE: func(cmd *cobra.Command, args []string) error {
+	RunE: func(*cobra.Command, []string) error {
 		rwc, err := openTpm()
 		if err != nil {
 			return err

--- a/cmd/verify.go
+++ b/cmd/verify.go
@@ -22,7 +22,7 @@ var verifyCmd = &cobra.Command{
 var debugCmd = &cobra.Command{
 	Use:   "debug",
 	Short: "Debug the contents of an attestation report without verifying its root-of-trust (e.g., attestation key certificate). For debugging purposes only",
-	RunE: func(cmd *cobra.Command, args []string) error {
+	RunE: func(*cobra.Command, []string) error {
 		attestationBytes, err := io.ReadAll(dataInput())
 		if err != nil {
 			return err

--- a/launcher/agent/agent_test.go
+++ b/launcher/agent/agent_test.go
@@ -75,7 +75,7 @@ func TestAttest(t *testing.T) {
 			}
 
 			claims := &fake.Claims{}
-			keyFunc := func(token *jwt.Token) (interface{}, error) { return fakeSigner.Public(), nil }
+			keyFunc := func(_ *jwt.Token) (interface{}, error) { return fakeSigner.Public(), nil }
 			token, err := jwt.ParseWithClaims(string(tokenBytes), claims, keyFunc)
 			if err != nil {
 				t.Errorf("Failed to parse token %s", err)
@@ -240,7 +240,7 @@ func TestFetchContainerImageSignatures(t *testing.T) {
 				t.Fatalf("VerifyAttestation failed: %v", err)
 			}
 			claims := &fake.Claims{}
-			keyFunc := func(token *jwt.Token) (interface{}, error) { return fakeSigner.Public(), nil }
+			keyFunc := func(_ *jwt.Token) (interface{}, error) { return fakeSigner.Public(), nil }
 			_, err = jwt.ParseWithClaims(string(got.ClaimsToken), claims, keyFunc)
 			if err != nil {
 				t.Errorf("Failed to parse token %s", err)

--- a/launcher/internal/systemctl/systemctl_test.go
+++ b/launcher/internal/systemctl/systemctl_test.go
@@ -7,14 +7,14 @@ import (
 )
 
 func TestRunSystmedCmd(t *testing.T) {
-	doneUnitFunc := func(ctx context.Context, unit string, mode string, progress chan<- string) (int, error) {
+	doneUnitFunc := func(_ context.Context, _, _ string, progress chan<- string) (int, error) {
 		progress <- "done"
 		return 1, nil
 	}
-	failedCallUnitFunc := func(ctx context.Context, unit string, mode string, progress chan<- string) (int, error) {
+	failedCallUnitFunc := func(context.Context, string, string, chan<- string) (int, error) {
 		return 1, errors.New("something went wrong")
 	}
-	failedUnitFunc := func(ctx context.Context, unit string, mode string, progress chan<- string) (int, error) {
+	failedUnitFunc := func(_ context.Context, _, _ string, progress chan<- string) (int, error) {
 		progress <- "failed"
 		return 1, nil
 	}

--- a/launcher/teeserver/tee_server_test.go
+++ b/launcher/teeserver/tee_server_test.go
@@ -42,7 +42,7 @@ func TestGetDefaultToken(t *testing.T) {
 	ah := attestHandler{defaultTokenFile: tmpToken,
 		logger: log.Default(),
 		attestAgent: fakeAttestationAgent{
-			attestFunc: func(_ context.Context, a agent.AttestAgentOpts) ([]byte, error) {
+			attestFunc: func(context.Context, agent.AttestAgentOpts) ([]byte, error) {
 				t.Errorf("This method should not be called")
 				return nil, nil
 			},
@@ -95,7 +95,7 @@ func TestCustomToken(t *testing.T) {
 				"nonces": ["thisIsAcustomNonce"],
 				"token_type": "OIDC"
 				}`,
-			attestFunc: func(_ context.Context, a agent.AttestAgentOpts) ([]byte, error) {
+			attestFunc: func(context.Context, agent.AttestAgentOpts) ([]byte, error) {
 				t.Errorf("This method should not be called")
 				return nil, nil
 			},
@@ -108,7 +108,7 @@ func TestCustomToken(t *testing.T) {
 				"nonces": ["thisIsAcustomNonce"],
 				"token_type": "OIDC"
 			}`,
-			attestFunc: func(_ context.Context, a agent.AttestAgentOpts) ([]byte, error) {
+			attestFunc: func(context.Context, agent.AttestAgentOpts) ([]byte, error) {
 				return nil, errors.New("Error")
 			},
 			want: http.StatusBadRequest,
@@ -120,7 +120,7 @@ func TestCustomToken(t *testing.T) {
 				"nonces": ["thisIsAcustomNonce"],
 				"token_type": ""
 			}`,
-			attestFunc: func(_ context.Context, a agent.AttestAgentOpts) ([]byte, error) {
+			attestFunc: func(context.Context, agent.AttestAgentOpts) ([]byte, error) {
 				t.Errorf("This method should not be called")
 				return nil, nil
 			},
@@ -133,7 +133,7 @@ func TestCustomToken(t *testing.T) {
 				"nonces": ["thisIsAcustomNonce"],
 				"token_type": "OIDC"
 			}`,
-			attestFunc: func(_ context.Context, a agent.AttestAgentOpts) ([]byte, error) {
+			attestFunc: func(context.Context, agent.AttestAgentOpts) ([]byte, error) {
 				return []byte{}, nil
 			},
 			want: http.StatusOK,


### PR DESCRIPTION
golangci-lint just got updated to version `v.1.56.1` https://golangci-lint.run/product/roadmap/#v1561 and started to fail with `unused parameter` error.

This PR is a quick fix to set all unused parameters as `_`