### PR TITLE
Update releaser actions.

### DIFF
--- a/.github/workflows/releaser.yaml
+++ b/.github/workflows/releaser.yaml
@@ -19,10 +19,10 @@ jobs:
     name: Release (${{ matrix.os}}, Go ${{ matrix.go-version }})
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - uses: actions/setup-go@v3
+      - uses: actions/setup-go@v5
         with:
           go-version: ${{ matrix.go-version }}
           cache: true
@@ -39,7 +39,7 @@ jobs:
       - name: Build all modules
         run: go build -v ./... ./cmd/... ./launcher/... ./verifier/...
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v3
+        uses: goreleaser/goreleaser-action@v6
         if: success() && startsWith(github.ref, 'refs/tags/') && steps.cache.outputs.cache-hit != 'true'
         with:
           version: latest


### PR DESCRIPTION
The defaults of goreleaser v3 are deprecated.