### PR TITLE
Update zone for CGPU image tests

### DIFF
--- a/launcher/image/test/test_gpu_driver_installation_cloudbuild.yaml
+++ b/launcher/image/test/test_gpu_driver_installation_cloudbuild.yaml
@@ -3,7 +3,7 @@ substitutions:
   '_IMAGE_PROJECT': ''
   '_CLEANUP': 'true'
   '_VM_NAME_PREFIX': 'cs-cgpu-test'
-  '_ZONE': 'us-west1-b'
+  '_ZONE': 'us-east1-c'
   '_WORKLOAD_IMAGE': 'us-west1-docker.pkg.dev/confidential-space-images-dev/cs-integ-test-images/gpu/cuda-vector-add:latest'
 steps:
 - name: 'gcr.io/cloud-builders/gcloud'


### PR DESCRIPTION
Image build fails because of the stockout error for zone `us-west1-b`. This PR moves the tests to different zone.

```
Step #4 - "CreateTDXCVMWithNonConfidentialGPU": ERROR: (gcloud.compute.instances.create) Could not fetch resource:
Step #4 - "CreateTDXCVMWithNonConfidentialGPU": ---
Step #4 - "CreateTDXCVMWithNonConfidentialGPU": code: ZONE_RESOURCE_POOL_EXHAUSTED_WITH_DETAILS
Step #4 - "CreateTDXCVMWithNonConfidentialGPU": errorDetails:
Step #4 - "CreateTDXCVMWithNonConfidentialGPU": - help:
Step #4 - "CreateTDXCVMWithNonConfidentialGPU":     links:
Step #4 - "CreateTDXCVMWithNonConfidentialGPU":     - description: Troubleshooting documentation
Step #4 - "CreateTDXCVMWithNonConfidentialGPU":       url: https://cloud.google.com/compute/docs/resource-error
Step #4 - "CreateTDXCVMWithNonConfidentialGPU": - localizedMessage:
Step #4 - "CreateTDXCVMWithNonConfidentialGPU":     locale: en-US
Step #4 - "CreateTDXCVMWithNonConfidentialGPU":     message: A n1-standard-4 VM instance with 1 nvidia-tesla-t4 accelerator(s) is
Step #4 - "CreateTDXCVMWithNonConfidentialGPU":       currently unavailable in the us-west1-b zone. Consider trying your request in
Step #4 - "CreateTDXCVMWithNonConfidentialGPU":       another zone which has capacity to accommodate your request. Alternatively,
Step #4 - "CreateTDXCVMWithNonConfidentialGPU":       you can try your request again with a different VM hardware configuration or
Step #4 - "CreateTDXCVMWithNonConfidentialGPU":       at a later time. For more information, see the troubleshooting documentation.
Step #4 - "CreateTDXCVMWithNonConfidentialGPU": - errorInfo:
Step #4 - "CreateTDXCVMWithNonConfidentialGPU":     domain: compute.googleapis.com
Step #4 - "CreateTDXCVMWithNonConfidentialGPU":     metadatas:
Step #4 - "CreateTDXCVMWithNonConfidentialGPU":       attachment: nvidia-tesla-t4:1
Step #4 - "CreateTDXCVMWithNonConfidentialGPU":       vmType: n1-standard-4
Step #4 - "CreateTDXCVMWithNonConfidentialGPU":       zone: us-west1-b
Step #4 - "CreateTDXCVMWithNonConfidentialGPU":       zonesAvailable: ''
Step #4 - "CreateTDXCVMWithNonConfidentialGPU":     reason: stockout
```