### PR TITLE
Add testutils package to make select test helpers publicly available

### DIFF
--- a/testutil/utils.go
+++ b/testutil/utils.go
@@ -8,6 +8,11 @@ import (
 	"github.com/google/go-tpm-tools/internal/test"
 )
 
+// GetTPM is a cross-platform testing helper function that retrives the
+// appropriate TPM device from the flags passed into "go test".
+//
+// If using a test TPM, this will also retrieve a test eventlog. In this case,
+// GetTPM extends the test event log's events into the test TPM.
 func GetTPM(tb testing.TB) io.ReadWriteCloser {
 	return test.GetTPM(tb)
 }

--- a/testutil/utils.go
+++ b/testutil/utils.go
@@ -1,0 +1,13 @@
+// Package testutil wraps select test utilities to make them externally usable.
+package testutil
+
+import (
+	"io"
+	"testing"
+
+	"github.com/google/go-tpm-tools/internal/test"
+)
+
+func GetTPM(tb testing.TB) io.ReadWriteCloser {
+	return test.GetTPM(tb)
+}


### PR DESCRIPTION
Adds a wrapper package around internal test functions as our need for testing outside of this repo expands.

Since `GetTPM` makes use of a package-level lock in `internal/test`, it is better to wrap the function than move it to a new package (same for any future functions in that package we also want to make available).