### PR TITLE
Use resizable integrity-fs with in-memory tags

### DIFF
--- a/launcher/image/preload.sh
+++ b/launcher/image/preload.sh
@@ -111,7 +111,9 @@ main() {
   # Install container launcher.
   copy_launcher
   setup_launcher_systemd_unit
-  append_cmdline "cos.protected_stateful_partition=e"
+  # Minimum required COS version for 'e': cos-dev-105-17222-0-0.
+  # Minimum required COS version for 'm': cos-dev-113-18203-0-0.
+  append_cmdline "cos.protected_stateful_partition=m"
   # Increase wait timeout of the protected stateful partition.
   append_cmdline "systemd.default_timeout_start_sec=900s"
 

--- a/launcher/image/test/create_vm.sh
+++ b/launcher/image/test/create_vm.sh
@@ -34,9 +34,16 @@ create_vm() {
   # check the active account
   gcloud auth list
 
+  # Max disk for n2d-standard-2 (8GB memory) at 1% memory overhead.
+  MIN_DISK_SIZE=11
+  MAX_DISK_SIZE_GB=80
+  ADDTL_DISK_RANGE=$(($MAX_DISK_SIZE_GB - $MIN_DISK_SIZE + 1))
+  DISK_SIZE_GB=$(($MIN_DISK_SIZE + ($RANDOM % $ADDTL_DISK_RANGE)))
+
   gcloud compute instances create $VM_NAME --confidential-compute --maintenance-policy=TERMINATE \
-    --scopes=cloud-platform --zone $ZONE --image=$IMAGE_NAME --image-project=$PROJECT_NAME \
-    --shielded-secure-boot $APPEND_METADATA $APPEND_METADATA_FILE
+    --machine-type=n2d-standard-2 --boot-disk-size=$DISK_SIZE_GB --scopes=cloud-platform --zone $ZONE \
+    --image=$IMAGE_NAME --image-project=$PROJECT_NAME --shielded-secure-boot $APPEND_METADATA \
+    $APPEND_METADATA_FILE
 }
 
 IMAGE_NAME=''


### PR DESCRIPTION
The Confidential Space image now uses dm-crypt with a backing dm-integrity where the integrity tags are stored in memory vs getting interleaved on the actual disk.

This changes comes with support for boot-time integrity tag initialization speed up and automatically resizing of the stateful partition on the boot disk.