### PR TITLE
[launcher] Increase shm size

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,7 +61,8 @@ jobs:
         run: sudo dpkg --add-architecture i386; sudo apt-get update; sudo apt-get -y install libssl-dev:i386 libgcc-s1:i386 gcc-multilib
         if: runner.os == 'Linux' && matrix.architecture == 'x32'
       - name: Install Mac packages
-        run: brew install openssl
+        run: |
+          brew install openssl
         if: runner.os == 'macOS'
       - name: Install Windows packages
         run: choco install openssl

--- a/.github/workflows/releaser.yaml
+++ b/.github/workflows/releaser.yaml
@@ -14,7 +14,7 @@ jobs:
         go-version: [1.20.x]
         os: [macos-latest, ubuntu-latest]
 
-    name: Release (${{ matrix.os}}, Go ${{ matrix.go-version }})
+    name: Release (${{ matrix.os}}, ${{ matrix.architecture }}, Go ${{ matrix.go-version }})
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3
@@ -23,6 +23,7 @@ jobs:
       - uses: actions/setup-go@v3
         with:
           go-version: ${{ matrix.go-version }}
+          architecture: ${{ matrix.architecture }}
           cache: true
       - shell: bash
         run: echo "sha_short=$(git rev-parse --short HEAD)" >> $GITHUB_ENV

--- a/launcher/container_runner.go
+++ b/launcher/container_runner.go
@@ -154,6 +154,7 @@ func NewRunner(ctx context.Context, cdClient *containerd.Client, token oauth2.To
 			oci.WithHostNamespace(specs.NetworkNamespace),
 			oci.WithEnv([]string{fmt.Sprintf("HOSTNAME=%s", hostname)}),
 			withRlimits(rlimits),
+			oci.WithDevShmSize(2097152), // 2GB = 2,097,152KB
 		),
 	)
 	if err != nil {

--- a/simulator/internal/internal_cgo.go
+++ b/simulator/internal/internal_cgo.go
@@ -34,6 +34,7 @@ package internal
 // // Flags to find OpenSSL installation on macOS (default Homebrew location)
 // #cgo darwin CFLAGS: -I/usr/local/opt/openssl/include
 // #cgo darwin LDFLAGS: -L/usr/local/opt/openssl/lib
+// // Flags to find OpenSSL (new Homebrew)
 // // Flags to find OpenSSL installation on Windows (default install location)
 // #cgo windows CFLAGS: -I"C:/Program Files/OpenSSL-Win64/include"
 // #cgo windows LDFLAGS: -L"C:/Program Files/OpenSSL-Win64/lib"


### PR DESCRIPTION
Increase /dev/shm size for container process from 64MB to 2GB.