### PR TITLE
Statically link binaries built by goreleaser

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -6,6 +6,8 @@ builds:
     goarch:
       - amd64
       - arm64
+    env:
+      - CGO_ENABLED=0
     id: "gotpm"
     main: ./cmd/gotpm
     binary: gotpm


### PR DESCRIPTION
Built using `goreleaser build --snapshot`

```
$ ls dist
artifacts.json         gotpm_darwin_arm64    gotpm_windows_amd64_v1
config.yaml            gotpm_linux_amd64_v1  gotpm_windows_arm64
gotpm_darwin_amd64_v1  gotpm_linux_arm64     metadata.json


$dist/gotpm_linux_amd64_v1/gotpm attest --tee-technology blah
Error: tee-technology should be either empty or should have values sev-snp or tdx

$ldd dist/gotpm_linux_amd64_v1/gotpm  
	not a dynamic executable
```