### PR TITLE
Add HashNonce flag to Attest and VerifyAttestation

### DIFF
--- a/client/attest.go
+++ b/client/attest.go
@@ -59,6 +59,11 @@ type AttestOpts struct {
 	// depending on the technology's size. Leaving this nil is not recommended. If
 	// nil, then TEEDevice must be nil.
 	TEENonce []byte
+	// HashNonce will apply the attestation key's signing scheme hash algorithm
+	// to the input Nonce field and use the resulting digest in place of the
+	// original Nonce.
+	// Nonce must still be unique and application-specific.
+	HashNonce bool
 }
 
 // SevSnpQuoteProvider encapsulates the SEV-SNP attestation device to add its attestation report
@@ -286,8 +291,16 @@ func (k *Key) Attest(opts AttestOpts) (*pb.Attestation, error) {
 		return nil, fmt.Errorf("failed to encode public area: %w", err)
 	}
 	attestation.AkCert = k.CertDERBytes()
+	extraData := opts.Nonce
+	if opts.HashNonce {
+		var err error
+		extraData, err = internal.HashNonce(k.PublicArea(), extraData)
+		if err != nil {
+			return nil, fmt.Errorf("failed to hash the input nonce: %w", err)
+		}
+	}
 	for _, sel := range sels {
-		quote, err := k.Quote(sel, opts.Nonce)
+		quote, err := k.Quote(sel, extraData)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/quote.go
+++ b/internal/quote.go
@@ -133,3 +133,20 @@ func validatePCRDigest(quoteInfo *tpm2.QuoteInfo, pcrs *pb.PCRs, hash crypto.Has
 	}
 	return nil
 }
+
+// HashNonce takes an arbitrary-sized nonce and ensures it can fit in the TPM's
+// extraData field by applying the given key's signing hash algorithm to the
+// nonce.
+func HashNonce(pubArea tpm2.Public, nonce []byte) ([]byte, error) {
+	sigHash, err := GetSigningHashAlg(pubArea)
+	if err != nil {
+		return nil, err
+	}
+	chash, err := sigHash.Hash()
+	if err != nil {
+		return nil, err
+	}
+	hasher := chash.New()
+	hasher.Write(nonce)
+	return hasher.Sum(nil), nil
+}

--- a/server/verify_test.go
+++ b/server/verify_test.go
@@ -13,6 +13,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"strconv"
 	"testing"
 
 	"github.com/google/go-tpm-tools/client"
@@ -217,6 +218,47 @@ func TestVerifyWithTrustedAK(t *testing.T) {
 	_, err = VerifyAttestation(attestation, opts)
 	if err != nil {
 		t.Errorf("failed to verify: %v", err)
+	}
+}
+
+func TestVerifyHashNonce(t *testing.T) {
+	rwc := test.GetTPM(t)
+	defer client.CheckedClose(t, rwc)
+
+	ak, err := client.AttestationKeyRSA(rwc)
+	if err != nil {
+		t.Fatalf("failed to generate AK: %v", err)
+	}
+	defer ak.Close()
+	tests := []struct {
+		attHash bool
+		verHash bool
+		wantErr bool
+	}{
+		{true, true, false},
+		{false, false, false},
+		{true, false, true},
+		{false, true, true},
+	}
+	nonce := []byte("super secret nonce")
+
+	for _, test := range tests {
+		t.Run("attest hash "+strconv.FormatBool(test.attHash)+" verify hash "+strconv.FormatBool(test.verHash), func(t *testing.T) {
+			attestation, err := ak.Attest(client.AttestOpts{Nonce: nonce, HashNonce: test.attHash})
+			if err != nil {
+				t.Fatalf("failed to attest: %v", err)
+			}
+
+			opts := VerifyOpts{
+				Nonce:      nonce,
+				TrustedAKs: []crypto.PublicKey{ak.PublicKey()},
+				HashNonce:  test.verHash,
+			}
+			_, err = VerifyAttestation(attestation, opts)
+			if test.wantErr != (err != nil) {
+				t.Errorf("Attest(HashNonce %v), Verify(HashNonce %v): got %v wantErr %v", test.attHash, test.verHash, err, test.wantErr)
+			}
+		})
 	}
 }
 
@@ -439,7 +481,7 @@ func TestValidateAK(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			_, _, err := validateAK(tc.att(), tc.opts)
+			_, _, _, err := validateAK(tc.att(), tc.opts)
 			if gotPass := (err == nil); gotPass != tc.wantPass {
 				t.Errorf("ValidateAK failed, got pass %v, but want %v", gotPass, tc.wantPass)
 			}


### PR DESCRIPTION
Currently, key.Attest takes a slice of data for the attestation nonce. This gets passed directly to the TPM. However, verifiers that are not aware of the TPM's max size for extraData can inadvertently send a challenge that is too large.
This change introduces a HashNonce flag that uses the key's signing scheme hash algorithm to first hash the AttestOpts nonce. The server package also introduces the same logic to hash the nonce based on the Attestation message's AkPub signing scheme.
This allows verifiers to send an arbitrary amount of entropy without knowing the max hash size of the TPM.

Note: this may be a breaking change to users that don't populate AKPub within the attestation proto. This was never optional, and it was always populated by the go-tpm-tools client code.