### PR TITLE
cel.AppendEventPCR extends to all PCR banks

### DIFF
--- a/cel/canonical_eventlog_test.go
+++ b/cel/canonical_eventlog_test.go
@@ -28,10 +28,10 @@ func TestCELEncodingDecoding(t *testing.T) {
 	cel := &CEL{}
 
 	cosEvent := CosTlv{ImageDigestType, []byte("sha256:781d8dfdd92118436bd914442c8339e653b83f6bf3c1a7a98efcfb7c4fed7483")}
-	appendPcrEventOrFatal(t, cel, tpm, test.DebugPCR, measuredHashes, cosEvent)
+	appendPcrEventOrFatal(t, cel, tpm, test.DebugPCR, cosEvent)
 
 	cosEvent2 := CosTlv{ImageRefType, []byte("docker.io/bazel/experimental/test:latest")}
-	appendPcrEventOrFatal(t, cel, tpm, test.ApplicationPCR, measuredHashes, cosEvent2)
+	appendPcrEventOrFatal(t, cel, tpm, test.ApplicationPCR, cosEvent2)
 
 	var buf bytes.Buffer
 	if err := cel.EncodeCEL(&buf); err != nil {
@@ -92,19 +92,19 @@ func TestCELMeasureAndReplay(t *testing.T) {
 	rand.Read(someEvent2)
 	cosEvent2 := CosTlv{ImageDigestType, someEvent2}
 
-	appendPcrEventOrFatal(t, cel, tpm, test.DebugPCR, measuredHashes, cosEvent)
+	appendPcrEventOrFatal(t, cel, tpm, test.DebugPCR, cosEvent)
 	appendRtmrEventOrFatal(t, celRTMR, fakeRTMR, CosRTMR, cosEvent)
 
-	appendPcrEventOrFatal(t, cel, tpm, test.DebugPCR, measuredHashes, cosEvent2)
+	appendPcrEventOrFatal(t, cel, tpm, test.DebugPCR, cosEvent2)
 	appendRtmrEventOrFatal(t, celRTMR, fakeRTMR, CosRTMR, cosEvent)
 
-	appendPcrEventOrFatal(t, cel, tpm, test.ApplicationPCR, measuredHashes, cosEvent2)
+	appendPcrEventOrFatal(t, cel, tpm, test.ApplicationPCR, cosEvent2)
 	appendRtmrEventOrFatal(t, celRTMR, fakeRTMR, CosRTMR, cosEvent2)
 
-	appendPcrEventOrFatal(t, cel, tpm, test.ApplicationPCR, measuredHashes, cosEvent)
+	appendPcrEventOrFatal(t, cel, tpm, test.ApplicationPCR, cosEvent)
 	appendRtmrEventOrFatal(t, celRTMR, fakeRTMR, CosRTMR, cosEvent)
 
-	appendPcrEventOrFatal(t, cel, tpm, test.ApplicationPCR, measuredHashes, cosEvent)
+	appendPcrEventOrFatal(t, cel, tpm, test.ApplicationPCR, cosEvent)
 	appendRtmrEventOrFatal(t, celRTMR, fakeRTMR, CosRTMR, cosEvent)
 
 	replay(t, cel, tpm, measuredHashes,
@@ -127,11 +127,11 @@ func TestCELReplayFailTamperedDigest(t *testing.T) {
 	rand.Read(someEvent2)
 	cosEvent2 := CosTlv{ImageDigestType, someEvent2}
 
-	appendPcrEventOrFatal(t, cel, tpm, test.DebugPCR, measuredHashes, cosEvent)
-	appendPcrEventOrFatal(t, cel, tpm, test.DebugPCR, measuredHashes, cosEvent2)
-	appendPcrEventOrFatal(t, cel, tpm, test.ApplicationPCR, measuredHashes, cosEvent2)
-	appendPcrEventOrFatal(t, cel, tpm, test.ApplicationPCR, measuredHashes, cosEvent)
-	appendPcrEventOrFatal(t, cel, tpm, test.ApplicationPCR, measuredHashes, cosEvent)
+	appendPcrEventOrFatal(t, cel, tpm, test.DebugPCR, cosEvent)
+	appendPcrEventOrFatal(t, cel, tpm, test.DebugPCR, cosEvent2)
+	appendPcrEventOrFatal(t, cel, tpm, test.ApplicationPCR, cosEvent2)
+	appendPcrEventOrFatal(t, cel, tpm, test.ApplicationPCR, cosEvent)
+	appendPcrEventOrFatal(t, cel, tpm, test.ApplicationPCR, cosEvent)
 
 	modifiedRecord := cel.Records[3]
 	for hash := range modifiedRecord.Digests {
@@ -162,13 +162,49 @@ func TestCELReplayFailMissingPCRsInBank(t *testing.T) {
 	someEvent2 := make([]byte, 10)
 	rand.Read(someEvent2)
 
-	appendPcrEventOrFatal(t, cel, tpm, test.DebugPCR, measuredHashes, CosTlv{ImageRefType, someEvent})
-	appendPcrEventOrFatal(t, cel, tpm, test.ApplicationPCR, measuredHashes, CosTlv{ImageDigestType, someEvent2})
+	appendPcrEventOrFatal(t, cel, tpm, test.DebugPCR, CosTlv{ImageRefType, someEvent})
+	appendPcrEventOrFatal(t, cel, tpm, test.ApplicationPCR, CosTlv{ImageDigestType, someEvent2})
 
 	replay(t, cel, tpm, measuredHashes,
 		[]int{test.DebugPCR}, false /*shouldSucceed*/)
 	replay(t, cel, tpm, measuredHashes,
 		[]int{test.ApplicationPCR}, false /*shouldSucceed*/)
+}
+
+func TestCELMeasureToAllPCRBanks(t *testing.T) {
+	tpm := test.GetTPM(t)
+	defer client.CheckedClose(t, tpm)
+
+	pcrs, err := client.ReadAllPCRs(tpm)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, bank := range pcrs {
+		// make sure debug pcr is empty before the append
+		if !isZeroBytes(bank.Pcrs[uint32(test.DebugPCR)]) {
+			t.Fatalf("PCR %d in bank %s is not empty before appending event", test.DebugPCR, bank.Hash.String())
+		}
+	}
+
+	cel := &CEL{}
+	someEvent := make([]byte, 10)
+	appendPcrEventOrFatal(t, cel, tpm, test.DebugPCR, CosTlv{ImageRefType, someEvent})
+
+	pcrs, err = client.ReadAllPCRs(tpm)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, bank := range pcrs {
+		// make sure debug pcr is NOT empty after the append
+		if isZeroBytes(bank.Pcrs[uint32(test.DebugPCR)]) {
+			t.Fatalf("PCR %d in bank %s is empty after appending event", test.DebugPCR, bank.Hash.String())
+		}
+	}
+}
+
+func isZeroBytes(bs []byte) bool {
+	allZeros := make([]byte, len(bs))
+	return bytes.Equal(allZeros, bs)
 }
 
 func replay(t *testing.T, cel *CEL, tpm io.ReadWriteCloser, measuredHashes []crypto.Hash, pcrs []int, shouldSucceed bool) {
@@ -217,8 +253,8 @@ func replayRTMR(t *testing.T, cel *CEL, rtmr *fakertmr.RtmrSubsystem, rtmrs []in
 	}
 }
 
-func appendPcrEventOrFatal(t *testing.T, cel *CEL, tpm io.ReadWriteCloser, pcr int, hashAlgos []crypto.Hash, event Content) {
-	if err := cel.AppendEventPCR(tpm, pcr, hashAlgos, event); err != nil {
+func appendPcrEventOrFatal(t *testing.T, cel *CEL, tpm io.ReadWriteCloser, pcr int, event Content) {
+	if err := cel.AppendEventPCR(tpm, pcr, event); err != nil {
 		t.Fatalf("failed to append PCR event: %v", err)
 	}
 }

--- a/cel/cos_tlv_test.go
+++ b/cel/cos_tlv_test.go
@@ -42,7 +42,7 @@ func TestCosEventlog(t *testing.T) {
 	for _, testEvent := range testEvents {
 		cosEvent := CosTlv{testEvent.cosNestedEventType, testEvent.eventPayload}
 
-		if err := cel.AppendEventPCR(tpm, testEvent.pcr, measuredHashes, cosEvent); err != nil {
+		if err := cel.AppendEventPCR(tpm, testEvent.pcr, cosEvent); err != nil {
 			t.Fatal(err)
 		}
 	}

--- a/client/attest.go
+++ b/client/attest.go
@@ -276,7 +276,7 @@ func (k *Key) Attest(opts AttestOpts) (*pb.Attestation, error) {
 	if len(opts.Nonce) == 0 {
 		return nil, fmt.Errorf("provided nonce must not be empty")
 	}
-	sels, err := allocatedPCRs(k.rw)
+	sels, err := AllocatedPCRs(k.rw)
 	if err != nil {
 		return nil, err
 	}

--- a/client/pcr.go
+++ b/client/pcr.go
@@ -26,8 +26,8 @@ const (
 // CertifyHashAlgTpm is the hard-coded algorithm used in certify PCRs.
 const CertifyHashAlgTpm = tpm2.AlgSHA256
 
-// allocatedPCRs returns a list of selections corresponding to the TPM's implemented PCRs.
-func allocatedPCRs(rw io.ReadWriter) ([]tpm2.PCRSelection, error) {
+// AllocatedPCRs returns a list of selections corresponding to the TPM's implemented PCRs.
+func AllocatedPCRs(rw io.ReadWriter) ([]tpm2.PCRSelection, error) {
 	caps, moreData, err := tpm2.GetCapability(rw, tpm2.CapabilityPCRs, math.MaxUint32, 0)
 	if err != nil {
 		return nil, fmt.Errorf("listing implemented PCR banks: %w", err)
@@ -80,7 +80,7 @@ func ReadPCRs(rw io.ReadWriter, sel tpm2.PCRSelection) (*pb.PCRs, error) {
 
 // ReadAllPCRs fetches all the PCR values from all implemented PCR banks.
 func ReadAllPCRs(rw io.ReadWriter) ([]*pb.PCRs, error) {
-	sels, err := allocatedPCRs(rw)
+	sels, err := AllocatedPCRs(rw)
 	if err != nil {
 		return nil, err
 	}

--- a/go.work.sum
+++ b/go.work.sum
@@ -17,7 +17,6 @@ cloud.google.com/go v0.113.0/go.mod h1:glEqlogERKYeePz6ZdkcLJ28Q2I6aERgDDErBg9Gz
 cloud.google.com/go v0.115.1/go.mod h1:DuujITeaufu3gL68/lOFIirVNJwQeyf5UXyi+Wbgknc=
 cloud.google.com/go v0.117.0/go.mod h1:ZbwhVTb1DBGt2Iwb3tNO6SEK4q+cplHZmLWH+DelYYc=
 cloud.google.com/go v0.118.3/go.mod h1:Lhs3YLnBlwJ4KA6nuObNMZ/fCbOQBPuWKPoE0Wa/9Vc=
-cloud.google.com/go v0.120.0/go.mod h1:/beW32s8/pGRuj4IILWQNd4uuebeT4dkOhKmkfit64Q=
 cloud.google.com/go v0.120.1/go.mod h1:56Vs7sf/i2jYM6ZL9NYlC82r04PThNcPS5YgFmb0rp8=
 cloud.google.com/go v0.121.1 h1:S3kTQSydxmu1JfLRLpKtxRPA7rSrYPRPEUmL/PavVUw=
 cloud.google.com/go v0.121.1/go.mod h1:nRFlrHq39MNVWu+zESP2PosMWA0ryJw8KUBZ2iZpxbw=
@@ -444,7 +443,6 @@ cloud.google.com/go/iam v1.1.7/go.mod h1:J4PMPg8TtyurAUvSmPj8FF3EDgY1SPRZxcUGrn7
 cloud.google.com/go/iam v1.1.8/go.mod h1:GvE6lyMmfxXauzNq8NbgJbeVQNspG+tcdL/W8QO1+zE=
 cloud.google.com/go/iam v1.2.0/go.mod h1:zITGuWgsLZxd8OwAlX+eMFgZDXzBm7icj1PVTYG766Q=
 cloud.google.com/go/iam v1.2.2/go.mod h1:0Ys8ccaZHdI1dEUilwzqng/6ps2YB6vRsjIe00/+6JY=
-cloud.google.com/go/iam v1.5.2/go.mod h1:SE1vg0N81zQqLzQEwxL2WI6yhetBdbNQuTvIKCSkUHE=
 cloud.google.com/go/iap v1.7.1/go.mod h1:WapEwPc7ZxGt2jFGB/C/bm+hP0Y6NXzOYGjpPnmMS74=
 cloud.google.com/go/iap v1.9.1/go.mod h1:SIAkY7cGMLohLSdBR25BuIxO+I4fXJiL06IBL7cy/5Q=
 cloud.google.com/go/iap v1.9.4/go.mod h1:vO4mSq0xNf/Pu6E5paORLASBwEmphXEjgCFg7aeNu1w=
@@ -491,8 +489,6 @@ cloud.google.com/go/logging v1.4.2 h1:Mu2Q75VBDQlW1HlBMjTX4X84UFR73G1TiLlRYc/b7t
 cloud.google.com/go/logging v1.4.2/go.mod h1:jco9QZSx8HiVVqLJReq7z7bVdj0P1Jb9PDFs63T+axo=
 cloud.google.com/go/logging v1.8.1 h1:26skQWPeYhvIasWKm48+Eq7oUqdcdbwsCVwz5Ys0FvU=
 cloud.google.com/go/logging v1.8.1/go.mod h1:TJjR+SimHwuC8MZ9cjByQulAMgni+RkXeI3wwctHJEI=
-cloud.google.com/go/logging v1.13.0 h1:7j0HgAp0B94o1YRDqiqm26w4q1rDMH7XNRU34lJXHYc=
-cloud.google.com/go/logging v1.13.0/go.mod h1:36CoKh6KA/M0PbhPKMq6/qety2DCAErbhXT62TuXALA=
 cloud.google.com/go/longrunning v0.5.0/go.mod h1:0JNuqRShmscVAhIACGtskSAWtqtOoPkwP0YF1oVEchc=
 cloud.google.com/go/longrunning v0.5.2 h1:u+oFqfEwwU7F9dIELigxbe0XVnBAo9wqMuQLA50CZ5k=
 cloud.google.com/go/longrunning v0.5.2/go.mod h1:nqo6DQbNV2pXhGDbDMoN2bWz68MjZUzqv2YttZiveCs=
@@ -503,8 +499,6 @@ cloud.google.com/go/longrunning v0.5.7/go.mod h1:8GClkudohy1Fxm3owmBGid8W0pSgodE
 cloud.google.com/go/longrunning v0.6.0/go.mod h1:uHzSZqW89h7/pasCWNYdUpwGz3PcVWhrWupreVPYLts=
 cloud.google.com/go/longrunning v0.6.2/go.mod h1:k/vIs83RN4bE3YCswdXC5PFfWVILjm3hpEUlSko4PiI=
 cloud.google.com/go/longrunning v0.6.6/go.mod h1:hyeGJUrPHcx0u2Uu1UFSoYZLn4lkMrccJig0t4FI7yw=
-cloud.google.com/go/longrunning v0.6.7 h1:IGtfDWHhQCgCjwQjV9iiLnUta9LBCo8R9QmAFsS/PrE=
-cloud.google.com/go/longrunning v0.6.7/go.mod h1:EAFV3IZAKmM56TyiE6VAP3VoTzhZzySwI/YI1s/nRsY=
 cloud.google.com/go/managedidentities v1.6.2/go.mod h1:5c2VG66eCa0WIq6IylRk3TBW83l161zkFvCj28X7jn8=
 cloud.google.com/go/managedidentities v1.6.5/go.mod h1:fkFI2PwwyRQbjLxlm5bQ8SjtObFMW3ChBGNqaMcgZjI=
 cloud.google.com/go/managedidentities v1.6.7/go.mod h1:UzslJgHnc6luoyx2JV19cTCi2Fni/7UtlcLeSYRzTV8=
@@ -729,6 +723,7 @@ cloud.google.com/go/storage v1.40.0/go.mod h1:Rrj7/hKlG87BLqDJYtwR0fbPld8uJPbQ2u
 cloud.google.com/go/storage v1.41.0/go.mod h1:J1WCa/Z2FcgdEDuPUY8DxT5I+d9mFKsCepp5vR6Sq80=
 cloud.google.com/go/storage v1.42.0/go.mod h1:HjMXRFq65pGKFn6hxj6x3HCyR41uSB72Z0SO/Vn6JFQ=
 cloud.google.com/go/storage v1.43.0/go.mod h1:ajvxEa7WmZS1PxvKRq4bq0tFT3vMd502JwstCcYv0Q0=
+cloud.google.com/go/storage v1.50.0/go.mod h1:l7XeiD//vx5lfqE3RavfmU9yvk5Pp0Zhcv482poyafY=
 cloud.google.com/go/storage v1.53.0/go.mod h1:7/eO2a/srr9ImZW9k5uufcNahT2+fPb8w5it1i5boaA=
 cloud.google.com/go/storagetransfer v1.10.1/go.mod h1:rS7Sy0BtPviWYTTJVWCSV4QrbBitgPeuK4/FKa4IdLs=
 cloud.google.com/go/storagetransfer v1.10.4/go.mod h1:vef30rZKu5HSEf/x1tK3WfWrL0XVoUQN/EPDRGPzjZs=
@@ -853,8 +848,10 @@ github.com/GoogleCloudPlatform/grpc-gcp-go/grpcgcp v1.5.0/go.mod h1:dppbR7CwXD4p
 github.com/GoogleCloudPlatform/grpc-gcp-go/grpcgcp v1.5.2/go.mod h1:dppbR7CwXD4pgtV9t3wD1812RaLDcBjtblcDF5f1vI0=
 github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v1.24.1/go.mod h1:itPGVDKf9cC/ov4MdvJ2QZ0khw4bfoo9jzwTJlaxy2k=
 github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v1.27.0/go.mod h1:yAZHSGnqScoU556rBOVkwLze6WP5N+U11RHuWaGVxwY=
+github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/metric v0.50.0/go.mod h1:ZV4VOm0/eHR06JLrXWe09068dHpr3TRpY9Uo7T+anuA=
 github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/metric v0.51.0/go.mod h1:BnBReJLvVYx2CS/UHOgVz2BXKXD9wsQPxZug20nZhd0=
 github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/cloudmock v0.51.0/go.mod h1:SZiPHWGOOk3bl8tkevxkoiwPgsIl6CwrWcbwjfHZpdM=
+github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.50.0/go.mod h1:otE2jQekW/PqXk1Awf5lmfokJx4uwuqcj1ab5SpGeW0=
 github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.51.0/go.mod h1:otE2jQekW/PqXk1Awf5lmfokJx4uwuqcj1ab5SpGeW0=
 github.com/Microsoft/cosesign1go v1.2.0/go.mod h1:1La/HcGw19rRLhPW0S6u55K6LKfti+GQSgGCtrfhVe8=
 github.com/Microsoft/didx509go v0.0.3/go.mod h1:wWt+iQsLzn3011+VfESzznLIp/Owhuj7rLF7yLglYbk=
@@ -1525,7 +1522,6 @@ github.com/stretchr/objx v0.5.2/go.mod h1:FRsXN1f5AsAjCGJKqEizvkpNtU+EGNCLh3NxZ/
 github.com/stretchr/testify v0.0.0-20180303142811-b89eecf5ca5d/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.7.2/go.mod h1:R6va5+xMeoiuVRoj+gSkQ7d3FALtqAAGI1FQKckRals=
 github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
-github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/subosito/gotenv v1.6.0/go.mod h1:Dk4QP5c2W3ibzajGcXpNraDfq2IrhjMIvMSWPKKo0FU=
 github.com/syndtr/gocapability v0.0.0-20170704070218-db04d3cc01c8/go.mod h1:hkRG7XYTFWNJGYcbNJQlaLq0fg1yr4J4t/NcTQtrfww=
 github.com/syndtr/gocapability v0.0.0-20180916011248-d98352740cb2/go.mod h1:hkRG7XYTFWNJGYcbNJQlaLq0fg1yr4J4t/NcTQtrfww=
@@ -1594,7 +1590,6 @@ go.etcd.io/etcd/server/v3 v3.5.13/go.mod h1:K/8nbsGupHqmr5MkgaZpLlH1QdX1pcNQLAkO
 go.etcd.io/gofail v0.1.0/go.mod h1:VZBCXYGZhHAinaBiiqYvuDynvahNsAyLFwB3kEHKz1M=
 go.mozilla.org/pkcs7 v0.0.0-20200128120323-432b2356ecb1/go.mod h1:SNgMg+EgDFwmvSmLRTNKC5fegJjB7v23qTQ0XLGUNHk=
 go.mozilla.org/pkcs7 v0.9.0/go.mod h1:SNgMg+EgDFwmvSmLRTNKC5fegJjB7v23qTQ0XLGUNHk=
-go.opentelemetry.io/auto/sdk v1.1.0/go.mod h1:3wSPjt5PWp2RhlCcmmOial7AvC4DQqZb7a7wCow3W8A=
 go.opentelemetry.io/contrib v0.20.0 h1:ubFQUn0VCZ0gPwIoJfBJVpeBlyRMxu8Mm/huKWYd9p0=
 go.opentelemetry.io/contrib/detectors/gcp v1.29.0/go.mod h1:GW2aWZNwR2ZxDLdv8OyC2G8zkRoQBuURgV7RPQgcPoU=
 go.opentelemetry.io/contrib/detectors/gcp v1.35.0/go.mod h1:qGWP8/+ILwMRIUf9uIVLloR1uo5ZYAslM4O6OqUi1DA=
@@ -1652,10 +1647,8 @@ go.opentelemetry.io/otel/sdk v1.19.0/go.mod h1:NedEbbS4w3C6zElbLdPJKOpJQOrGUJ+Gf
 go.opentelemetry.io/otel/sdk v1.21.0/go.mod h1:Nna6Yv7PWTdgJHVRD9hIYywQBRx7pbox6nwBnZIxl/E=
 go.opentelemetry.io/otel/sdk v1.29.0/go.mod h1:pM8Dx5WKnvxLCb+8lG1PRNIDxu9g9b9g59Qr7hfAAok=
 go.opentelemetry.io/otel/sdk v1.35.0/go.mod h1:+ga1bZliga3DxJ3CQGg3updiaAJoNECOgJREo9KHGQg=
-go.opentelemetry.io/otel/sdk v1.36.0/go.mod h1:+lC+mTgD+MUWfjJubi2vvXWcVxyr9rmlshZni72pXeY=
 go.opentelemetry.io/otel/sdk/metric v1.29.0/go.mod h1:6zZLdCl2fkauYoZIOn/soQIDSWFmNSRcICarHfuhNJQ=
 go.opentelemetry.io/otel/sdk/metric v1.35.0/go.mod h1:is6XYCUMpcKi+ZsOvfluY5YstFnhW0BidkR+gL+qN+w=
-go.opentelemetry.io/otel/sdk/metric v1.36.0/go.mod h1:qTNOhFDfKRwX0yXOqJYegL5WRaW376QbB7P4Pb0qva4=
 go.opentelemetry.io/otel/trace v1.3.0/go.mod h1:c/VDhno8888bvQYmbYLqe41/Ldmr/KKunbvWM4/fEjk=
 go.opentelemetry.io/otel/trace v1.7.0/go.mod h1:fzLSB9nqR2eXzxPXb2JW9IKE+ScyXA48yyE4TNvoHqU=
 go.opentelemetry.io/otel/trace v1.19.0/go.mod h1:mfaSyvGyEJEI0nyV2I4qhNQnbBOUUmYZpYojqMnX2vo=

--- a/launcher/agent/agent.go
+++ b/launcher/agent/agent.go
@@ -8,7 +8,6 @@ package agent
 import (
 	"bytes"
 	"context"
-	"crypto"
 	"encoding/base64"
 	"fmt"
 	"io"
@@ -36,8 +35,6 @@ import (
 	"github.com/google/go-tpm-tools/verifier/oci"
 	"github.com/google/go-tpm-tools/verifier/util"
 )
-
-var defaultCELHashAlgo = []crypto.Hash{crypto.SHA256, crypto.SHA1}
 
 const (
 	audienceSTS = "https://sts.googleapis.com"
@@ -295,7 +292,7 @@ func (t *tpmAttestRoot) GetCEL() *cel.CEL {
 }
 
 func (t *tpmAttestRoot) Extend(c cel.Content) error {
-	return t.cosCel.AppendEventPCR(t.tpm, cel.CosEventPCR, defaultCELHashAlgo, c)
+	return t.cosCel.AppendEventPCR(t.tpm, cel.CosEventPCR, c)
 }
 
 func (t *tpmAttestRoot) Attest(nonce []byte) (any, error) {

--- a/server/eventlog_test.go
+++ b/server/eventlog_test.go
@@ -995,7 +995,7 @@ func TestParsingCELEventLog(t *testing.T) {
 	for _, testEvent := range testCELEvents {
 		cosEvent := cel.CosTlv{EventType: testEvent.cosNestedEventType, EventContent: testEvent.eventPayload}
 
-		if err := coscel.AppendEventPCR(tpm, testEvent.pcr, implementedHashes, cosEvent); err != nil {
+		if err := coscel.AppendEventPCR(tpm, testEvent.pcr, cosEvent); err != nil {
 			t.Fatal(err)
 		}
 	}

--- a/server/verify_test.go
+++ b/server/verify_test.go
@@ -30,8 +30,6 @@ import (
 	"google.golang.org/protobuf/testing/protocmp"
 )
 
-var measuredHashes = []crypto.Hash{crypto.SHA1, crypto.SHA256}
-
 func getDigestHash(input string) []byte {
 	inputDigestHash := sha256.New()
 	inputDigestHash.Write([]byte(input))
@@ -313,7 +311,7 @@ func TestVerifyAttestationWithCEL(t *testing.T) {
 	}
 	for _, testEvent := range testEvents {
 		cosEvent := cel.CosTlv{EventType: testEvent.cosNestedEventType, EventContent: testEvent.eventPayload}
-		if err := coscel.AppendEventPCR(rwc, testEvent.pcr, measuredHashes, cosEvent); err != nil {
+		if err := coscel.AppendEventPCR(rwc, testEvent.pcr, cosEvent); err != nil {
 			t.Fatal(err)
 		}
 	}
@@ -385,11 +383,11 @@ func TestVerifyFailWithTamperedCELContent(t *testing.T) {
 	cosEvent := cel.CosTlv{EventType: cel.ImageRefType, EventContent: []byte("docker.io/bazel/experimental/test:latest")}
 	cosEvent2 := cel.CosTlv{EventType: cel.ImageDigestType, EventContent: []byte("sha256:781d8dfdd92118436bd914442c8339e653b83f6bf3c1a7a98efcfb7c4fed7483")}
 
-	if err := c.AppendEventPCR(rwc, cel.CosEventPCR, measuredHashes, cosEvent); err != nil {
+	if err := c.AppendEventPCR(rwc, cel.CosEventPCR, cosEvent); err != nil {
 		t.Fatalf("failed to append event: %v", err)
 	}
 
-	if err := c.AppendEventPCR(rwc, cel.CosEventPCR, measuredHashes, cosEvent2); err != nil {
+	if err := c.AppendEventPCR(rwc, cel.CosEventPCR, cosEvent2); err != nil {
 		t.Fatalf("failed to append event: %v", err)
 	}
 


### PR DESCRIPTION
BREAKING CHANGE: cel.AppendEventPCR and cel.AppendEvent stop taking in []crypto.Hash, instead they will get all available PCR banks from the TPM capability.

Make AllocatedPCRs public