### PR TITLE
[launcher] Switch base image to 113 cos

### DIFF
--- a/launcher/cloudbuild.yaml
+++ b/launcher/cloudbuild.yaml
@@ -1,8 +1,6 @@
 substitutions:
-  # using this base image for now, because there is an issue causing the newest COS dev
-  # image not booting with cs.
-  '_BASE_IMAGE': 'cos-dev-117-18374-0-0' # Use a stable COS version to avoid CS image build issues
-  '_BASE_IMAGE_FAMILY': 'cos-dev' # base image family
+  '_BASE_IMAGE': '' # an empty base image means the build will use the latest image in '_BASE_IMAGE_FAMILY'
+  '_BASE_IMAGE_FAMILY': 'cos-113-lts' # base image family
   '_OUTPUT_IMAGE_PREFIX': 'confidential-space'
   '_OUTPUT_IMAGE_SUFFIX': ''
   '_OUTPUT_IMAGE_FAMILY': ''


### PR DESCRIPTION
latest cos dev image has constant network interface issue (probably due to using new 6.6 kernel).

It's time for CS to base on a more stable and supportive release track.

Current latest build is on [cos-dev-117-18374-0-0](https://cloud.google.com/container-optimized-os/docs/release-notes/dev#cos-dev-117-18374-0-0_)

we will switch to 113 track [cos-113-18244-85-49](https://cloud.google.com/container-optimized-os/docs/release-notes/m113#cos-113-18244-85-49_)
