### PR TITLE
Allow server verification to accept tpm attestation evidence in remote attestation request from tdx and sevsnp machines

### DIFF
--- a/server/verify_test.go
+++ b/server/verify_test.go
@@ -128,6 +128,20 @@ func TestVerifyHappyCases(t *testing.T) {
 	}
 }
 
+func TestVerifyAllowGCESoftwareTEEAttestation(t *testing.T) {
+	if err := VerifyGceTechnology(&attestpb.Attestation{}, attestpb.GCEConfidentialTechnology_AMD_SEV_SNP, &VerifyOpts{
+		AllowGCESoftwareTEEAttestation: true,
+	}); err != nil {
+		t.Error("Skip sev snp hardware attestation verification if AllowGCESoftwareTEEAttestation fail")
+	}
+
+	if err := VerifyGceTechnology(&attestpb.Attestation{}, attestpb.GCEConfidentialTechnology_INTEL_TDX, &VerifyOpts{
+		AllowGCESoftwareTEEAttestation: true,
+	}); err != nil {
+		t.Error("Skip tdx hardware attestation verification if AllowGCESoftwareTEEAttestation fail")
+	}
+}
+
 func TestVerifyPCRChanged(t *testing.T) {
 	rwc := test.GetTPM(t)
 	defer client.CheckedClose(t, rwc)


### PR DESCRIPTION
The current server.VerifyAttestation function enforce itself to only accept hardware attestation report when the event log record (event type == NonhostInfo) is 3 or 4 (standing for GCEConfidentialTechnology_INTEL_TDX & GCEConfidentialTechnology_AMD_SEV_SNP).

When server.VerifyAttestation calls VerifyGceTechnology, server.VerifyAttestation returns error when it cannot find a pb.Attestation_SevSnpAttestation or pb.Attestation_TdxAttestation in the received attestation evidence (pb.Attestation).

However, we want to still allow vTPM attestation on tdx and sev-snp machines. This PR is for removing the enforcement.

See more context in https://docs.google.com/document/d/1bqy3MJdbQrZzn0RQTo1WWZ9wqTXl_y7Jq7Wvnw8Oobo/edit?resourcekey=0-Pfgmgvm7HqCp37cOAu8pbw&tab=t.0#heading=h.mf27ppdi03e3.
