### PR TITLE
Remove filesystem and timer dependencies from container_runner_test.go

### DIFF
--- a/launcher/models/data_writer.go
+++ b/launcher/models/data_writer.go
@@ -1,0 +1,46 @@
+// Package models contains models needed in client and server
+package models
+
+import (
+	"fmt"
+	"os"
+	"path"
+)
+
+const (
+	tokenFileTmp = ".token.tmp"
+)
+
+// DataWriter is an interface for writing opaque data to some destination.
+type DataWriter interface {
+	Write(token []byte) error
+}
+
+// FileWriter is a tokenWriter that writes the token to a file.
+type FileWriter struct {
+	directory string
+	filename  string
+}
+
+// Write writes the data to a tmp file before copying it over to the desired location.
+func (t *FileWriter) Write(token []byte) error {
+	// Write to a temp file first.
+	tmpTokenPath := path.Join(t.directory, tokenFileTmp)
+	if err := os.WriteFile(tmpTokenPath, token, 0644); err != nil {
+		return fmt.Errorf("failed to write a tmp token file: %v", err)
+	}
+
+	// Rename the temp file to the token file (to avoid race conditions).
+	if err := os.Rename(tmpTokenPath, path.Join(t.directory, t.filename)); err != nil {
+		return fmt.Errorf("failed to rename the token file: %v", err)
+	}
+	return nil
+}
+
+// NewFileWriter creates a FileWriter and ensures the directory exists.
+func NewFileWriter(directory string, filename string) (*FileWriter, error) {
+	if err := os.MkdirAll(directory, 0744); err != nil {
+		return nil, err
+	}
+	return &FileWriter{directory: directory, filename: filename}, nil
+}

--- a/launcher/models/fake_timer.go
+++ b/launcher/models/fake_timer.go
@@ -1,0 +1,36 @@
+package models
+
+import "time"
+
+// FakeTimer is a fake implementation of Timer for testing purposes.
+type FakeTimer struct {
+	OutChan   chan time.Time
+	ResetChan chan int
+	StopChan  chan int
+}
+
+// NewFakeTimer creates a new instance of FakeTimer.
+func NewFakeTimer() *FakeTimer {
+	return &FakeTimer{
+		OutChan:   make(chan time.Time, 1),
+		ResetChan: make(chan int, 1),
+		StopChan:  make(chan int, 1),
+	}
+}
+
+// C returns the channel on which the timer will send the current time when it fires.
+func (f *FakeTimer) C() <-chan time.Time {
+	return f.OutChan
+}
+
+// Reset notifies the reset channel to signal that that reset was called.
+func (f *FakeTimer) Reset(_ time.Duration) bool {
+	f.ResetChan <- 1
+	return true
+}
+
+// Stop notifies the stop channel to signal that stop was called.
+func (f *FakeTimer) Stop() bool {
+	f.StopChan <- 1
+	return true
+}

--- a/launcher/models/fake_token_writer.go
+++ b/launcher/models/fake_token_writer.go
@@ -1,0 +1,51 @@
+package models
+
+import (
+	"errors"
+	"sync"
+)
+
+// FakeTokenWriter is a fake implementation of TokenWriter for testing purposes.
+type FakeTokenWriter struct {
+	tokensReturned int
+	tokens         [][]byte
+	writeTokenFunc func([]byte) error
+	mu             *sync.Mutex
+}
+
+// NewFakeTokenWriter creates a new instance of FakeTokenWriter.
+func NewFakeTokenWriter() *FakeTokenWriter {
+	return &FakeTokenWriter{
+		tokensReturned: 0,
+		tokens:         make([][]byte, 0),
+		writeTokenFunc: nil,
+		mu:             &sync.Mutex{},
+	}
+}
+
+// Write calls writeTokenFunc to write the token if it is set, otherwise appends the token to the tokens slice.
+func (f *FakeTokenWriter) Write(data []byte) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	if f.writeTokenFunc != nil {
+		return f.writeTokenFunc(data)
+	}
+
+	f.tokens = append(f.tokens, data)
+	return nil
+}
+
+// GetNextToken returns the next token from the tokens slice.
+// It returns an error if there are no more tokens to return.
+func (f *FakeTokenWriter) GetNextToken() ([]byte, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	if f.tokensReturned >= len(f.tokens) {
+		return nil, errors.New("no new token added")
+	}
+
+	f.tokensReturned++
+	return f.tokens[f.tokensReturned-1], nil
+}

--- a/launcher/models/file_writer_test.go
+++ b/launcher/models/file_writer_test.go
@@ -1,0 +1,31 @@
+package models
+
+import (
+	"bytes"
+	"os"
+	"path"
+	"testing"
+
+	"github.com/google/go-tpm-tools/launcher/launcherfile"
+)
+
+func TestFileWriterWritesToDisk(t *testing.T) {
+	// Do not create the directory
+
+	directory := launcherfile.HostTmpPath
+	filename := "token"
+	tokenWriter, err := NewFileWriter(directory, filename)
+	if err != nil {
+		t.Fatalf("failed to create token writer: %v", err)
+	}
+	tokenWriter.Write([]byte("test token"))
+
+	data, err := os.ReadFile(path.Join(directory, filename))
+	if err != nil {
+		t.Fatalf("failed to read token file: %v", err)
+	}
+
+	if !bytes.Equal(data, []byte("test token")) {
+		t.Errorf("token written to file does not match expected token: got %v, want %v", data, "test token")
+	}
+}

--- a/launcher/models/real_timer_test.go
+++ b/launcher/models/real_timer_test.go
@@ -1,0 +1,28 @@
+package models
+
+import (
+	"fmt"
+	"testing"
+	"time"
+)
+
+// This test relies on the timeout to fail, since channels will block indefinitely.
+func TestRealTimerFires(_ *testing.T) {
+	timer := NewRealTimer(100 * time.Millisecond)
+	time.Sleep(125 * time.Millisecond)
+	<-timer.C()
+
+	fmt.Printf("%v\n", timer.Reset(100*time.Millisecond))
+	time.Sleep(125 * time.Millisecond)
+	<-timer.C()
+}
+
+// This test relies on the timeout to fail, since channels will block indefinitely.
+func TestRealTimerFiresInstantly(_ *testing.T) {
+	timer := NewRealTimer(0)
+	<-timer.C()
+
+	timer.Reset(100 * time.Millisecond)
+	time.Sleep(125 * time.Millisecond)
+	<-timer.C()
+}

--- a/launcher/models/timer.go
+++ b/launcher/models/timer.go
@@ -1,0 +1,37 @@
+package models
+
+import "time"
+
+// Timer is an interface that wraps the basic methods of time.Timer.
+type Timer interface {
+	C() <-chan time.Time
+	Stop() bool
+	Reset(time.Duration) bool
+}
+
+// RealTimer is an implementation of Timer that uses a real time.Timer.
+type RealTimer struct {
+	inner *time.Timer
+}
+
+// NewRealTimer creates and returns a reference to a RealTimer.
+func NewRealTimer(d time.Duration) *RealTimer {
+	return &RealTimer{
+		inner: time.NewTimer(d),
+	}
+}
+
+// C returns the channel on which the timer will send the current time when it fires.
+func (t *RealTimer) C() <-chan time.Time {
+	return t.inner.C
+}
+
+// Stop stops the timer and returns true if the timer was active.
+func (t *RealTimer) Stop() bool {
+	return t.inner.Stop()
+}
+
+// Reset resets the timer to the specified duration and returns true if the timer was active.
+func (t *RealTimer) Reset(d time.Duration) bool {
+	return t.inner.Reset(d)
+}


### PR DESCRIPTION
This PR aims to remove time.Sleep() from container_runner_test.go to reduce flakiness and reduce test runtime.

To do this I added:

- A timer interface
- A real and fake implementation of the timer interface.
- A data writer interface
- A real and fake implementation of a token writer

I put these in "models" to separate them from the core "container_runner" logic.

In addition, the test TestTokenIsNotChangedIfRefreshFails was removed as it is redundant with TestTokenRefreshRetryPolicyFail.

