### PR TITLE
Add version information and fix cloudbuild

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -36,6 +36,7 @@ steps:
   - 'OUTPUT_IMAGE_SUFFIX=$_OUTPUT_IMAGE_SUFFIX'
   - 'OUTPUT_IMAGE_FAMILY=$_OUTPUT_IMAGE_FAMILY'
   - 'BUCKET_NAME=$_BUCKET_NAME'
+  - 'SHORT_SHA=${SHORT_SHA}'
   script: |
     #!/usr/bin/env bash
     set -exuo pipefail
@@ -43,7 +44,7 @@ steps:
     base_image=$(cat /workspace/base_image.txt)
     echo "building the debug image: ${OUTPUT_IMAGE_PREFIX}-debug-${OUTPUT_IMAGE_SUFFIX} with the base image: ${base_image}"
     gcloud builds submit --config=launcher/image/cloudbuild.yaml --region us-west1 \
-      --substitutions _BASE_IMAGE=${base_image},_OUTPUT_IMAGE_FAMILY=${OUTPUT_IMAGE_FAMILY}-debug,_OUTPUT_IMAGE_NAME=${OUTPUT_IMAGE_PREFIX}-debug-${OUTPUT_IMAGE_SUFFIX},_IMAGE_ENV=debug,_CS_LICENSE=projects/confidential-space-images/global/licenses/confidential-space-debug,_BUCKET_NAME=${BUCKET_NAME}
+      --substitutions _SHORT_SHA=${SHORT_SHA},_BASE_IMAGE=${base_image},_OUTPUT_IMAGE_FAMILY=${OUTPUT_IMAGE_FAMILY}-debug,_OUTPUT_IMAGE_NAME=${OUTPUT_IMAGE_PREFIX}-debug-${OUTPUT_IMAGE_SUFFIX},_IMAGE_ENV=debug,_CS_LICENSE=projects/confidential-space-images/global/licenses/confidential-space-debug,_BUCKET_NAME=${BUCKET_NAME}
     exit
 
 - name: 'gcr.io/cloud-builders/gcloud'
@@ -54,6 +55,7 @@ steps:
   - 'OUTPUT_IMAGE_SUFFIX=$_OUTPUT_IMAGE_SUFFIX'
   - 'OUTPUT_IMAGE_FAMILY=$_OUTPUT_IMAGE_FAMILY'
   - 'BUCKET_NAME=$_BUCKET_NAME'
+  - 'SHORT_SHA=${SHORT_SHA}'
   script: |
     #!/usr/bin/env bash
     set -exuo pipefail
@@ -61,7 +63,7 @@ steps:
     base_image=$(cat /workspace/base_image.txt)
     echo "building the hardened image: ${OUTPUT_IMAGE_PREFIX}-hardened-${OUTPUT_IMAGE_SUFFIX} with the base image: ${base_image}"
     gcloud builds submit --config=launcher/image/cloudbuild.yaml --region us-west1 \
-      --substitutions _BASE_IMAGE=${base_image},_OUTPUT_IMAGE_FAMILY=${OUTPUT_IMAGE_FAMILY},_OUTPUT_IMAGE_NAME=${OUTPUT_IMAGE_PREFIX}-hardened-${OUTPUT_IMAGE_SUFFIX},_IMAGE_ENV=hardened,_CS_LICENSE=projects/confidential-space-images/global/licenses/confidential-space,_BUCKET_NAME=${BUCKET_NAME}
+      --substitutions _SHORT_SHA=${SHORT_SHA},_BASE_IMAGE=${base_image},_OUTPUT_IMAGE_FAMILY=${OUTPUT_IMAGE_FAMILY},_OUTPUT_IMAGE_NAME=${OUTPUT_IMAGE_PREFIX}-hardened-${OUTPUT_IMAGE_SUFFIX},_IMAGE_ENV=hardened,_CS_LICENSE=projects/confidential-space-images/global/licenses/confidential-space,_BUCKET_NAME=${BUCKET_NAME}
     exit
 
 - name: 'gcr.io/cloud-builders/gcloud'

--- a/cmd/gotpm/main.go
+++ b/cmd/gotpm/main.go
@@ -2,12 +2,43 @@
 package main
 
 import (
+	"fmt"
 	"os"
+	"runtime/debug"
 
 	"github.com/google/go-tpm-tools/cmd"
 )
 
+// GoReleaser will populates those fields
+// https://goreleaser.com/cookbooks/using-main.version/
+var (
+	version = "dev"
+	commit  = "none"
+	date    = "unknown"
+)
+
+var (
+	tdxGuestVersion = "unknown"
+	sevGuestVersion = "unknown"
+	sevGuest        = "github.com/google/go-sev-guest"
+	tdxGuest        = "github.com/google/go-tdx-guest"
+)
+
 func main() {
+	if info, ok := debug.ReadBuildInfo(); ok {
+		for _, dep := range info.Deps {
+			switch dep.Path {
+			case sevGuest:
+				sevGuestVersion = dep.Version
+			case tdxGuest:
+				tdxGuestVersion = dep.Version
+			}
+		}
+	}
+
+	cmd.RootCmd.Version = fmt.Sprintf("%s, commit %s, built at %s\n- go-sev-guest version %s\n- go-tdx-guest version %s",
+		version, commit, date, tdxGuestVersion, sevGuestVersion)
+
 	if cmd.RootCmd.Execute() != nil {
 		os.Exit(1)
 	}

--- a/launcher/image/cloudbuild.yaml
+++ b/launcher/image/cloudbuild.yaml
@@ -6,15 +6,16 @@ substitutions:
   '_IMAGE_ENV': ''
   '_BUCKET_NAME': '${PROJECT_ID}_cloudbuild'
   '_CS_LICENSE': ''
+  '_SHORT_SHA': ''
 
 steps:
-  - name: golang:1.20
+  - name: golang:1.21
     entrypoint: /bin/bash
     args:
       - -c
       - |
         cd launcher/launcher
-        CGO_ENABLED=0 go build -o ../image/launcher
+        CGO_ENABLED=0 go build -o ../image/launcher -ldflags="-X 'main.BuildCommit=${_SHORT_SHA}'"
   - name: 'gcr.io/cloud-builders/gcloud'
     id: DownloadExpBinary
     entrypoint: 'gcloud'

--- a/launcher/image/preload.sh
+++ b/launcher/image/preload.sh
@@ -128,6 +128,12 @@ main() {
          "Only 'debug' and 'hardened' are supported."
     exit 1
   fi
+
+  # Make sure cache is flushed for the OEM partition.
+  sync ${OEM_PATH}
+
+  # Verify the content before the OEM sealing step.
+  ls -lh ${CS_PATH}
 }
 
 main

--- a/launcher/image/test/test_memory_monitoring.yaml
+++ b/launcher/image/test/test_memory_monitoring.yaml
@@ -3,7 +3,7 @@ substitutions:
   '_IMAGE_PROJECT': ''
   '_CLEANUP': 'true'
   '_VM_NAME_PREFIX': 'memory-monitoring'
-  '_ZONE': 'us-east1-b'
+  '_ZONE': 'us-west1-a'
   '_WORKLOAD_IMAGE': 'us-west1-docker.pkg.dev/confidential-space-images-dev/cs-integ-test-images/memorymonitoring:latest'
 
 steps:

--- a/launcher/launcher/main.go
+++ b/launcher/launcher/main.go
@@ -45,6 +45,9 @@ var rcMessage = map[int]string{
 	holdRC:    "VM remains running",
 }
 
+// BuildCommit shows the commit when building the binary, set by -ldflags when building
+var BuildCommit = "dev"
+
 var logger *log.Logger
 var mdsClient *metadata.Client
 
@@ -74,6 +77,7 @@ func main() {
 	logger.SetOutput(io.MultiWriter(os.Stdout, serialConsole))
 
 	logger.Println(welcomeMessage)
+	logger.Printf("Build commit: %s\n", BuildCommit)
 
 	if err := verifyFsAndMount(); err != nil {
 		logger.Printf("failed to verify filesystem and mounts: %v\n", err)


### PR DESCRIPTION
* gotpm cmd can now shows version info:
```
$ go-tpm-tools_linux_amd64_v1/go-tpm-tools -v
gotpm version 0.4.4, commit 2dca42d8bece8ce657cd972d4451e3ba803b8e96, built at 2024-05-22T20:46:34Z
- go-sev-guest version v0.3.1
- go-tdx-guest version v0.9.3
```

* launcher will also show build commit in the welcome message.

* update launcher cloudbuild to go1.21 to match its go.mod

* add "sync" at the end of the `preload.sh` file to fix (hopefully) the empty files in OEM partition when building the image.
```
/usr/share/oem/confidential_space $ ls -althr
total 80M
drwxr-xr-x 4 root root 4.0K May 28 20:51 ..
-rwxr-xr-x 1 root root  55M May 28 20:51 confidential_space_experiments
-rwxr-xr-x 1 root root  26M May 28 20:51 cs_container_launcher
-rw-r--r-- 1 root root    0 May 28 20:51 container-runner.service
-rwxr-xr-x 1 root root    0 May 28 20:51 exit_script.sh
-rw-r--r-- 1 root root    0 May 28 20:51 fluent-bit-cs.conf
-rw-r--r-- 1 root root    0 May 28 20:51 system-stats-monitor-cs.json
-rw-r--r-- 1 root root    0 May 28 20:51 boot-disk-size-consistency-monitor-cs.json
-rw-r--r-- 1 root root    0 May 28 20:51 docker-monitor-cs.json
-rw-r--r-- 1 root root    0 May 28 20:51 kernel-monitor-cs.json
drwxr-xr-x 2 root root 4.0K May 28 20:51 .
```

