### PR TITLE
Fix releaser.yaml and ci.yml file on macos

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,11 +30,15 @@ jobs:
       matrix:
         go-version: [1.20.x]
         # TODO: Get this working on windows-latest
-        os: [macos-latest, ubuntu-latest]
+        os: [ubuntu-latest]
         architecture: [x32, x64]
-        exclude:
+        include:
           - os: macos-latest
-            architecture: x32
+            architecture: arm64
+            go-version: 1.20.x
+          - os: macos-14-large
+            architecture: x64
+            go-version: 1.20.x
     name: Generate/Build/Test (${{ matrix.os }}, ${{ matrix.architecture }}, Go ${{ matrix.go-version }})
     runs-on: ${{ matrix.os }}
     steps:
@@ -61,7 +65,8 @@ jobs:
         run: sudo dpkg --add-architecture i386; sudo apt-get update; sudo apt-get -y install libssl-dev:i386 libgcc-s1:i386 gcc-multilib
         if: runner.os == 'Linux' && matrix.architecture == 'x32'
       - name: Install Mac packages
-        run: brew install openssl
+        run: |
+          brew install openssl
         if: runner.os == 'macOS'
       - name: Install Windows packages
         run: choco install openssl

--- a/.github/workflows/releaser.yaml
+++ b/.github/workflows/releaser.yaml
@@ -11,8 +11,10 @@ jobs:
   release:
     strategy:
       matrix:
+        # We can cross-compile from Linux to macOS and Windows. See .goreleaser.yaml
+        # So running just on ubuntu is sufficient.
         go-version: [1.20.x]
-        os: [macos-latest, ubuntu-latest]
+        os: [ubuntu-latest]
 
     name: Release (${{ matrix.os}}, Go ${{ matrix.go-version }})
     runs-on: ${{ matrix.os }}
@@ -34,12 +36,6 @@ jobs:
       - name: Install Linux packages
         run: sudo apt-get -y install libssl-dev
         if: runner.os == 'Linux'
-      - name: Install Mac packages
-        run: brew install openssl
-        if: runner.os == 'macOS'
-      - name: Install Windows packages
-        run: choco install openssl
-        if: runner.os == 'Windows'
       - name: Build all modules
         run: go build -v ./... ./cmd/... ./launcher/...
       - name: Run GoReleaser

--- a/simulator/internal/internal_cgo.go
+++ b/simulator/internal/internal_cgo.go
@@ -32,8 +32,10 @@ package internal
 // #cgo CFLAGS: -DALG_SHA512=ALG_YES
 // #cgo CFLAGS: -DMAX_CONTEXT_SIZE=1360
 // // Flags to find OpenSSL installation on macOS (default Homebrew location)
-// #cgo darwin CFLAGS: -I/usr/local/opt/openssl/include
-// #cgo darwin LDFLAGS: -L/usr/local/opt/openssl/lib
+// #cgo darwin,amd64 CFLAGS: -I/usr/local/opt/openssl/include
+// #cgo darwin,amd64 LDFLAGS: -L/usr/local/opt/openssl/lib
+// #cgo darwin,arm64 CFLAGS: -I/opt/homebrew/opt/openssl/include
+// #cgo darwin,arm64 LDFLAGS: -L/opt/homebrew/opt/openssl/lib
 // // Flags to find OpenSSL installation on Windows (default install location)
 // #cgo windows CFLAGS: -I"C:/Program Files/OpenSSL-Win64/include"
 // #cgo windows LDFLAGS: -L"C:/Program Files/OpenSSL-Win64/lib"


### PR DESCRIPTION
Root cause:
macos-latest no longer gives us an amd64 machine to build and run our test (even if we ask for an amd64 machine specifically, I tested using uname, and it's still a arm64 mac)

https://github.com/actions/runner-images/tree/main


Changes:
* Specifically add `macos-latest/arm64` to the build/test
* Add `macos-14-large` which supports amd64

* Adding openssl lib location (homebrew) for `darwin/arm64`
* Remove `macos-latest` from releaser file, as we don't need to run the releaser in different OSes. And since `gotpm` binary doesn't need the simulator CGO support, the linux should handle the cross compilation for all platform/arch when doing the release. This should also fix the error when we creating a release (because we were trying to release the same binary twice)


