### PR TITLE
Refactor container runner to not depend on file system or use a real timer

### DIFF
--- a/launcher/launcher/clock/fake_timer.go
+++ b/launcher/launcher/clock/fake_timer.go
@@ -1,0 +1,36 @@
+package clock
+
+import "time"
+
+// FakeTimer is a fake implementation of Timer for testing purposes.
+type FakeTimer struct {
+	OutChan   chan time.Time
+	ResetChan chan int
+	StopChan  chan int
+}
+
+// NewFakeTimer creates a new instance of FakeTimer.
+func NewFakeTimer() FakeTimer {
+	return FakeTimer{
+		OutChan:   make(chan time.Time, 1),
+		ResetChan: make(chan int, 1),
+		StopChan:  make(chan int, 1),
+	}
+}
+
+// C returns the channel on which the timer will send the current time when it fires.
+func (f *FakeTimer) C() <-chan time.Time {
+	return f.OutChan
+}
+
+// Reset notifies the reset channel to signal that that reset was called.
+func (f *FakeTimer) Reset(_ time.Duration) bool {
+	f.ResetChan <- 1
+	return true
+}
+
+// Stop notifies the stop channel to signal that stop was called.
+func (f *FakeTimer) Stop() bool {
+	f.StopChan <- 1
+	return true
+}

--- a/launcher/launcher/clock/real_timer_test.go
+++ b/launcher/launcher/clock/real_timer_test.go
@@ -1,0 +1,26 @@
+package clock
+
+import (
+	"fmt"
+	"testing"
+	"time"
+)
+
+func TestRealTimerFires(_ *testing.T) {
+	timer := NewRealTimer(100 * time.Millisecond)
+	time.Sleep(125 * time.Millisecond)
+	<-timer.C()
+
+	fmt.Printf("%v\n", timer.Reset(100*time.Millisecond))
+	time.Sleep(125 * time.Millisecond)
+	<-timer.C()
+}
+
+func TestRealTimerFiresInstantly(_ *testing.T) {
+	timer := NewRealTimer(0)
+	<-timer.C()
+
+	timer.Reset(100 * time.Millisecond)
+	time.Sleep(125 * time.Millisecond)
+	<-timer.C()
+}

--- a/launcher/launcher/clock/timer.go
+++ b/launcher/launcher/clock/timer.go
@@ -1,0 +1,41 @@
+// Package clock contains time-related utilities
+package clock
+
+import "time"
+
+// Timer is an interface that wraps the basic methods of time.Timer.
+type Timer interface {
+	C() <-chan time.Time
+	Stop() bool
+	Reset(time.Duration) bool
+}
+
+// Ensure conformance on Timer
+var _ Timer = (*RealTimer)(nil)
+
+// RealTimer is an implementation of Timer that uses a real time.Timer.
+type RealTimer struct {
+	inner *time.Timer
+}
+
+// NewRealTimer creates and returns a reference to a RealTimer.
+func NewRealTimer(d time.Duration) Timer {
+	return &RealTimer{
+		inner: time.NewTimer(d),
+	}
+}
+
+// C returns the channel on which the timer will send the current time when it fires.
+func (t *RealTimer) C() <-chan time.Time {
+	return t.inner.C
+}
+
+// Stop stops the timer and returns true if the timer was active.
+func (t *RealTimer) Stop() bool {
+	return t.inner.Stop()
+}
+
+// Reset resets the timer to the specified duration and returns true if the timer was active.
+func (t *RealTimer) Reset(d time.Duration) bool {
+	return t.inner.Reset(d)
+}


### PR DESCRIPTION
This PR was broken out from this PR: https://github.com/google/go-tpm-tools/pull/560

This PR:

- Refactors the container runner goroutine starting to make it more testable and remove race conditions
- Adds time based utilities to test the container runner better
- Adds missing tests to our container runner