### PR TITLE
Use a different zone with higher N2D quota for image tests

### DIFF
--- a/launcher/image/test/test_debug_cloudbuild.yaml
+++ b/launcher/image/test/test_debug_cloudbuild.yaml
@@ -3,7 +3,7 @@ substitutions:
   '_IMAGE_PROJECT': ''
   '_CLEANUP': 'true'
   '_VM_NAME_PREFIX': 'cs-debug-test'
-  '_ZONE': 'us-central1-a'
+  '_ZONE': 'us-central2-a'
   '_WORKLOAD_IMAGE': 'us-west1-docker.pkg.dev/confidential-space-images-dev/cs-integ-test-images/basic-test:latest,tee-cmd=["newCmd"],tee-env-ALLOWED_OVERRIDE=overridden'
 steps:
 - name: 'gcr.io/cloud-builders/gcloud'

--- a/launcher/image/test/test_debug_unstable_cloudbuild.yaml
+++ b/launcher/image/test/test_debug_unstable_cloudbuild.yaml
@@ -3,7 +3,7 @@ substitutions:
   '_IMAGE_PROJECT': ''
   '_CLEANUP': 'true'
   '_VM_NAME_PREFIX': 'cs-debug-test'
-  '_ZONE': 'us-central1-a'
+  '_ZONE': 'us-central2-a'
   '_WORKLOAD_IMAGE': 'us-west1-docker.pkg.dev/confidential-space-images-dev/cs-integ-test-images/basic-test:latest'
 steps:
 - name: 'gcr.io/cloud-builders/gcloud'

--- a/launcher/image/test/test_experiments_client.yaml
+++ b/launcher/image/test/test_experiments_client.yaml
@@ -3,7 +3,7 @@ substitutions:
   '_IMAGE_PROJECT': ''
   '_CLEANUP': 'true'
   '_VM_NAME_PREFIX': 'cs-experiments-test'
-  '_ZONE': 'asia-east1-a'
+  '_ZONE': 'us-central2-a'
   '_WORKLOAD_IMAGE': 'us-west1-docker.pkg.dev/confidential-space-images-dev/cs-integ-test-images/basic-test:latest'
 steps:
 - name: 'gcr.io/cloud-builders/gcloud'

--- a/launcher/image/test/test_hardened_unstable_cloudbuild.yaml
+++ b/launcher/image/test/test_hardened_unstable_cloudbuild.yaml
@@ -3,7 +3,7 @@ substitutions:
   '_IMAGE_PROJECT': ''
   '_CLEANUP': 'true'
   '_VM_NAME_PREFIX': 'cs-hardened-test'
-  '_ZONE': 'asia-south2-a'
+  '_ZONE': 'us-central2-a'
   '_WORKLOAD_IMAGE': 'us-west1-docker.pkg.dev/confidential-space-images-dev/cs-integ-test-images/basic-test:latest'
 steps:
 - name: 'gcr.io/cloud-builders/gcloud'

--- a/launcher/image/test/test_http_server.yaml
+++ b/launcher/image/test/test_http_server.yaml
@@ -5,7 +5,7 @@ substitutions:
   '_IMAGE_PROJECT': ''
   '_CLEANUP': 'true'
   '_VM_NAME_PREFIX': 'cs-http-server-test'
-  '_ZONE': 'asia-east1-a'
+  '_ZONE': 'us-central2-a'
   '_WORKLOAD_IMAGE': 'us-west1-docker.pkg.dev/confidential-space-images-dev/cs-integ-test-images/ipc/happypath:latest'
 steps:
 - name: 'gcr.io/cloud-builders/gcloud'

--- a/launcher/image/test/test_ingress_network.yaml
+++ b/launcher/image/test/test_ingress_network.yaml
@@ -4,7 +4,7 @@ substitutions:
   '_IMAGE_NAME': ''
   '_IMAGE_PROJECT': ''
   '_CLEANUP': 'true'
-  '_ZONE': 'asia-east1-a'
+  '_ZONE': 'us-central2-a'
   '_WORKLOAD_IMAGE': 'docker.io/library/nginx:latest'
 
 steps:

--- a/launcher/image/test/test_launchpolicy_cloudbuild.yaml
+++ b/launcher/image/test/test_launchpolicy_cloudbuild.yaml
@@ -5,7 +5,7 @@ substitutions:
   '_METADATA_FILE': 'startup-script=data/echo_startupscript.sh,user-data=data/cloud-init-config.yaml'
   '_CLEANUP': 'true'
   '_VM_NAME_PREFIX': 'cs-launchpolicy-test'
-  '_ZONE': 'us-east4-a'
+  '_ZONE': 'us-central2-a'
   '_WORKLOAD_IMAGE_LOG_NEVER': 'us-west1-docker.pkg.dev/confidential-space-images-dev/cs-integ-test-images/launchpolicylognever:latest'
   '_WORKLOAD_IMAGE_LOG_DEBUG': 'us-west1-docker.pkg.dev/confidential-space-images-dev/cs-integ-test-images/launchpolicylogdebug:latest'
   '_WORKLOAD_IMAGE_ENV': 'us-west1-docker.pkg.dev/confidential-space-images-dev/cs-integ-test-images/basic-test:latest'

--- a/launcher/image/test/test_log_redirection.yaml
+++ b/launcher/image/test/test_log_redirection.yaml
@@ -3,7 +3,7 @@ substitutions:
   '_IMAGE_PROJECT': ''
   '_CLEANUP': 'true'
   '_VM_NAME_PREFIX': 'cs-logredirect-test'
-  '_ZONE': 'us-central1-a'
+  '_ZONE': 'us-central2-a'
   '_WORKLOAD_IMAGE': 'us-west1-docker.pkg.dev/confidential-space-images-dev/cs-integ-test-images/basic_test:latest'
 
 steps:

--- a/launcher/image/test/test_memory_monitoring.yaml
+++ b/launcher/image/test/test_memory_monitoring.yaml
@@ -3,7 +3,7 @@ substitutions:
   '_IMAGE_PROJECT': ''
   '_CLEANUP': 'true'
   '_VM_NAME_PREFIX': 'memory-monitoring'
-  '_ZONE': 'us-east1-b'
+  '_ZONE': 'us-central2-a'
   '_WORKLOAD_IMAGE': 'us-west1-docker.pkg.dev/confidential-space-images-dev/cs-integ-test-images/memorymonitoring:latest'
 
 steps:

--- a/launcher/image/test/test_oda_with_signed_container.yaml
+++ b/launcher/image/test/test_oda_with_signed_container.yaml
@@ -3,7 +3,7 @@ substitutions:
   '_IMAGE_PROJECT': ''
   '_CLEANUP': 'true'
   '_VM_NAME_PREFIX': 'oda-signedcontainer'
-  '_ZONE': 'us-east1-b'
+  '_ZONE': 'us-central2-a'
   # If the workload image changes, the commit author should change the cosign signature as well to not break tests.
   '_WORKLOAD_IMAGE': 'us-west1-docker.pkg.dev/confidential-space-images-dev/cs-integ-test-images/ipc/happypath@sha256:a7d9b216e16ad1fb2b1e8a35e3da58b21ee8dba84c3b4970567d7ec0234a4010'
   '_SIGNATURE_REPO': 'us-docker.pkg.dev/confidential-space-images-dev/cs-cosign-tests/oda'


### PR DESCRIPTION
To make image tests less flaky and reduce `N2D QUOTA_EXHAUSTED` errors when creating VMs, change the VM zone to `me-central2-a` with 2200 N2D quota.