### PR TITLE
Add driver digest verification in confidential GPU driver installation flow

### DIFF
--- a/go.work.sum
+++ b/go.work.sum
@@ -706,6 +706,7 @@ github.com/andreyvit/diff v0.0.0-20170406064948-c7f18ee00883/go.mod h1:rCTlJbsFo
 github.com/andygrunwald/go-gerrit v0.0.0-20201231163137-46815e48bfe0/go.mod h1:soxaYLbAFToS0OelBriItCts/mtUZOuLBkCk1Xv4ZSo=
 github.com/apache/arrow/go/v15 v15.0.2/go.mod h1:DGXsR3ajT524njufqf95822i+KTh+yea1jass9YXgjA=
 github.com/aws/aws-sdk-go v1.43.16/go.mod h1:y4AeaBuwd2Lk+GepC1E9v0qOiTws0MIWAX4oIKwKHZo=
+github.com/beevik/etree v1.1.0/go.mod h1:r8Aw8JqVegEf0w2fDnATrX9VpkMcyFeM0FhwO62wh+A=
 github.com/blang/semver/v4 v4.0.0/go.mod h1:IbckMUScFkM3pff0VJDNKRiT6TG/YpiHIM2yvyW5YoQ=
 github.com/bshuster-repo/logrus-logstash-hook v1.0.0/go.mod h1:zsTqEiSzDgAa/8GZR7E1qaXrhYNDKBYy5/dWPTIflbk=
 github.com/buger/jsonparser v1.1.1/go.mod h1:6RYKKt7H4d4+iWqouImQ9R2FZql3VbhNgx27UK13J/0=
@@ -954,6 +955,7 @@ github.com/safchain/ethtool v0.0.0-20210803160452-9aa261dae9b1/go.mod h1:Z0q5wiB
 github.com/sclevine/agouti v3.0.0+incompatible/go.mod h1:b4WX9W9L1sfQKXeJf1mUTLZKJ48R1S7H23Ji7oFO5Bw=
 github.com/seccomp/libseccomp-golang v0.9.2-0.20210429002308-3879420cc921/go.mod h1:JA8cRccbGaA1s33RQf7Y1+q9gHmZX1yB/z9WDN1C6fg=
 github.com/sirupsen/logrus v1.9.0/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=
+github.com/smartystreets/assertions v1.1.1/go.mod h1:tcbTF8ujkAEcZ8TElKY+i30BzYlVhC/LOxJk7iOWnoo=
 github.com/spaolacci/murmur3 v1.1.0/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/spdx/tools-golang v0.5.3/go.mod h1:/ETOahiAo96Ob0/RAIBmFZw6XN0yTnyr/uFZm2NTMhI=
 github.com/spf13/afero v1.10.0/go.mod h1:UBogFpq8E9Hx+xc5CNTTEpTnuHVmXDwZcZcE1eb/UhQ=
@@ -984,6 +986,7 @@ github.com/yashtewari/glob-intersection v0.1.0/go.mod h1:LK7pIC3piUjovexikBbJ26Y
 github.com/yuin/goldmark v1.4.1/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
 github.com/zeebo/xxh3 v1.0.2/go.mod h1:5NWz9Sef7zIDm2JHfFlcQvNekmcEl9ekUZQQKCYaDcA=
+go.chromium.org/luci v0.0.0-20200722211809-bab0c30be68b/go.mod h1:MIQewVTLvOvc0UioV0JNqTNO/RspKFS0XEeoKrOxsdM=
 go.einride.tech/aip v0.67.1/go.mod h1:ZGX4/zKw8dcgzdLsrvpOOGxfxI2QSk12SlP7d6c0/XI=
 go.einride.tech/aip v0.68.0/go.mod h1:7y9FF8VtPWqpxuAxl0KQWqaULxW4zFIesD6zF5RIHHg=
 go.etcd.io/bbolt v1.3.7/go.mod h1:N9Mkw9X8x5fupy0IKsmuqVtoGDyxsaDlbk4Rd05IAQw=

--- a/launcher/image/preload.sh
+++ b/launcher/image/preload.sh
@@ -6,8 +6,8 @@ readonly EXPERIMENTS_BINARY="confidential_space_experiments"
 readonly GPU_REF_VALUES_PATH="${CS_PATH}/gpu"
 readonly COS_GPU_INSTALLER_IMAGE_REF="${GPU_REF_VALUES_PATH}/cos_gpu_installer_image_ref"
 readonly COS_GPU_INSTALLER_IMAGE_DIGEST="${GPU_REF_VALUES_PATH}/cos_gpu_installer_image_digest"
-readonly DRIVER_DIGEST_SHA256SUM="${GPU_REF_VALUES_PATH}/driver_digest_sha256sum"
-readonly DRIVERS_GCS_BUCKET="cos-nvidia-gpu-drivers"
+readonly DRIVER_DIGEST="${GPU_REF_VALUES_PATH}/driver_digest"
+readonly DRIVER_GCS_BUCKET="cos-nvidia-gpu-drivers"
 
 copy_launcher() {
   cp launcher "${CS_PATH}/cs_container_launcher"
@@ -128,24 +128,35 @@ get_cos_gpu_installer_image_digest() {
   echo "${image_digest}"
 }
 
-set_reference_driver_digest() {
-  local driver_version
-  local driver_digest_gcs_url
-
-  # Fetching the default driver version for H100 GPU.
-  driver_version=$(cos-extensions list -- --target-gpu NVIDIA_H100_80GB | grep DEFAULT | cut -d" " -f 1)
-  driver_digest_gcs_url="https://storage.googleapis.com/${DRIVERS_GCS_BUCKET}/sha256/NVIDIA-Linux-x86_64-${driver_version}.run.sha256"
-  if ! curl -sSL ${driver_digest_gcs_url} -o ${DRIVER_DIGEST_SHA256SUM}; then
-    echo "Error: failed to download the driver digest file from ${driver_digest_gcs_url}." >&2
-    return 1
-  fi
-  
-  driver_digest=$(cat ${DRIVER_DIGEST_SHA256SUM} | cut -d " " -f 1)
+validate_sha256_hex() {
+  driver_digest="${1}"
   # Check for the expected length of the SHA256 digest (64 hex characters)
   if [ ${#driver_digest} -ne 64 ]; then
     echo "Error: driver digest has an unexpected length: ${#driver_digest}, Expected 64." >&2
     return 1
   fi
+  # Check for valid hexadecimal string
+  if [[ ! ${driver_digest} =~ ^[0-9a-fA-F]+$ ]]; then
+    return "Error: driver digest ${driver_digest} is not a valid hexadecimal string." >&2
+    return 1
+  fi
+}
+
+store_driver_digest() {
+  local gpu_type="${1}"
+  local driver_version
+  local driver_digest_gcs_url
+
+  # Fetching the default driver version for the given GPU.
+  driver_version=$(cos-extensions list -- --target-gpu ${gpu_type} | grep DEFAULT | cut -d" " -f 1)
+  driver_digest_gcs_url="https://storage.googleapis.com/${DRIVER_GCS_BUCKET}/sha256/NVIDIA-Linux-x86_64-${driver_version}.run.sha256"
+  if ! curl -sSL ${driver_digest_gcs_url} -o ${DRIVER_DIGEST}; then
+    echo "Error: failed to download the driver digest file from ${driver_digest_gcs_url}." >&2
+    return 1
+  fi
+  
+  driver_digest=$(cat ${DRIVER_DIGEST} | cut -d " " -f 1)
+  validate_sha256_hex ${driver_digest}
 }
 
 
@@ -161,21 +172,17 @@ set_gpu_driver_ref_values() {
   fi
 
   cos_gpu_installer_image_digest=$(get_cos_gpu_installer_image_digest ${cos_gpu_installer_image_ref})
-  if [ -z "${cos_gpu_installer_image_ref}" ]; then
+  if [ -z "${cos_gpu_installer_image_digest}" ]; then
     echo "Error: get_cos_gpu_installer_image_digest returned an empty or invalid digest for: ${cos_gpu_installer_image_ref}." >&2
     return 1
   fi
 
   image_digest_hex_part=$(echo "${cos_gpu_installer_image_digest}" | sed 's/^sha256://' | tr -d '[:space:]')
-  # Check for the expected length of the SHA256 digest (64 hex characters)
-  if [ ${#image_digest_hex_part} -ne 64 ]; then
-    echo "Error: cos_gpu_installer image digest has an unexpected length: ${#image_digest_hex_part}, Expected 64." >&2
-    return 1
-  fi
+  validate_sha256_hex ${image_digest_hex_part}
   
   echo ${cos_gpu_installer_image_ref} > ${COS_GPU_INSTALLER_IMAGE_REF}
   echo ${cos_gpu_installer_image_digest} > ${COS_GPU_INSTALLER_IMAGE_DIGEST}
-  set_reference_driver_digest
+  store_driver_digest "NVIDIA_H100_80GB"
 }
 
 main() {

--- a/launcher/internal/gpu/config.go
+++ b/launcher/internal/gpu/config.go
@@ -9,4 +9,6 @@ const (
 	InstallerImageRefFile = "/usr/share/oem/confidential_space/gpu/cos_gpu_installer_image_ref"
 	// InstallerImageDigestFile is a filename which has the container image digest of cos_gpu_installer.
 	InstallerImageDigestFile = "/usr/share/oem/confidential_space/gpu/cos_gpu_installer_image_digest"
+	// ReferenceDriverDigestFile is a filename which has the reference digest of nvidia driver installer.
+	ReferenceDriverDigestFile = "/usr/share/oem/confidential_space/gpu/driver_digest_sha256sum"
 )

--- a/launcher/internal/gpu/config.go
+++ b/launcher/internal/gpu/config.go
@@ -10,5 +10,5 @@ const (
 	// InstallerImageDigestFile is a filename which has the container image digest of cos_gpu_installer.
 	InstallerImageDigestFile = "/usr/share/oem/confidential_space/gpu/cos_gpu_installer_image_digest"
 	// ReferenceDriverDigestFile is a filename which has the reference digest of nvidia driver installer.
-	ReferenceDriverDigestFile = "/usr/share/oem/confidential_space/gpu/driver_digest_sha256sum"
+	ReferenceDriverDigestFile = "/usr/share/oem/confidential_space/gpu/driver_digest"
 )

--- a/launcher/internal/gpu/driverinstaller.go
+++ b/launcher/internal/gpu/driverinstaller.go
@@ -220,7 +220,7 @@ func verifyDriverDigest(driverFile, referenceHash string) error {
 		return err
 	}
 	if calculatedHash != referenceHash {
-		return fmt.Errorf("gpu driver digest verification failed - expected : %s, got : %s", referenceHash, calculatedHash)
+		return fmt.Errorf("GPU driver digest verification failed - expected : %s, got : %s", referenceHash, calculatedHash)
 	}
 	return nil
 }

--- a/launcher/internal/gpu/driverinstaller_test.go
+++ b/launcher/internal/gpu/driverinstaller_test.go
@@ -291,14 +291,14 @@ func TestVerifyDriverDigest(t *testing.T) {
 			driverDigest:    "test-digest",
 			refDriverDigest: "8edf273aa28919d86f9f0ab68b1f267280821a3251c281d19748f940c180d27a",
 			wantErr:         true,
-			errSubstr:       "gpu driver digest verification failed",
+			errSubstr:       "GPU driver digest verification failed",
 		},
 		{
 			name:            "Empty reference driver digest",
 			driverDigest:    "test-digest",
 			refDriverDigest: "",
 			wantErr:         true,
-			errSubstr:       "gpu driver digest verification failed",
+			errSubstr:       "GPU driver digest verification failed",
 		},
 		{
 			name:            "Installed driver file does not exist",


### PR DESCRIPTION
This PR contains the following changes:

- Adds the verification of driver (nvidia .run file) digest in driver installation flow.
- Reads the run file digest from well known public GCS bucket and stores it under OEM partition as reference driver digest.
- Required utility functions for parsing and hash calculation.  

**Testing:**

- Existing image tests for confidential GPU ran successfully.
- Unit tests for newly added functions

**Changes which would be part of follow-up PR:**

- Measure GPU CC mode status.

