### PR TITLE
Fix bug dropping CEL in launcher attestations

### DIFF
--- a/cmd/token.go
+++ b/cmd/token.go
@@ -12,6 +12,7 @@ import (
 	"cloud.google.com/go/logging"
 	"github.com/containerd/containerd/namespaces"
 	"github.com/golang-jwt/jwt/v4"
+	"github.com/google/go-tpm-tools/cel"
 	"github.com/google/go-tpm-tools/client"
 	"github.com/google/go-tpm-tools/internal/util"
 	"github.com/google/go-tpm-tools/verifier"
@@ -123,7 +124,7 @@ The OIDC token includes claims regarding the GCE VM, which is verified by Attest
 			return fmt.Errorf("failed to get principal tokens: %w", err)
 		}
 
-		attestation, err := util.FetchAttestation(rwc, attestationKeys[key][keyAlgo], challenge.Nonce)
+		attestation, err := util.FetchAttestation(rwc, attestationKeys[key][keyAlgo], challenge.Nonce, &cel.CEL{})
 		if err != nil {
 			return err
 		}

--- a/internal/util/util_test.go
+++ b/internal/util/util_test.go
@@ -10,6 +10,7 @@ import (
 	"cloud.google.com/go/compute/metadata"
 	"github.com/containerd/containerd/namespaces"
 	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-tpm-tools/cel"
 	"github.com/google/go-tpm-tools/client"
 	"github.com/google/go-tpm-tools/internal/test"
 	"github.com/google/go-tpm-tools/proto/attest"
@@ -48,7 +49,7 @@ func TestFetchAttestation(t *testing.T) {
 	}
 	for _, op := range tests {
 		t.Run(op.name, func(t *testing.T) {
-			attestation, err := FetchAttestation(rwc, op.keyFetcher, []byte("test"))
+			attestation, err := FetchAttestation(rwc, op.keyFetcher, []byte("test"), &cel.CEL{})
 			if err != nil {
 				t.Errorf("Failed to get attestation %s", err)
 			}

--- a/launcher/agent/agent.go
+++ b/launcher/agent/agent.go
@@ -94,7 +94,7 @@ func (a *agent) Attest(ctx context.Context, opts AttestAgentOpts) ([]byte, error
 		return nil, fmt.Errorf("failed to get principal tokens: %w", err)
 	}
 
-	attestation, err := util.FetchAttestation(a.tpm, a.akFetcher, challenge.Nonce)
+	attestation, err := util.FetchAttestation(a.tpm, a.akFetcher, challenge.Nonce, &a.cosCel)
 	if err != nil {
 		return nil, err
 	}

--- a/verifier/fake/fakeclaims.go
+++ b/verifier/fake/fakeclaims.go
@@ -9,6 +9,7 @@ var _ jwt.Claims = Claims{}
 type Claims struct {
 	jwt.RegisteredClaims
 	ContainerImageSignatures []ContainerImageSignatureClaims `json:"container_image_signatures"`
+	MachineStateMarshaled    string
 }
 
 // ContainerImageSignatureClaims contains claims about a container image signature.

--- a/verifier/fake/fakeverifier.go
+++ b/verifier/fake/fakeverifier.go
@@ -5,23 +5,31 @@ import (
 	"context"
 	"crypto"
 	"encoding/binary"
+	"fmt"
 	"time"
 
 	"github.com/golang-jwt/jwt/v4"
+	"github.com/google/go-tpm-tools/server"
 	"github.com/google/go-tpm-tools/verifier"
 	"github.com/google/go-tpm-tools/verifier/oci"
+	"github.com/google/go-tpm/legacy/tpm2"
 	"go.uber.org/multierr"
 	"google.golang.org/genproto/googleapis/rpc/code"
 	"google.golang.org/genproto/googleapis/rpc/status"
+	"google.golang.org/protobuf/encoding/protojson"
 )
 
 type fakeClient struct {
 	signer crypto.Signer
+	nonce  []byte
 }
 
 // NewClient constructs a new fake client given a crypto.Signer.
 func NewClient(signer crypto.Signer) verifier.Client {
-	return &fakeClient{signer}
+	nonce := make([]byte, 2)
+	binary.LittleEndian.PutUint16(nonce, 15)
+
+	return &fakeClient{signer, nonce}
 }
 
 // CreateChallenge returns a hard coded, basic challenge.
@@ -29,22 +37,35 @@ func NewClient(signer crypto.Signer) verifier.Client {
 // If you have found this method is insufficient for your tests, this class must be updated to
 // allow for better testing.
 func (fc *fakeClient) CreateChallenge(_ context.Context) (*verifier.Challenge, error) {
-	bs := make([]byte, 2)
-	binary.LittleEndian.PutUint16(bs, 15)
 	return &verifier.Challenge{
 		Name:  "projects/fakeProject/locations/fakeRegion/challenges/d882c62f-452f-4709-9335-0cccaf64eee1",
-		Nonce: bs,
+		Nonce: fc.nonce,
 	}, nil
 }
 
-// VerifyAttestation does basic checks and returns a hard coded attestation response.
-//
-// If you have found this method is insufficient for your tests, this class must be updated to
-// allow for better testing.
+// VerifyAttestation calls server.VerifyAttestation against the request's public key.
+// It returns the marshaled MachineState as a claim.
 func (fc *fakeClient) VerifyAttestation(_ context.Context, req verifier.VerifyAttestationRequest) (*verifier.VerifyAttestationResponse, error) {
 	// Determine signing algorithm.
 	signingMethod := jwt.SigningMethodRS256
 	now := jwt.TimeFunc()
+	akPub, err := tpm2.DecodePublic(req.Attestation.GetAkPub())
+	if err != nil {
+		return nil, fmt.Errorf("failed to decode AKPub as TPMT_PUBLIC: %v", err)
+	}
+	akCrypto, err := akPub.Key()
+	if err != nil {
+		return nil, fmt.Errorf("failed to convert TPMT_PUBLIC to crypto.PublicKey: %v", err)
+	}
+	ms, err := server.VerifyAttestation(req.Attestation, server.VerifyOpts{Nonce: fc.nonce, TrustedAKs: []crypto.PublicKey{akCrypto}})
+	if err != nil {
+		return nil, fmt.Errorf("failed to verify attestation: %v", err)
+	}
+
+	msJSON, err := protojson.Marshal(ms)
+	if err != nil {
+		return nil, fmt.Errorf("failed to convert proto object to JSON: %v", err)
+	}
 	claims := Claims{
 		RegisteredClaims: jwt.RegisteredClaims{
 			IssuedAt:  &jwt.NumericDate{Time: now},
@@ -54,6 +75,7 @@ func (fc *fakeClient) VerifyAttestation(_ context.Context, req verifier.VerifyAt
 			Issuer:    "https://confidentialcomputing.googleapis.com/",
 			Subject:   "https://www.googleapis.com/compute/v1/projects/fakeProject/zones/fakeZone/instances/fakeInstance",
 		},
+		MachineStateMarshaled: string(msJSON),
 	}
 
 	var signatureClaims []ContainerImageSignatureClaims


### PR DESCRIPTION
We inadvertently dropped the launcher's canonical event log when refactoring in #419. This fix adds back the launcher CEL and adds a unit test that checks for CEL measurements in the MachineState.

## Failing Unit Test Before Fix:
2024/04/12 18:01:17 Refreshed container image signature cache: [0xc00030e260 0xc00030e280]
2024/04/12 18:01:17 Found container image signatures: [0xc00030e260 0xc00030e280]
--- FAIL: TestAttest (0.00s)
    --- FAIL: TestAttest/all_experiment_flags_disabled (0.17s)
        /Users/wuale/Projects/go-tpm-tools/launcher/agent/agent_test.go:389: got image ref , want image ref gcr.io/fakeRepo/fakeTestImage:latest
        /Users/wuale/Projects/go-tpm-tools/launcher/agent/agent_test.go:392: got image digest , want image digest sha256:adb591795f9e9047f9117163b83c2ebcd5edc4503644d59a98cf911aef0367f8
        /Users/wuale/Projects/go-tpm-tools/launcher/agent/agent_test.go:398: got args [], want length 1
    --- FAIL: TestAttest/enable_signed_container (0.40s)
        /Users/wuale/Projects/go-tpm-tools/launcher/agent/agent_test.go:389: got image ref , want image ref gcr.io/fakeRepo/fakeTestImage:latest
        /Users/wuale/Projects/go-tpm-tools/launcher/agent/agent_test.go:392: got image digest , want image digest sha256:adb591795f9e9047f9117163b83c2ebcd5edc4503644d59a98cf911aef0367f8
        /Users/wuale/Projects/go-tpm-tools/launcher/agent/agent_test.go:398: got args [], want length 1
FAIL
FAIL    github.com/google/go-tpm-tools/launcher/agent   0.926s
FAIL
