### PR TITLE
Refresh SA auth token in signaturediscovery client before fetching container image signatures

### DIFF
--- a/launcher/launcher/main.go
+++ b/launcher/launcher/main.go
@@ -21,6 +21,7 @@ import (
 	"github.com/google/go-tpm-tools/launcher"
 	"github.com/google/go-tpm-tools/launcher/internal/experiments"
 	"github.com/google/go-tpm-tools/launcher/launcherfile"
+	"github.com/google/go-tpm-tools/launcher/registryauth"
 	"github.com/google/go-tpm-tools/launcher/spec"
 	"github.com/google/go-tpm/legacy/tpm2"
 )
@@ -186,7 +187,7 @@ func startLauncher(ctx context.Context, launchSpec spec.LaunchSpec, serialConsol
 	}
 	gceAk.Close()
 
-	token, err := launcher.RetrieveAuthToken(ctx, mdsClient)
+	token, err := registryauth.RetrieveAuthToken(ctx, mdsClient)
 	if err != nil {
 		logger.Printf("failed to retrieve auth token: %v, using empty auth for image pulling\n", err)
 	}

--- a/launcher/registryauth/auth.go
+++ b/launcher/registryauth/auth.go
@@ -1,8 +1,10 @@
-package launcher
+// Package registryauth contains functionalities to authenticate docker repo.
+package registryauth
 
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"strings"
 
 	"cloud.google.com/go/compute/metadata"
@@ -44,4 +46,20 @@ func Resolver(token string) remotes.Resolver {
 	options.Authorizer = docker.NewDockerAuthorizer(authOpts...)
 
 	return docker.NewResolver(options)
+}
+
+// RefreshResolver takes in a metadata server client, uses it to refresh the default service
+// account token, and returns a custom resolver that can use the token to authenticate with
+// the repo.
+func RefreshResolver(ctx context.Context, client *metadata.Client) (remotes.Resolver, error) {
+	token, err := RetrieveAuthToken(ctx, client)
+	if err != nil {
+		return nil, fmt.Errorf("failed to retrieve auth token from metadata server: %v", err)
+	}
+
+	if token.Valid() {
+		return Resolver(token.AccessToken), nil
+	}
+
+	return nil, fmt.Errorf("invalid token from metadata server: %v", token)
 }


### PR DESCRIPTION
Currently we only fetch the VM SA once, for the purpose of downloading workload image from Artifact registry.
But it doesn't work well for long running workloads because the VM SA token will expire after 1 hr, and thus lead to 401 errors when the signaturediscovery client tries to fetch image signatures periodically.
We'll need to refresh the resolver for signaturediscovery client to authenticate with the target docker repo before fetching container signatures.

# Breaking changes:
- move `auth.go` to from package `launcher` a to a new sub-package `github.com/google/go-tpm-tools/launcher/registryauth` so that auth utilities can be used cross packages. Add a new method that takes in a metadata server client and returns a refreshed remote resolver.
- refactor of signaturesdiscovery client to be able to refresh resolver before pulling docker image.