### PR TITLE
Add the location of the service we are calling to the API error logs

### DIFF
--- a/verifier/rest/rest.go
+++ b/verifier/rest/rest.go
@@ -102,7 +102,7 @@ func (c *restClient) CreateChallenge(ctx context.Context) (*verifier.Challenge, 
 	}
 	chal, err := c.v1Client.CreateChallenge(ctx, req)
 	if err != nil {
-		return nil, fmt.Errorf("calling v1.CreateChallenge: %w", err)
+		return nil, fmt.Errorf("calling v1.CreateChallenge in %v: %w", c.location.LocationId, err)
 	}
 	return convertChallengeFromREST(chal)
 }
@@ -116,7 +116,7 @@ func (c *restClient) VerifyAttestation(ctx context.Context, request verifier.Ver
 	req.Challenge = request.Challenge.Name
 	response, err := c.v1Client.VerifyAttestation(ctx, req)
 	if err != nil {
-		return nil, fmt.Errorf("calling v1.VerifyAttestation: %w", err)
+		return nil, fmt.Errorf("calling v1.VerifyAttestation in %v: %w", c.location.LocationId, err)
 	}
 	return convertResponseFromREST(response)
 }


### PR DESCRIPTION
This will make it a bit easier to find which service failed when investigating machine failures. Currently you need to look around for other logs that specify which region the machine is in, which is annoying.

Ideally in the future we have some sort of ID from the service to be able to easily identify logs on the service side.