### PR TITLE
Remove Attested COS specific CEL parsing logic

### DIFF
--- a/server/verify.go
+++ b/server/verify.go
@@ -8,8 +8,6 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/google/go-eventlog/proto/state"
-	"github.com/google/go-eventlog/register"
 	"github.com/google/go-tpm-tools/internal"
 	pb "github.com/google/go-tpm-tools/proto/attest"
 	tpmpb "github.com/google/go-tpm-tools/proto/tpm"
@@ -137,26 +135,6 @@ func VerifyAttestation(attestation *pb.Attestation, opts VerifyOpts) (*pb.Machin
 			lastErr = fmt.Errorf("failed to parse machine state from TCG event log: %w", err)
 			continue
 		}
-
-		pcrBank := register.PCRBank{TCGHashAlgo: state.HashAlgo(pcrs.Hash)}
-		digestAlg, err := pcrBank.TCGHashAlgo.CryptoHash()
-		if err != nil {
-			return nil, fmt.Errorf("invalid digest algorithm")
-		}
-
-		for pcrIndex, digest := range pcrs.GetPcrs() {
-			pcrBank.PCRs = append(pcrBank.PCRs, register.PCR{
-				Index:     int(pcrIndex),
-				Digest:    digest,
-				DigestAlg: digestAlg})
-		}
-
-		celState, err := ParseCosCELPCR(attestation.GetCanonicalEventLog(), pcrBank)
-		if err != nil {
-			lastErr = fmt.Errorf("failed to validate the Canonical event log: %w", err)
-			continue
-		}
-		machineState.Cos = celState
 
 		// Verify the PCR hash algorithm. We have this check here (instead of at
 		// the start of the loop) so that the user gets a "SHA-1 not supported"


### PR DESCRIPTION
This PR removes the Attested COS state specific CEL parsing logic which would help us use the `VerifyAttestation` method for the clients who wants to parse the CEL differently. This PR keeps the `ParseCOSCELPCR` method (under `eventlog.go`) as is if existing client want to use it. 

It updates the implementation of fake verifier with additional logic of parsing COS state. This would make agent tests (in launcher) continue to work without any issue. 

**Testing:**
- Unit tests of server package passed successfully.
- Successfully built the gotpm library.