### PR TITLE
Update go-tdx-guest version to v0.3.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/google/go-attestation v0.5.0
 	github.com/google/go-cmp v0.5.9
 	github.com/google/go-sev-guest v0.9.3
-	github.com/google/go-tdx-guest v0.2.3-0.20231222042644-aeefcb0d0eb3
+	github.com/google/go-tdx-guest v0.3.1-0.20240216171427-43efd1ff6ae8
 	github.com/google/go-tpm v0.9.0
 	github.com/google/logger v1.1.1
 	google.golang.org/protobuf v1.31.0

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/google/go-attestation v0.5.0
 	github.com/google/go-cmp v0.5.9
 	github.com/google/go-sev-guest v0.9.3
-	github.com/google/go-tdx-guest v0.3.1-0.20240216171427-43efd1ff6ae8
+	github.com/google/go-tdx-guest v0.3.1
 	github.com/google/go-tpm v0.9.0
 	github.com/google/logger v1.1.1
 	google.golang.org/protobuf v1.31.0

--- a/go.sum
+++ b/go.sum
@@ -316,6 +316,8 @@ github.com/google/go-tdx-guest v0.2.3-0.20231222042644-aeefcb0d0eb3 h1:0EpD00z41
 github.com/google/go-tdx-guest v0.2.3-0.20231222042644-aeefcb0d0eb3/go.mod h1:Iut2YE9wI7DbuNY9hFcExiUH5oeayMkHNgh/JpByzHQ=
 github.com/google/go-tdx-guest v0.3.1-0.20240216171427-43efd1ff6ae8 h1:/0VgwAVpTt5TPNndpNUguQlF+fWHaS9azdJzu4K8XNY=
 github.com/google/go-tdx-guest v0.3.1-0.20240216171427-43efd1ff6ae8/go.mod h1:/rc3d7rnPykOPuY8U9saMyEps0PZDThLk/RygXm04nE=
+github.com/google/go-tdx-guest v0.3.1 h1:gl0KvjdsD4RrJzyLefDOvFOUH3NAJri/3qvaL5m83Iw=
+github.com/google/go-tdx-guest v0.3.1/go.mod h1:/rc3d7rnPykOPuY8U9saMyEps0PZDThLk/RygXm04nE=
 github.com/google/go-tpm v0.9.0 h1:sQF6YqWMi+SCXpsmS3fd21oPy/vSddwZry4JnmltHVk=
 github.com/google/go-tpm v0.9.0/go.mod h1:FkNVkc6C+IsvDI9Jw1OveJmxGZUUaKxtrpOS47QWKfU=
 github.com/google/go-tspi v0.3.0 h1:ADtq8RKfP+jrTyIWIZDIYcKOMecRqNJFOew2IT0Inus=

--- a/go.sum
+++ b/go.sum
@@ -314,6 +314,8 @@ github.com/google/go-tdx-guest v0.2.3-0.20231011100059-4cf02bed9d33 h1:lRlUusuie
 github.com/google/go-tdx-guest v0.2.3-0.20231011100059-4cf02bed9d33/go.mod h1:84ut3oago/BqPXD4ppiGXdkZNW3WFPkcyAO4my2hXdY=
 github.com/google/go-tdx-guest v0.2.3-0.20231222042644-aeefcb0d0eb3 h1:0EpD00z41G8EjJsHmO54BoUb3izF8/hgUzAzmlo6mCk=
 github.com/google/go-tdx-guest v0.2.3-0.20231222042644-aeefcb0d0eb3/go.mod h1:Iut2YE9wI7DbuNY9hFcExiUH5oeayMkHNgh/JpByzHQ=
+github.com/google/go-tdx-guest v0.3.1-0.20240216171427-43efd1ff6ae8 h1:/0VgwAVpTt5TPNndpNUguQlF+fWHaS9azdJzu4K8XNY=
+github.com/google/go-tdx-guest v0.3.1-0.20240216171427-43efd1ff6ae8/go.mod h1:/rc3d7rnPykOPuY8U9saMyEps0PZDThLk/RygXm04nE=
 github.com/google/go-tpm v0.9.0 h1:sQF6YqWMi+SCXpsmS3fd21oPy/vSddwZry4JnmltHVk=
 github.com/google/go-tpm v0.9.0/go.mod h1:FkNVkc6C+IsvDI9Jw1OveJmxGZUUaKxtrpOS47QWKfU=
 github.com/google/go-tspi v0.3.0 h1:ADtq8RKfP+jrTyIWIZDIYcKOMecRqNJFOew2IT0Inus=

--- a/go.work.sum
+++ b/go.work.sum
@@ -206,6 +206,8 @@ github.com/godbus/dbus v0.0.0-20190422162347-ade71ed3457e h1:BWhy2j3IXJhjCbC68Fp
 github.com/golang/glog v1.1.2/go.mod h1:zR+okUeTbrL6EL3xHUDxZuEtGv04p5shwip1+mL/rLQ=
 github.com/golang/snappy v0.0.4/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
 github.com/google/go-cmp v0.5.7/go.mod h1:n+brtR0CgQNWTVd5ZUFpTBC8YFBDLK/h/bpaJ8/DtOE=
+github.com/google/go-configfs-tsm v0.2.2 h1:YnJ9rXIOj5BYD7/0DNnzs8AOp7UcvjfTvt215EWcs98=
+github.com/google/go-configfs-tsm v0.2.2/go.mod h1:EL1GTDFMb5PZQWDviGfZV9n87WeGTR/JUg13RfwkgRo=
 github.com/google/go-pkcs11 v0.2.1-0.20230907215043-c6f79328ddf9/go.mod h1:6eQoGcuNJpa7jnd5pMGdkSaQpNDYvPlXWMcjXXThLlY=
 github.com/google/go-sev-guest v0.8.0/go.mod h1:hc1R4R6f8+NcJwITs0L90fYWTsBpd1Ix+Gur15sqHDs=
 github.com/google/martian/v3 v3.3.2/go.mod h1:oBOf6HBosgwRXnUGWUB05QECsc6uvmMiJ3+6W4l/CUk=


### PR DESCRIPTION
Update go-tdx-guest version to v0.3.1 which includes -
1. go-configfs-tsm moved from go-tdx-guest to its separately managed git repo.
2. Logging added to client package for QuoteProvider/Device.
3. Updated TCB Info verification logic.