### PR TITLE
Populate the SNP/TDX Machine State field with the verified SNP/TDX attestation data + use a stable COS image version

### DIFF
--- a/launcher/cloudbuild.yaml
+++ b/launcher/cloudbuild.yaml
@@ -1,7 +1,7 @@
 substitutions:
   # using this base image for now, because there is an issue causing the newest COS dev
   # image not booting with cs.
-  '_BASE_IMAGE': '' # left empty means using the latest image in the family
+  '_BASE_IMAGE': 'cos-dev-117-18374-0-0' # Use a stable COS version to avoid CS image build issues
   '_BASE_IMAGE_FAMILY': 'cos-dev' # base image family
   '_OUTPUT_IMAGE_PREFIX': 'confidential-space'
   '_OUTPUT_IMAGE_SUFFIX': ''

--- a/launcher/image/test/test_oda_with_signed_container.yaml
+++ b/launcher/image/test/test_oda_with_signed_container.yaml
@@ -3,7 +3,7 @@ substitutions:
   '_IMAGE_PROJECT': ''
   '_CLEANUP': 'true'
   '_VM_NAME_PREFIX': 'oda-signedcontainer'
-  '_ZONE': 'us-east1-b'
+  '_ZONE': 'us-west1-a'
   # If the workload image changes, the commit author should change the cosign signature as well to not break tests.
   '_WORKLOAD_IMAGE': 'us-west1-docker.pkg.dev/confidential-space-images-dev/cs-integ-test-images/ipc/happypath@sha256:a7d9b216e16ad1fb2b1e8a35e3da58b21ee8dba84c3b4970567d7ec0234a4010'
   '_SIGNATURE_REPO': 'us-docker.pkg.dev/confidential-space-images-dev/cs-cosign-tests/oda'


### PR DESCRIPTION
This PR includes changes to populate the machinState proto with the verified SNP/TDX attestation data. The attestation verifier service will leverage the verified machineState to make claims around.

# Breaking changes:
- Unexport `verifyGceTechnology` because GCETechnology event log is closely related to TPM, this function is directly called after the event log is parsed.
- Use a stable COS image version `cos-dev-117-18374-0-0` rather than the latest COS image version to avoid CS image build issues. 