### PR TITLE
Add ContainerImageSignature type to verifier client

### DIFF
--- a/launcher/agent/agent.go
+++ b/launcher/agent/agent.go
@@ -252,20 +252,9 @@ func convertToContainerSignatures(ociSigs []oci.Signature) ([]*verifier.Containe
 		if err != nil {
 			return nil, fmt.Errorf("failed to decode signature for signature [%v]: %v", ociSig, err)
 		}
-		pubKey, err := ociSig.PublicKey()
-		if err != nil {
-			return nil, fmt.Errorf("failed to get public key from signature [%v]: %v", ociSig, err)
-		}
-		sigAlg, err := ociSig.SigningAlgorithm()
-		if err != nil {
-			return nil, fmt.Errorf("failed to get signing algorithm from signature [%v]: %v", ociSig, err)
-		}
-
 		sigs[i] = &verifier.ContainerSignature{
 			Payload:   payload,
 			Signature: sigBytes,
-			PubKey:    pubKey,
-			SigAlg:    sigAlg,
 		}
 	}
 

--- a/launcher/agent/agent_test.go
+++ b/launcher/agent/agent_test.go
@@ -154,13 +154,13 @@ func TestAttest(t *testing.T) {
 			got := claims.ContainerImageSignatures
 			want := []fake.ContainerImageSignatureClaims{
 				{
-					Payload:   "test data",
+					Payload:   "test data,ECDSA_P256_SHA256",
 					Signature: base64.StdEncoding.EncodeToString([]byte("test data")),
 					PubKey:    "test data",
 					SigAlg:    "ECDSA_P256_SHA256",
 				},
 				{
-					Payload:   "hello world",
+					Payload:   "hello world,RSASSA_PKCS1V15_SHA256",
 					Signature: base64.StdEncoding.EncodeToString([]byte("hello world")),
 					PubKey:    "hello world",
 					SigAlg:    "RSASSA_PKCS1V15_SHA256",
@@ -204,13 +204,13 @@ func TestFetchContainerImageSignatures(t *testing.T) {
 			},
 			wantSignatureClaims: []fake.ContainerImageSignatureClaims{
 				{
-					Payload:   "test data",
+					Payload:   "test data,ECDSA_P256_SHA256",
 					Signature: base64.StdEncoding.EncodeToString([]byte("test data")),
 					PubKey:    "test data",
 					SigAlg:    "ECDSA_P256_SHA256",
 				},
 				{
-					Payload:   "hello world",
+					Payload:   "hello world,RSASSA_PKCS1V15_SHA256",
 					Signature: base64.StdEncoding.EncodeToString([]byte("hello world")),
 					PubKey:    "hello world",
 					SigAlg:    "RSASSA_PKCS1V15_SHA256",
@@ -265,7 +265,7 @@ func TestFetchContainerImageSignatures(t *testing.T) {
 			},
 			wantSignatureClaims: []fake.ContainerImageSignatureClaims{
 				{
-					Payload:   "test data",
+					Payload:   "test data,ECDSA_P256_SHA256",
 					Signature: base64.StdEncoding.EncodeToString([]byte("test data")),
 					PubKey:    "test data",
 					SigAlg:    "ECDSA_P256_SHA256",

--- a/launcher/agent/agent_test.go
+++ b/launcher/agent/agent_test.go
@@ -314,9 +314,14 @@ func TestFetchContainerImageSignatures(t *testing.T) {
 				t.Fatalf("failed to attest %v", err)
 			}
 
-			containerSigs, err := convertToContainerSignatures(gotSigs)
-			if err != nil {
-				t.Fatalf("failed to convert gotSigs: %v", err)
+			var containerSigs []*verifier.ContainerSignature
+			for _, gotSig := range gotSigs {
+				sig, err := convertOCIToContainerSignature(gotSig)
+				if err != nil {
+					t.Fatalf("failed to convert gotSigs: %v", err)
+				}
+
+				containerSigs = append(containerSigs, sig)
 			}
 			req := verifier.VerifyAttestationRequest{
 				Attestation:              attestation,

--- a/launcher/agent/agent_test.go
+++ b/launcher/agent/agent_test.go
@@ -313,9 +313,14 @@ func TestFetchContainerImageSignatures(t *testing.T) {
 			if err != nil {
 				t.Fatalf("failed to attest %v", err)
 			}
+
+			containerSigs, err := convertToContainerSignatures(gotSigs)
+			if err != nil {
+				t.Fatalf("failed to convert gotSigs: %v", err)
+			}
 			req := verifier.VerifyAttestationRequest{
 				Attestation:              attestation,
-				ContainerImageSignatures: gotSigs,
+				ContainerImageSignatures: containerSigs,
 			}
 			got, err := verifierClient.VerifyAttestation(context.Background(), req)
 			if err != nil {

--- a/verifier/client.go
+++ b/verifier/client.go
@@ -33,6 +33,13 @@ type TokenOptions struct {
 	TokenType      string
 }
 
+type ContainerSignature struct {
+	Payload   []byte
+	Signature []byte
+	PubKey    []byte
+	SigAlg    oci.SigningAlgorithm
+}
+
 // VerifyAttestationRequest is passed in on VerifyAttestation. It contains the
 // Challenge from CreateChallenge, optional GcpCredentials linked to the
 // attestation, the Attestation generated from the TPM, and optional container image signatures associated with the workload.
@@ -41,7 +48,7 @@ type VerifyAttestationRequest struct {
 	GcpCredentials [][]byte
 	// Attestation is for TPM attestation
 	Attestation              *attestpb.Attestation
-	ContainerImageSignatures []oci.Signature
+	ContainerImageSignatures []*ContainerSignature
 	TokenOptions             TokenOptions
 	// TDCCELAttestation is for TDX CCEL RTMR attestation
 	TDCCELAttestation *TDCCELAttestation

--- a/verifier/client.go
+++ b/verifier/client.go
@@ -6,7 +6,6 @@ import (
 	"context"
 
 	attestpb "github.com/google/go-tpm-tools/proto/attest"
-	"github.com/google/go-tpm-tools/verifier/oci"
 	"google.golang.org/genproto/googleapis/rpc/status"
 )
 
@@ -36,8 +35,6 @@ type TokenOptions struct {
 type ContainerSignature struct {
 	Payload   []byte
 	Signature []byte
-	PubKey    []byte
-	SigAlg    oci.SigningAlgorithm
 }
 
 // VerifyAttestationRequest is passed in on VerifyAttestation. It contains the

--- a/verifier/oci/cosign/fakesignature.go
+++ b/verifier/oci/cosign/fakesignature.go
@@ -19,7 +19,7 @@ func NewFakeSignature(data string, sigAlg oci.SigningAlgorithm) oci.Signature {
 
 // Payload returns a fake payload.
 func (f fakeSig) Payload() ([]byte, error) {
-	return []byte(f.data), nil
+	return []byte(f.data + "," + string(f.sigAlg)), nil
 }
 
 // Base64Encoded returns a fake base64 encoded signature.
@@ -29,15 +29,10 @@ func (f fakeSig) Base64Encoded() (string, error) {
 
 // PublicKey returns a fake public key.
 func (f fakeSig) PublicKey() ([]byte, error) {
-	return []byte(f.data), nil
+	return nil, fmt.Errorf("not implemented")
 }
 
 // SigningAlgorithm returns a fake signature algorithm.
 func (f fakeSig) SigningAlgorithm() (oci.SigningAlgorithm, error) {
-	switch f.sigAlg {
-	case oci.ECDSAP256SHA256, oci.RSASSAPKCS1V152048SHA256, oci.RSASSAPSS2048SHA256:
-		return f.sigAlg, nil
-	default:
-		return "", fmt.Errorf("unsupported signing algorithm: %v", f.sigAlg)
-	}
+	return "", fmt.Errorf("not implemented")
 }


### PR DESCRIPTION
OCI signatures are converted to a different structure in the Rest client for GCA. With the addition of ITA, we want to send a similar structure, so the conversion should be done at a higher level - the agent - rather than being verifier-specific.

The verifier client package will have its own `ContainerSignature` type - which contains only the fields that will be sent to verifier services - rather than using the full `oci.Signature` object.

`fakesignature` is also updated to remove implementations for `PublicKey` and `SigningAlgorthm` since the corresponding `fakeverifier` will use the new `ContainerSignature` type that lacks these methods. Instead, `fakeverifier` will parse the pubkey and sigalg from the payload - similar to how this is done in the actual verification process.

- In `verifier/client`, `VerifyAttestationRequest.ContainerImageSignatures` type is changed from `[]ociSignature` to `[]*ContainerSignature`
- In `verifier/fake`, `verifyContainerImageSignature()` is changed to `extractClaims()`
- In `verifier/oci/cosign/fakesignature`, `fakeSig.PublicKey()` and `fakeSig.SigningAlgorithm` now return "not implemented" errors. Additionally, `fakeSig.Payload()` returns "f.data,f.sigAlg" rather than the data alone.
- In `verifier/rest`, `convertOCISignatureToREST` is removed