### PR TITLE
add custom nonce flag to cmd package token subcommand

### DIFF
--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -14,18 +14,19 @@ import (
 )
 
 var (
-	output    string
-	input     string
-	nvIndex   uint32
-	nonce     []byte
-	teeNonce  []byte
-	keyAlgo   = tpm2.AlgRSA
-	pcrs      []int
-	format    string
-	asAddress string
-	audience  string
-	eventLog  string
-	cloudLog  bool
+	output      string
+	input       string
+	nvIndex     uint32
+	nonce       []byte
+	teeNonce    []byte
+	keyAlgo     = tpm2.AlgRSA
+	pcrs        []int
+	format      string
+	asAddress   string
+	audience    string
+	eventLog    string
+	cloudLog    bool
+	customNonce []string
 )
 
 type pcrsFlag struct {
@@ -142,6 +143,12 @@ func addCloudLoggingFlag(cmd *cobra.Command) {
 func addAudienceFlag(cmd *cobra.Command) {
 	cmd.PersistentFlags().StringVar(&audience, "audience", "",
 		"the audience field in the claims token. Cannot be sts.googleapis.com.")
+}
+
+// Lets this command specify custom nonce field of the attestation token.
+func addCustomNonceFlag(cmd *cobra.Command) {
+	cmd.PersistentFlags().StringArrayVar(&customNonce, "custom-nonce", nil,
+		"the custom nonce field in the claims token. use this flag multiple times to add multiple custom nonces.")
 }
 
 // Lets this command specify event log path.

--- a/cmd/token.go
+++ b/cmd/token.go
@@ -138,7 +138,7 @@ The OIDC token includes claims regarding the GCE VM, which is verified by Attest
 			Challenge:      challenge,
 			GcpCredentials: principalTokens,
 			Attestation:    attestation,
-			TokenOptions:   verifier.TokenOptions{CustomAudience: audience, TokenType: "OIDC"},
+			TokenOptions:   verifier.TokenOptions{CustomAudience: audience, CustomNonce: customNonce, TokenType: "OIDC"},
 		}
 
 		resp, err := verifierClient.VerifyAttestation(ctx, req)
@@ -208,6 +208,7 @@ func init() {
 	addCloudLoggingFlag(tokenCmd)
 	addAudienceFlag(tokenCmd)
 	addEventLogFlag(tokenCmd)
+	addCustomNonceFlag(tokenCmd)
 	// TODO: Add TEE hardware OIDC token generation
 	// addTeeNonceflag(tokenCmd)
 	// addTeeTechnology(tokenCmd)

--- a/verifier/util/fake_attestation_server.go
+++ b/verifier/util/fake_attestation_server.go
@@ -2,11 +2,14 @@ package util
 
 import (
 	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
 
+	"cloud.google.com/go/confidentialcomputing/apiv1/confidentialcomputingpb"
 	"github.com/golang-jwt/jwt/v4"
 	"golang.org/x/net/http2"
+	"google.golang.org/protobuf/encoding/protojson"
 )
 
 // FakeChallengeUUID is the challenge for fake attestation server
@@ -14,6 +17,12 @@ const FakeChallengeUUID = "947b4f7b-e6d4-4cfe-971c-39ffe00268ba"
 
 // FakeTpmNonce is the tpm nonce for fake attestation server
 const FakeTpmNonce = "R29vZ0F0dGVzdFYxeGtJUGlRejFPOFRfTzg4QTRjdjRpQQ=="
+
+// FakeCustomNonce is the custom nonce for fake attestation server
+var FakeCustomNonce = []string{"1234567890", "1234567890"}
+
+// FakeCustomNonce is the custom audience for fake attestation server
+const FakeCustomAudience = "https://api.test.com"
 
 // MockAttestationServer provides fake implementation for the GCE attestation server.
 type MockAttestationServer struct {
@@ -45,6 +54,12 @@ func NewMockAttestationServer() (*MockAttestationServer, error) {
 		}
 		verifyAttestationPath := challengePath + "/" + FakeChallengeUUID + ":verifyAttestation"
 		if r.URL.Path == verifyAttestationPath {
+			err := validateCustomNonceAndAudienceFromRequest(r)
+			if err != nil {
+				fmt.Print("error validating Custom Nonce and Custom Audience")
+				http.Error(w, "Invalid Nonce or Audience", http.StatusBadRequest) // Return 400 Bad Request
+				return
+			}
 			payload := &fakeOidcTokenPayload{
 				Audience:  "test",
 				IssuedAt:  1709752525,
@@ -54,6 +69,8 @@ func NewMockAttestationServer() (*MockAttestationServer, error) {
 			fakeJwtToken, err := jwtTokenUnsigned.SignedString([]byte("kcxjxnalpraetgccnnwhpnfwocxscaih"))
 			if err != nil {
 				fmt.Print("error creating test OIDC token")
+				http.Error(w, "Invalid OIDC token creation", http.StatusBadRequest) // Return 400 Bad Request
+				return
 			}
 			w.Write([]byte("{\n  \"oidcClaimsToken\": \"" + fakeJwtToken + "\"\n}\n"))
 		}
@@ -70,4 +87,31 @@ func NewMockAttestationServer() (*MockAttestationServer, error) {
 // Stop shuts down the server.
 func (s *MockAttestationServer) Stop() {
 	s.Server.Close()
+
+}
+
+// validateCustomNonceAndAudienceFromRequest validates the custom nonce and custom audience from a VerifyAttestationRequest.
+func validateCustomNonceAndAudienceFromRequest(r *http.Request) error {
+	req := &confidentialcomputingpb.VerifyAttestationRequest{}
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		return fmt.Errorf("error reading request body: %v", err)
+	}
+	defer r.Body.Close()
+
+	if err := protojson.Unmarshal(body, req); err != nil {
+		return fmt.Errorf("error decoding attestation request: %v", err)
+	}
+
+	if req.TokenOptions.Nonce != nil {
+		if req.TokenOptions.Nonce[0] != FakeCustomNonce[0] || req.TokenOptions.Nonce[1] != FakeCustomNonce[1] {
+			return fmt.Errorf("error comparing custom nonce: %v", err)
+		}
+	}
+	if req.TokenOptions.Audience != "" {
+		if req.TokenOptions.Audience != FakeCustomAudience {
+			return fmt.Errorf("error comparing custom audience: %v", err)
+		}
+	}
+	return nil
 }


### PR DESCRIPTION
- add a custom-nonce flag to allow user supplied string array for Custom Nonce
- added the flag in token subcommand for generating tokens with the custom nonce field
- added the flag in unit test