### PR TITLE
[launcher] Fix a concurrent TPM access issue

### DIFF
--- a/cmd/token.go
+++ b/cmd/token.go
@@ -124,10 +124,15 @@ The OIDC token includes claims regarding the GCE VM, which is verified by Attest
 			return fmt.Errorf("failed to get principal tokens: %w", err)
 		}
 
-		attestation, err := util.FetchAttestation(rwc, attestationKeys[key][keyAlgo], challenge.Nonce, &cel.CEL{})
+		ak, err := attestationKeys[key][keyAlgo](rwc)
+		if err != nil {
+			return fmt.Errorf("failed to get an AK: %w", err)
+		}
+		attestation, err := util.FetchAttestation(ak, challenge.Nonce, &cel.CEL{})
 		if err != nil {
 			return err
 		}
+		ak.Close()
 
 		req := verifier.VerifyAttestationRequest{
 			Challenge:      challenge,

--- a/go.work.sum
+++ b/go.work.sum
@@ -202,10 +202,12 @@ cloud.google.com/go/logging v1.4.2 h1:Mu2Q75VBDQlW1HlBMjTX4X84UFR73G1TiLlRYc/b7t
 cloud.google.com/go/logging v1.4.2/go.mod h1:jco9QZSx8HiVVqLJReq7z7bVdj0P1Jb9PDFs63T+axo=
 cloud.google.com/go/logging v1.8.1 h1:26skQWPeYhvIasWKm48+Eq7oUqdcdbwsCVwz5Ys0FvU=
 cloud.google.com/go/logging v1.8.1/go.mod h1:TJjR+SimHwuC8MZ9cjByQulAMgni+RkXeI3wwctHJEI=
+cloud.google.com/go/logging v1.9.0 h1:iEIOXFO9EmSiTjDmfpbRjOxECO7R8C7b8IXUGOj7xZw=
 cloud.google.com/go/logging v1.9.0/go.mod h1:1Io0vnZv4onoUnsVUQY3HZ3Igb1nBchky0A0y7BBBhE=
 cloud.google.com/go/longrunning v0.5.0/go.mod h1:0JNuqRShmscVAhIACGtskSAWtqtOoPkwP0YF1oVEchc=
 cloud.google.com/go/longrunning v0.5.2 h1:u+oFqfEwwU7F9dIELigxbe0XVnBAo9wqMuQLA50CZ5k=
 cloud.google.com/go/longrunning v0.5.2/go.mod h1:nqo6DQbNV2pXhGDbDMoN2bWz68MjZUzqv2YttZiveCs=
+cloud.google.com/go/longrunning v0.5.5 h1:GOE6pZFdSrTb4KAiKnXsJBtlE6mEyaW44oKyMILWnOg=
 cloud.google.com/go/longrunning v0.5.5/go.mod h1:WV2LAxD8/rg5Z1cNW6FJ/ZpX4E4VnDnoTk0yawPBB7s=
 cloud.google.com/go/managedidentities v1.6.2/go.mod h1:5c2VG66eCa0WIq6IylRk3TBW83l161zkFvCj28X7jn8=
 cloud.google.com/go/managedidentities v1.6.5/go.mod h1:fkFI2PwwyRQbjLxlm5bQ8SjtObFMW3ChBGNqaMcgZjI=
@@ -337,6 +339,7 @@ github.com/google/uuid v1.3.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+
 github.com/googleapis/enterprise-certificate-proxy v0.2.4/go.mod h1:AwSRAtLfXpU5Nm3pW+v7rGDHp09LsPtGY9MduiEsR9k=
 github.com/googleapis/gax-go v2.0.2+incompatible h1:silFMLAnr330+NRuag/VjIGF7TLp/LBrV2CJKFLWEww=
 github.com/googleapis/gax-go/v2 v2.12.2/go.mod h1:61M8vcyyXR2kqKFxKrfA22jaA8JGF7Dc8App1U3H6jc=
+github.com/klauspost/compress v1.16.7 h1:2mk3MPGNzKyxErAw8YaohYh69+pa4sIQSC0fPGCFR9I=
 github.com/klauspost/compress v1.16.7/go.mod h1:ntbaceVETuRiXiv4DpjP66DpAtAGkEQskQzEyD//IeE=
 go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.47.0/go.mod h1:SK2UL73Zy1quvRPonmOmRDiWk1KBV3LyIeeIxcEApWw=
 go.opentelemetry.io/otel v1.22.0/go.mod h1:eoV4iAi3Ea8LkAEI9+GFT44O6T/D0GWAVFyZVCC6pMI=

--- a/internal/util/util.go
+++ b/internal/util/util.go
@@ -43,13 +43,7 @@ func PrincipalFetcher(audience string, mdsClient *metadata.Client) ([][]byte, er
 }
 
 // FetchAttestation gathers the materials required for remote attestation from TPM
-func FetchAttestation(tpm io.ReadWriteCloser, akFetcher TpmKeyFetcher, nonce []byte, cosCEL *cel.CEL) (*attestpb.Attestation, error) {
-	ak, err := akFetcher(tpm)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get AK: %v", err)
-	}
-	defer ak.Close()
-
+func FetchAttestation(ak *client.Key, nonce []byte, cosCEL *cel.CEL) (*attestpb.Attestation, error) {
 	var buf bytes.Buffer
 	if cosCEL != nil {
 		if err := cosCEL.EncodeCEL(&buf); err != nil {

--- a/internal/util/util_test.go
+++ b/internal/util/util_test.go
@@ -49,7 +49,11 @@ func TestFetchAttestation(t *testing.T) {
 	}
 	for _, op := range tests {
 		t.Run(op.name, func(t *testing.T) {
-			attestation, err := FetchAttestation(rwc, op.keyFetcher, []byte("test"), &cel.CEL{})
+			key, err := op.keyFetcher(rwc)
+			if err != nil {
+				t.Fatalf("failed to fetch an AK %v", err)
+			}
+			attestation, err := FetchAttestation(key, []byte("test"), &cel.CEL{})
 			if err != nil {
 				t.Errorf("Failed to get attestation %s", err)
 			}

--- a/launcher/container_runner_test.go
+++ b/launcher/container_runner_test.go
@@ -69,6 +69,10 @@ func (f *fakeAttestationAgent) Refresh(ctx context.Context) error {
 	return nil
 }
 
+func (f fakeAttestationAgent) Close() error {
+	return nil
+}
+
 type fakeClaims struct {
 	jwt.RegisteredClaims
 	Signatures []string

--- a/launcher/teeserver/tee_server_test.go
+++ b/launcher/teeserver/tee_server_test.go
@@ -34,6 +34,10 @@ func (f fakeAttestationAgent) Refresh(_ context.Context) error {
 	return nil
 }
 
+func (f fakeAttestationAgent) Close() error {
+	return nil
+}
+
 func TestGetDefaultToken(t *testing.T) {
 	tmpDir := t.TempDir()
 	tmpToken := path.Join(tmpDir, launcherfile.AttestationVerifierTokenFilename)


### PR DESCRIPTION
**Breaking Change**
`CreateAttestationAgent()` now returns an error in addition to the agent object

Concurrent http requests will exhaust TPM transient handle (3), adding a mutex to handle the requests one by one.

The AK key in the agent will now only be fetched once and saved to the struct.

Tested on a GCE VM, "failed to get AK: warning code 0x2 : out of memory for object contexts" error no longer appears
