### PR TITLE
[launcher] Add DA lockout params when launching

### DIFF
--- a/client/pcr_test.go
+++ b/client/pcr_test.go
@@ -32,14 +32,14 @@ var extends = map[tpm2.Algorithm][]struct {
 		{bytes.Repeat([]byte{0x02}, sha512.Size384)}},
 }
 
-func pcrExtend(alg tpm2.Algorithm, old, new []byte) ([]byte, error) {
+func pcrExtend(alg tpm2.Algorithm, oldVal, newVal []byte) ([]byte, error) {
 	hCon, err := alg.Hash()
 	if err != nil {
 		return nil, fmt.Errorf("not a valid hash type: %v", alg)
 	}
 	h := hCon.New()
-	h.Write(old)
-	h.Write(new)
+	h.Write(oldVal)
+	h.Write(newVal)
 	return h.Sum(nil), nil
 }
 

--- a/launcher/container_runner.go
+++ b/launcher/container_runner.go
@@ -130,7 +130,7 @@ func NewRunner(ctx context.Context, cdClient *containerd.Client, token oauth2.To
 		return nil, err
 	}
 
-	logger.Info("Launch Policy              : %+v\n", launchPolicy)
+	logger.Info(fmt.Sprintf("Launch Policy              : %+v\n", launchPolicy))
 
 	if imageConfigDescriptor, err := image.Config(ctx); err != nil {
 		logger.Error(err.Error())

--- a/launcher/launcher/main.go
+++ b/launcher/launcher/main.go
@@ -34,6 +34,12 @@ const (
 	holdRC   = 4 // hold
 )
 
+var expectedTPMDAParams = launcher.TPMDAParams{
+	MaxTries:        0x20,    // 32 tries
+	RecoveryTime:    0x1C20,  // 120 mins
+	LockoutRecovery: 0x15180, // 24 hrs
+}
+
 var rcMessage = map[int]string{
 	successRC: "workload finished successfully, shutting down the VM",
 	failRC:    "workload or launcher error, shutting down the VM",
@@ -175,7 +181,7 @@ func getUptime() (string, error) {
 }
 
 func startLauncher(launchSpec spec.LaunchSpec, serialConsole *os.File) error {
-	logger.Info(fmt.Sprintf("Launch Spec: %+v\n", launchSpec))
+	logger.Info(fmt.Sprintf("Launch Spec: %+v", launchSpec))
 	containerdClient, err := containerd.New(defaults.DefaultAddress)
 	if err != nil {
 		return &launcher.RetryableError{Err: err}
@@ -187,6 +193,27 @@ func startLauncher(launchSpec spec.LaunchSpec, serialConsole *os.File) error {
 		return &launcher.RetryableError{Err: err}
 	}
 	defer tpm.Close()
+
+	// check DA info, don't crash if failed
+	daInfo, err := launcher.GetTPMDAInfo(tpm)
+	if err != nil {
+		logger.Error(fmt.Sprintf("Failed to get DA Info: %v", err))
+	} else {
+		if !daInfo.StartupClearOrderly {
+			logger.Warn(fmt.Sprintf("Failed orderly startup. Avoid using instance reset. Instead, use instance stop/start. DA lockout counter incremented: LockoutCounter: %d / MaxAuthFail: %d", daInfo.LockoutCounter, daInfo.MaxTries))
+		}
+
+		if err := launcher.SetTPMDAParams(tpm, expectedTPMDAParams); err != nil {
+			logger.Error(fmt.Sprintf("Failed to set DA params: %v", err))
+		}
+
+		daInfo, err := launcher.GetTPMDAInfo(tpm)
+		if err != nil {
+			logger.Error(fmt.Sprintf("Failed to get DA Info: %v", err))
+		} else {
+			logger.Info(fmt.Sprintf("Updated TPM DA params: %+v", daInfo))
+		}
+	}
 
 	// check AK (EK signing) cert
 	gceAk, err := client.GceAttestationKeyECC(tpm)

--- a/launcher/util.go
+++ b/launcher/util.go
@@ -3,10 +3,21 @@ package launcher
 import (
 	"context"
 	"fmt"
+	"io"
 
+	"github.com/google/go-tpm/legacy/tpm2"
 	"google.golang.org/api/impersonate"
 	"google.golang.org/api/option"
 )
+
+// TPMDAParams holds TPM Dictionary Attack parameters.
+type TPMDAParams struct {
+	LockoutCounter      uint32
+	MaxTries            uint32 // aka "MaxAuthFail" in TPM Properties
+	RecoveryTime        uint32 // aka "LockoutInterval" in TPM Properties
+	LockoutRecovery     uint32 // aka "LockoutRecovery" in TPM Properties
+	StartupClearOrderly bool
+}
 
 // FetchImpersonatedToken return an access token for the impersonated service account.
 func FetchImpersonatedToken(ctx context.Context, serviceAccount string, audience string, opts ...option.ClientOption) ([]byte, error) {
@@ -27,4 +38,70 @@ func FetchImpersonatedToken(ctx context.Context, serviceAccount string, audience
 	}
 
 	return []byte(token.AccessToken), nil
+}
+
+// SetTPMDAParams takes in a TPM and updates its Dictionary Attack parameters
+// Only MaxAuthFail, LockoutInterval and LockoutRecovery of TPMDAParams are
+// used in this function.
+func SetTPMDAParams(tpm io.ReadWriter, daParams TPMDAParams) error {
+	// empty auth
+	auth := tpm2.AuthCommand{
+		Session:    tpm2.HandlePasswordSession,
+		Attributes: tpm2.AttrContinueSession,
+		Auth:       []byte(""),
+	}
+	return tpm2.DictionaryAttackParameters(tpm, auth, daParams.MaxTries, daParams.RecoveryTime, daParams.LockoutRecovery)
+}
+
+// GetTPMDAInfo takes in a TPM and read its Dictionary Attack parameters
+func GetTPMDAInfo(tpm io.ReadWriter) (*TPMDAParams, error) {
+	var tpmDAParams TPMDAParams
+
+	lockoutCounter, err := getCapabilityProperty(tpm, tpm2.LockoutCounter) // 526
+	if err != nil {
+		return nil, err
+	}
+	tpmDAParams.LockoutCounter = lockoutCounter.Value
+
+	maxAuthFail, err := getCapabilityProperty(tpm, tpm2.MaxAuthFail) // 527
+	if err != nil {
+		return nil, err
+	}
+	tpmDAParams.MaxTries = maxAuthFail.Value
+
+	lockoutInterval, err := getCapabilityProperty(tpm, tpm2.LockoutInterval) // 528
+	if err != nil {
+		return nil, err
+	}
+	tpmDAParams.RecoveryTime = lockoutInterval.Value
+
+	lockoutRecovery, err := getCapabilityProperty(tpm, tpm2.LockoutRecovery) // 529
+	if err != nil {
+		return nil, err
+	}
+	tpmDAParams.LockoutRecovery = lockoutRecovery.Value
+
+	startUpClear, err := getCapabilityProperty(tpm, tpm2.TPMAStartupClear)
+	if err != nil {
+		return nil, err
+	}
+	// get the 31st bit (TPM-Rev-2.0-Part-2-Structures-01.38.pdf, Page 73)
+	tpmDAParams.StartupClearOrderly = (startUpClear.Value&(1<<31)>>31 == 1)
+
+	return &tpmDAParams, nil
+}
+
+func getCapabilityProperty(tpm io.ReadWriter, property tpm2.TPMProp) (*tpm2.TaggedProperty, error) {
+	vals, _, err := tpm2.GetCapability(tpm, tpm2.CapabilityTPMProperties, 1, uint32(property))
+	if err != nil {
+		return nil, err
+	}
+	val, ok := vals[0].(tpm2.TaggedProperty)
+	if !ok {
+		return nil, fmt.Errorf("failed to cast returned value to tpm2.TaggedProperty: %v", val)
+	}
+	if val.Tag != property {
+		return nil, fmt.Errorf("failed to get expected property from the TPM, want: %v, got: %v", property, val)
+	}
+	return &val, nil
 }

--- a/launcher/util_test.go
+++ b/launcher/util_test.go
@@ -2,6 +2,7 @@ package launcher
 
 import (
 	"bytes"
+
 	"context"
 	"encoding/json"
 	"fmt"
@@ -10,6 +11,9 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-tpm-tools/client"
+	"github.com/google/go-tpm-tools/internal/test"
 	"google.golang.org/api/option"
 )
 
@@ -41,6 +45,36 @@ var testClient = &http.Client{
 			}
 		},
 	},
+}
+
+func TestTPMDAOps(t *testing.T) {
+	rwc := test.GetTPM(t)
+	defer client.CheckedClose(t, rwc)
+
+	daInfo, err := GetTPMDAInfo(rwc)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// default simualator TPM params
+	expectedDaInfo := TPMDAParams{0, 3, 1000, 1000, true}
+	if !cmp.Equal(*daInfo, expectedDaInfo) {
+		t.Errorf("expected default DA parameters, got %+v, want %+v", daInfo, expectedDaInfo)
+	}
+
+	err = SetTPMDAParams(rwc, TPMDAParams{MaxTries: 123, RecoveryTime: 456, LockoutRecovery: 789})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	daInfo, err = GetTPMDAInfo(rwc)
+	if err != nil {
+		t.Fatal(err)
+	}
+	expectedDaInfo = TPMDAParams{0 /*LockoutCounter*/, 123 /*MaxTries*/, 456 /*RecoveryTime*/, 789 /*LockoutRecovery*/, true}
+	if !cmp.Equal(*daInfo, expectedDaInfo) {
+		t.Errorf("expected default DA parameters, got %+v, want %+v", daInfo, expectedDaInfo)
+	}
 }
 
 func TestFetchImpersonatedToken(t *testing.T) {


### PR DESCRIPTION
Log TPM dictionary attack related info for debugging.

Also update the TPM lockout params before launching the workload (if it's not set to the default):
max tries : 3 -> 32
interval  : 1000 seconds -> 0x1C20 (120 mins)
lockout recovery : 1000 seconds -> 0x15180 (24 hrs)