### PR TITLE
[launcher] Optimize serial read in test

### DIFF
--- a/launcher/image/test/util/read_serial.sh
+++ b/launcher/image/test/util/read_serial.sh
@@ -18,10 +18,16 @@ read_serial() {
       break
     fi
 
+    # VM may already exit
+    if grep -qi 'Could not fetch serial port output' /workspace/next_start.txt; then
+      serial_out="$serial_out $1 VM stopped"
+      break
+    fi
+
     next=$(cat /workspace/next_start.txt | sed -n 2p | cut -d ' ' -f2)
     local next_cmd="${base_cmd} ${next}"
     
-    # sleeping 5s for the next serial console read"
+    # sleeping 5s for the next serial console read
     sleep 5
 
     local tmp=$(eval ${next_cmd})


### PR DESCRIPTION
I noticed some test is blocked on read serial on an already stopped VM. So creating a case to catch that.

Return the serial log immediately instead of waiting for full 10mins in that case. This shorten the overall cloudbuild time from 50mins to 24mins.