### PR TITLE
 Add ITA support to CS

### DIFF
--- a/launcher/container_runner.go
+++ b/launcher/container_runner.go
@@ -240,7 +240,7 @@ func NewRunner(ctx context.Context, cdClient *containerd.Client, token oauth2.To
 	asAddr := launchSpec.AttestationServiceAddr
 
 	var verifierClient verifier.Client
-	if launchSpec.ITARegion == "" {
+	if launchSpec.ITAConfig.ITARegion == "" {
 		gcaClient, err := util.NewRESTClient(ctx, asAddr, launchSpec.ProjectID, launchSpec.Region)
 		if err != nil {
 			return nil, fmt.Errorf("failed to create REST verifier client: %v", err)
@@ -582,7 +582,7 @@ func (r *ContainerRunner) Run(ctx context.Context) error {
 	}
 
 	// Only refresh token if agent has a default GCA client (not ITA use case).
-	if r.launchSpec.ITARegion == "" {
+	if r.launchSpec.ITAConfig.ITARegion == "" {
 		if err := r.fetchAndWriteToken(ctx); err != nil {
 			return fmt.Errorf("failed to fetch and write OIDC token: %v", err)
 		}
@@ -591,9 +591,9 @@ func (r *ContainerRunner) Run(ctx context.Context) error {
 	// create and start the TEE server
 	r.logger.Info("EnableOnDemandAttestation is enabled: initializing TEE server.")
 
-	attestClients := &teeserver.AttestClients{}
-	if r.launchSpec.ITARegion != "" {
-		itaClient, err := ita.NewClient(r.launchSpec.ITARegion, r.launchSpec.ITAKey)
+	attestClients := teeserver.AttestClients{}
+	if r.launchSpec.ITAConfig.ITARegion != "" {
+		itaClient, err := ita.NewClient(r.launchSpec.ITAConfig)
 		if err != nil {
 			return fmt.Errorf("failed to create ITA client: %v", err)
 		}

--- a/launcher/go.sum
+++ b/launcher/go.sum
@@ -155,6 +155,7 @@ github.com/caarlos0/ctrlc v1.0.0/go.mod h1:CdXpj4rmq0q/1Eb44M9zi2nKB0QraNKuRGYGr
 github.com/campoy/unique v0.0.0-20180121183637-88950e537e7e/go.mod h1:9IOqJGCPMSc6E5ydlp5NIonxObaeu/Iub/X03EKPVYo=
 github.com/casbin/casbin/v2 v2.1.2/go.mod h1:YcPU1XXisHhLzuxH9coDNf2FbKpjGlbCg3n9yuLkIJQ=
 github.com/cavaliercoder/go-cpio v0.0.0-20180626203310-925f9528c45e/go.mod h1:oDpT4efm8tSYHXV5tHSdRvBet/b/QzxZ+XyyPehvm3A=
+github.com/cenkalti/backoff v2.2.1+incompatible h1:tNowT99t7UNflLxfYYSlKYsBpXdEet03Pg2g16Swow4=
 github.com/cenkalti/backoff v2.2.1+incompatible/go.mod h1:90ReRw6GdpyfrHakVjL/QHaoyV4aDUVVkXQJJJ3NXXM=
 github.com/cenkalti/backoff/v4 v4.3.0 h1:MyRJ/UdXutAwSAT+s3wNd7MfTIcy71VQueUuFK343L8=
 github.com/cenkalti/backoff/v4 v4.3.0/go.mod h1:Y3VNntkOUPxTVeUxJ/G5vcM//AlwfmyYozVcomhLiZE=

--- a/launcher/spec/launch_spec_test.go
+++ b/launcher/spec/launch_spec_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-tpm-tools/launcher/internal/experiments"
 	"github.com/google/go-tpm-tools/launcher/internal/launchermount"
+	"github.com/google/go-tpm-tools/verifier"
 )
 
 func TestLaunchSpecUnmarshalJSONHappyCases(t *testing.T) {
@@ -64,8 +65,10 @@ func TestLaunchSpecUnmarshalJSONHappyCases(t *testing.T) {
 		DevShmSize:                 234234,
 		Mounts: []launchermount.Mount{launchermount.TmpfsMount{Destination: "/tmpmount", Size: 0},
 			launchermount.TmpfsMount{Destination: "/sized", Size: 222}},
-		ITARegion: "US",
-		ITAKey:    "test-api-key",
+		ITAConfig: verifier.ITAConfig{
+			ITARegion: "US",
+			ITAKey:    "test-api-key",
+		},
 		Experiments: experiments.Experiments{
 			EnableItaVerifier: true,
 		},

--- a/verifier/client.go
+++ b/verifier/client.go
@@ -66,3 +66,22 @@ type VerifyAttestationResponse struct {
 	ClaimsToken []byte
 	PartialErrs []*status.Status
 }
+
+// ITAConfig represents the configuration needed to integrate with ITA as a verifier.
+type ITAConfig struct {
+	ITARegion string
+	ITAKey    string
+}
+
+// AttestClients contains clients for supported verifier services that can be used to
+// get attestation tokens.
+type AttestClients struct {
+	GCA Client
+	ITA Client
+}
+
+// HasThirdPartyClient returns true if AttestClients contains an initialzied
+// third-party verifier client.
+func (ac *AttestClients) HasThirdPartyClient() bool {
+	return ac.ITA != nil
+}

--- a/verifier/ita/client.go
+++ b/verifier/ita/client.go
@@ -42,7 +42,6 @@ func urlFromRegion(region string) (string, error) {
 	if region == "" {
 		return "", errors.New("API region required to initialize ITA client")
 	}
-
 	url, ok := regionalURLs[strings.ToUpper(region)]
 	if !ok {
 		// Create list of allowed regions.
@@ -54,32 +53,6 @@ func urlFromRegion(region string) (string, error) {
 	}
 
 	return url, nil
-}
-
-func NewClient(region string, key string) (verifier.Client, error) {
-	url, err := urlFromRegion(region)
-	if err != nil {
-		return nil, err
-	}
-
-	return &client{
-		inner: &http.Client{
-			Transport: &http.Transport{
-				// https://github.com/intel/trustauthority-client-for-go/blob/main/go-connector/token.go#L130.
-				TLSClientConfig: &tls.Config{
-					CipherSuites: []uint16{
-						tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
-						tls.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
-					},
-					InsecureSkipVerify: false,
-					MinVersion:         tls.VersionTLS12,
-				},
-				Proxy: http.ProxyFromEnvironment,
-			},
-		},
-		apiURL: url,
-		apiKey: key,
-	}, nil
 }
 
 // Confirm that client implements verifier.Client interface.
@@ -104,11 +77,36 @@ func createHashedNonce(nonce *itaNonce) ([]byte, error) {
 	return hash.Sum(nil), err
 }
 
+func NewClient(itaConfig verifier.ITAConfig) (verifier.Client, error) { //region string, key string) (verifier.Client, error) {
+	url, err := urlFromRegion(itaConfig.ITARegion)
+	if err != nil {
+		return nil, err
+	}
+
+	return &client{
+		inner: &http.Client{
+			Transport: &http.Transport{
+				// https://github.com/intel/trustauthority-client-for-go/blob/main/go-connector/token.go#L130.
+				TLSClientConfig: &tls.Config{
+					CipherSuites: []uint16{
+						tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
+						tls.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
+					},
+					InsecureSkipVerify: false,
+					MinVersion:         tls.VersionTLS12,
+				},
+				Proxy: http.ProxyFromEnvironment,
+			},
+		},
+		apiURL: url,
+		apiKey: itaConfig.ITAKey,
+	}, nil
+}
+
 func (c *client) CreateChallenge(_ context.Context) (*verifier.Challenge, error) {
 	url := c.apiURL + nonceEndpoint
 
 	headers := map[string]string{
-		apiKeyHeader: c.apiKey,
 		acceptHeader: applicationJSON,
 	}
 
@@ -129,6 +127,79 @@ func (c *client) CreateChallenge(_ context.Context) (*verifier.Challenge, error)
 		Iat:       resp.Iat,
 		Signature: resp.Signature,
 	}, nil
+}
+
+func (c *client) VerifyAttestation(_ context.Context, request verifier.VerifyAttestationRequest) (*verifier.VerifyAttestationResponse, error) {
+	if request.TDCCELAttestation == nil {
+		return nil, errors.New("TDX required for ITA attestation")
+	}
+
+	tokenReq := convertRequestToTokenRequest(request)
+
+	url := c.apiURL + tokenEndpoint
+	headers := map[string]string{
+		apiKeyHeader:      c.apiKey,
+		acceptHeader:      applicationJSON,
+		contentTypeHeader: applicationJSON,
+	}
+
+	resp := &tokenResponse{}
+	if err := c.doHTTPRequest(http.MethodPost, url, tokenReq, headers, &resp); err != nil {
+		return nil, err
+	}
+
+	return &verifier.VerifyAttestationResponse{
+		ClaimsToken: []byte(resp.Token),
+	}, nil
+}
+
+func (c *client) doHTTPRequest(method string, url string, reqStruct any, headers map[string]string, respStruct any) error {
+	// Create HTTP request.
+	var req *http.Request
+	var err error
+	if reqStruct != nil {
+		body, err := json.Marshal(reqStruct)
+		if err != nil {
+			return fmt.Errorf("error marshaling request: %v", err)
+		}
+
+		req, err = http.NewRequest(method, url, bytes.NewReader(body))
+		if err != nil {
+			return fmt.Errorf("error creating HTTP request: %v", err)
+		}
+	} else {
+		req, err = http.NewRequest(method, url, nil)
+		if err != nil {
+			return fmt.Errorf("error creating HTTP request: %v", err)
+		}
+	}
+
+	// Add headers to request.
+	headers[apiKeyHeader] = string(c.apiKey)
+	for key, val := range headers {
+		req.Header.Add(key, val)
+	}
+
+	resp, err := c.inner.Do(req)
+	if err != nil {
+		return fmt.Errorf("HTTP request error: %v", err)
+	}
+	defer resp.Body.Close()
+
+	// Read and unmarshal response body.
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return fmt.Errorf("error reading response body: %v", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("HTTP request failed with status code %d, response body %s", resp.StatusCode, string(respBody))
+	}
+
+	if err := json.Unmarshal(respBody, respStruct); err != nil {
+		return fmt.Errorf("error unmarshaling response: %v", err)
+	}
+
+	return nil
 }
 
 func convertRequestToTokenRequest(request verifier.VerifyAttestationRequest) tokenRequest {
@@ -190,74 +261,6 @@ func convertRequestToTokenRequest(request verifier.VerifyAttestationRequest) tok
 	return tokenReq
 }
 
-func (c *client) VerifyAttestation(_ context.Context, request verifier.VerifyAttestationRequest) (*verifier.VerifyAttestationResponse, error) {
-	if request.TDCCELAttestation == nil {
-		return nil, errors.New("TDX required for ITA attestation")
-	}
-
-	tokenReq := convertRequestToTokenRequest(request)
-
-	url := c.apiURL + tokenEndpoint
-	headers := map[string]string{
-		apiKeyHeader:      c.apiKey,
-		acceptHeader:      applicationJSON,
-		contentTypeHeader: applicationJSON,
-	}
-
-	resp := &tokenResponse{}
-	if err := c.doHTTPRequest(http.MethodPost, url, tokenReq, headers, &resp); err != nil {
-		return nil, err
-	}
-
-	return &verifier.VerifyAttestationResponse{
-		ClaimsToken: []byte(resp.Token),
-	}, nil
-}
-
 func (c *client) VerifyConfidentialSpace(ctx context.Context, request verifier.VerifyAttestationRequest) (*verifier.VerifyAttestationResponse, error) {
 	return c.VerifyAttestation(ctx, request)
-}
-
-func (c *client) doHTTPRequest(method string, url string, reqStruct any, headers map[string]string, respStruct any) error {
-	// Create HTTP request.
-	var req *http.Request
-	var err error
-	if reqStruct != nil {
-		body, err := json.Marshal(reqStruct)
-		if err != nil {
-			return fmt.Errorf("error marshaling request: %v", err)
-		}
-
-		req, err = http.NewRequest(method, url, bytes.NewReader(body))
-		if err != nil {
-			return fmt.Errorf("error creating HTTP request: %v", err)
-		}
-	} else {
-		req, err = http.NewRequest(method, url, nil)
-		if err != nil {
-			return fmt.Errorf("error creating HTTP request: %v", err)
-		}
-	}
-
-	// Add headers to request.
-	for key, val := range headers {
-		req.Header.Add(key, val)
-	}
-
-	resp, err := c.inner.Do(req)
-	if err != nil {
-		return fmt.Errorf("HTTP request error: %v", err)
-	}
-
-	// Read and unmarshal response body.
-	respBody, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return fmt.Errorf("error reading response body: %v", err)
-	}
-
-	if err := json.Unmarshal(respBody, respStruct); err != nil {
-		return fmt.Errorf("error unmarshaling response: %v", err)
-	}
-
-	return nil
 }

--- a/verifier/ita/client_test.go
+++ b/verifier/ita/client_test.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -144,7 +144,7 @@ func TestVerifyAttestation(t *testing.T) {
 
 		// Verify HTTP Request body.
 		defer r.Body.Close()
-		reqBody, err := ioutil.ReadAll(r.Body)
+		reqBody, err := io.ReadAll(r.Body)
 		if err != nil {
 			t.Fatalf("Error reading HTTP request body: %s", err)
 		}
@@ -212,7 +212,7 @@ func TestDoHTTPRequest(t *testing.T) {
 
 		// Verify HTTP Request body.
 		defer r.Body.Close()
-		reqBody, err := ioutil.ReadAll(r.Body)
+		reqBody, err := io.ReadAll(r.Body)
 		if err != nil {
 			t.Fatalf("Error reading HTTP request body: %s", err)
 		}

--- a/verifier/ita/evidence.go
+++ b/verifier/ita/evidence.go
@@ -33,8 +33,8 @@ type tokenTypeOptions struct {
 type tokenOptions struct {
 	Audience      string           `json:"audience"`
 	Nonces        []string         `json:"nonce"`
-	TokenType     string           `json:"tokenType"`
-	TokenTypeOpts tokenTypeOptions `json:"tokenTypeOptions"`
+	TokenType     string           `json:"token_type"`
+	TokenTypeOpts tokenTypeOptions `json:"token_type_options"`
 }
 
 type confidentialSpaceInfo struct {


### PR DESCRIPTION
Replaces https://github.com/google/go-tpm-tools/pull/560 after the refactoring changes were split out into https://github.com/google/go-tpm-tools/pull/602. This does not include image tests for the new changes.