### PR TITLE
Use confidentialcomputing api v1.6.0 to send TDX attestation

### DIFF
--- a/cmd/token.go
+++ b/cmd/token.go
@@ -107,12 +107,12 @@ The OIDC token includes claims regarding the GCE VM, which is verified by Attest
 			}
 
 			cloudLogger = cloudLogClient.Logger(toolName)
-			fmt.Fprintf(debugOutput(), "cloudLogger created for project: "+projectID+"\n")
+			fmt.Fprint(debugOutput(), "cloudLogger created for project: "+projectID+"\n")
 		}
 
 		key = "gceAK"
 
-		fmt.Fprintf(debugOutput(), "Fetching attestation verifier OIDC token\n")
+		fmt.Fprint(debugOutput(), "Fetching attestation verifier OIDC token\n")
 
 		challenge, err := verifierClient.CreateChallenge(ctx)
 		if err != nil {
@@ -175,7 +175,7 @@ The OIDC token includes claims regarding the GCE VM, which is verified by Attest
 		}
 
 		if output == "" {
-			fmt.Fprintf(messageOutput(), string(token)+"\n")
+			fmt.Fprint(messageOutput(), string(token)+"\n")
 		} else {
 			out := []byte(token)
 			if _, err := dataOutput().Write(out); err != nil {
@@ -194,7 +194,7 @@ The OIDC token includes claims regarding the GCE VM, which is verified by Attest
 			}
 		}
 
-		fmt.Fprintf(debugOutput(), string(claimsString)+"\n"+"Note: these Claims are for debugging purpose and not verified"+"\n")
+		fmt.Fprint(debugOutput(), string(claimsString)+"\n"+"Note: these Claims are for debugging purpose and not verified"+"\n")
 
 		return nil
 	},


### PR DESCRIPTION
This PR introduces the following changes:

- Convert tdx quoteV4 proto from go-tdx-guest repo to API protos such that new confidentialcomputing client library can understand.