### PR TITLE
fix: Replace metadata server error with warning

### DIFF
--- a/cmd/attest.go
+++ b/cmd/attest.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"log"
 	"strconv"
 
 	"cloud.google.com/go/compute/metadata"
@@ -116,7 +117,7 @@ hardware and guarantees a fresh quote.
 		if key == "gceAK" {
 			instanceInfo, err := getInstanceInfoFromMetadata()
 			if err != nil {
-				return err
+				log.Printf("Could not get GCE instance info, continuing without it: %v", err)
 			}
 			attestation.InstanceInfo = instanceInfo
 		}


### PR DESCRIPTION
This change replaces the hard error with a warning when the attestation tool fails to access the GCE metadata server (MDS).

In certain environments, like the SEV-SNP VIT setup, the MDS is not accessible. This previously caused the attestation process to fail, blocking vTPM tests. By downgrading the failure to a warning, the attest tool can now continue to run, unblocking these essential tests.