### PR TITLE
Instantiate backoff strategy per goroutine

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,8 +77,8 @@ jobs:
         run: |
           GO_EXECUTABLE_PATH=$(which go)
           sudo $GO_EXECUTABLE_PATH test -v -run "TestFetchImageSignaturesDockerPublic" ./launcher
-      - name: Run specific tests to capture potential data race
-        run: go test ./launcher/agent -race -run TestCacheConcurrentSetGet
+      - name: Run all tests in launcher to capture potential data race
+        run: go test -v -race ./launcher/...
         if: (runner.os == 'Linux' || runner.os == 'macOS') && matrix.architecture == 'x64'
       - name: Test all modules
         run: go test -v ./... ./cmd/... ./launcher/... ./verifier/... -skip='TestCacheConcurrentSetGet|TestHwAttestationPass|TestHardwareAttestationPass'

--- a/launcher/container_runner.go
+++ b/launcher/container_runner.go
@@ -407,13 +407,13 @@ func (r *ContainerRunner) refreshToken(ctx context.Context) (time.Duration, erro
 
 // ctx must be a cancellable context.
 func (r *ContainerRunner) fetchAndWriteToken(ctx context.Context) error {
-	return r.fetchAndWriteTokenWithRetry(ctx, defaultRetryPolicy())
+	return r.fetchAndWriteTokenWithRetry(ctx, defaultRetryPolicy)
 }
 
 // ctx must be a cancellable context.
 // retry specifies the refresher goroutine's retry policy.
 func (r *ContainerRunner) fetchAndWriteTokenWithRetry(ctx context.Context,
-	retry *backoff.ExponentialBackOff) error {
+	retry func() *backoff.ExponentialBackOff) error {
 	if err := os.MkdirAll(launcherfile.HostTmpPath, 0744); err != nil {
 		return err
 	}
@@ -439,7 +439,7 @@ func (r *ContainerRunner) fetchAndWriteTokenWithRetry(ctx context.Context,
 						duration, err = r.refreshToken(ctx)
 						return err
 					},
-					retry,
+					retry(),
 					func(err error, t time.Duration) {
 						r.logger.Printf("failed to refresh attestation service token at time %v: %v", t, err)
 					})

--- a/launcher/container_runner_test.go
+++ b/launcher/container_runner_test.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"path"
 	"strconv"
+	"sync"
 	"testing"
 	"time"
 
@@ -43,6 +44,10 @@ type fakeAttestationAgent struct {
 	sigsCache        []string
 	sigsFetcherFunc  func(context.Context) []string
 	launchSpec       spec.LaunchSpec
+
+	// attMu sits on top of attempts field and protects attempts.
+	attMu    sync.Mutex
+	attempts int
 }
 
 func (f *fakeAttestationAgent) MeasureEvent(event cel.Content) error {
@@ -69,7 +74,7 @@ func (f *fakeAttestationAgent) Refresh(ctx context.Context) error {
 	return nil
 }
 
-func (f fakeAttestationAgent) Close() error {
+func (f *fakeAttestationAgent) Close() error {
 	return nil
 }
 
@@ -315,16 +320,22 @@ func TestTokenIsNotChangedIfRefreshFails(t *testing.T) {
 
 	expectedToken := createJWT(t, 5*time.Second)
 	ttl := 5 * time.Second
-	successfulAttestFunc := func(context.Context, agent.AttestAgentOpts) ([]byte, error) {
-		return expectedToken, nil
-	}
 
-	errorAttestFunc := func(context.Context, agent.AttestAgentOpts) ([]byte, error) {
+	attestAgent := &fakeAttestationAgent{}
+	attestAgent.attestFunc = func(context.Context, agent.AttestAgentOpts) ([]byte, error) {
+		attestAgent.attMu.Lock()
+		defer func() {
+			attestAgent.attempts = attestAgent.attempts + 1
+			attestAgent.attMu.Unlock()
+		}()
+		if attestAgent.attempts%2 == 0 {
+			return expectedToken, nil
+		}
 		return nil, errors.New("attest unsuccessful")
 	}
 
 	runner := ContainerRunner{
-		attestAgent: &fakeAttestationAgent{attestFunc: successfulAttestFunc},
+		attestAgent: attestAgent,
 		logger:      log.Default(),
 	}
 
@@ -341,9 +352,6 @@ func TestTokenIsNotChangedIfRefreshFails(t *testing.T) {
 	if !bytes.Equal(data, expectedToken) {
 		t.Errorf("Initial token written to file does not match expected token: got %v, want %v", data, expectedToken)
 	}
-
-	// Change attest agent to return error.
-	runner.attestAgent = &fakeAttestationAgent{attestFunc: errorAttestFunc}
 
 	time.Sleep(ttl)
 
@@ -407,7 +415,7 @@ func testRetryPolicyWithNTries(t *testing.T, numTries int, expectRefresh bool) {
 		attestAgent: &fakeAttestationAgent{attestFunc: attestFunc},
 		logger:      log.Default(),
 	}
-	if err := runner.fetchAndWriteTokenWithRetry(ctx, testRetryPolicyThreeTimes()); err != nil {
+	if err := runner.fetchAndWriteTokenWithRetry(ctx, testRetryPolicyThreeTimes); err != nil {
 		t.Fatalf("fetchAndWriteTokenWithRetry failed: %v", err)
 	}
 	filepath := path.Join(launcherfile.HostTmpPath, launcherfile.AttestationVerifierTokenFilename)
@@ -448,16 +456,25 @@ func TestFetchAndWriteTokenWithTokenRefresh(t *testing.T) {
 	defer cancel()
 
 	expectedToken := createJWT(t, 5*time.Second)
+	expectedRefreshedToken := createJWT(t, 10*time.Second)
 
 	ttl := 5 * time.Second
 
+	attestAgent := &fakeAttestationAgent{}
+	attestAgent.attestFunc = func(context.Context, agent.AttestAgentOpts) ([]byte, error) {
+		attestAgent.attMu.Lock()
+		defer func() {
+			attestAgent.attempts = attestAgent.attempts + 1
+			attestAgent.attMu.Unlock()
+		}()
+		if attestAgent.attempts%2 == 0 {
+			return expectedToken, nil
+		}
+		return expectedRefreshedToken, nil
+	}
 	runner := ContainerRunner{
-		attestAgent: &fakeAttestationAgent{
-			attestFunc: func(context.Context, agent.AttestAgentOpts) ([]byte, error) {
-				return expectedToken, nil
-			},
-		},
-		logger: log.Default(),
+		attestAgent: attestAgent,
+		logger:      log.Default(),
 	}
 
 	if err := runner.fetchAndWriteToken(ctx); err != nil {
@@ -472,14 +489,6 @@ func TestFetchAndWriteTokenWithTokenRefresh(t *testing.T) {
 
 	if !bytes.Equal(data, expectedToken) {
 		t.Errorf("Initial token written to file does not match expected token: got %v, want %v", data, expectedToken)
-	}
-
-	// Change attest agent to return new token.
-	expectedRefreshedToken := createJWT(t, 10*time.Second)
-	runner.attestAgent = &fakeAttestationAgent{
-		attestFunc: func(context.Context, agent.AttestAgentOpts) ([]byte, error) {
-			return expectedRefreshedToken, nil
-		},
 	}
 
 	// Check that token has not been refreshed yet.

--- a/verifier/rest/rest_test.go
+++ b/verifier/rest/rest_test.go
@@ -130,10 +130,10 @@ func testRawCertTable(t testing.TB) *testCertTable {
 
 func TestConvertTDXProtoToREST(t *testing.T) {
 	testCases := []struct {
-		name string
-		quote func() *tpb.QuoteV4
+		name     string
+		quote    func() *tpb.QuoteV4
 		wantPass bool
-	} {
+	}{
 		{
 			name: "successful TD quote conversion",
 			quote: func() *tpb.QuoteV4 {
@@ -141,7 +141,7 @@ func TestConvertTDXProtoToREST(t *testing.T) {
 				if err != nil {
 					t.Fatalf("Unable to convert Raw TD Quote to TDX V4 quote: %v", err)
 				}
-			
+
 				quote, ok := tdx.(*tpb.QuoteV4)
 				if !ok {
 					t.Fatal("Quote format not supported, want QuoteV4 format")
@@ -151,8 +151,8 @@ func TestConvertTDXProtoToREST(t *testing.T) {
 			wantPass: true,
 		},
 		{
-			name: "nil TD quote conversion",
-			quote: func() *tpb.QuoteV4 { return nil },
+			name:     "nil TD quote conversion",
+			quote:    func() *tpb.QuoteV4 { return nil },
 			wantPass: false,
 		},
 	}
@@ -169,7 +169,7 @@ func TestConvertTDXProtoToREST(t *testing.T) {
 					TdQuote: tgtestdata.RawQuote,
 				},
 			}
-		
+
 			if diff := cmp.Diff(got, want, protocmp.Transform()); diff != "" {
 				t.Errorf("TDX API proto mismatch: %s", diff)
 			}


### PR DESCRIPTION
Instantiate a new backoff object per goroutine since the current retry library is not thread-safe.

This PR also adds those tests related to `RefreshToken` + `FetchContainerSignatures` to a test suite with race condition check.