### PR TITLE
Bootstrap KCC directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,7 @@ files/go-tpm-tools
 main
 go.work
 go.work.sum
+kcc/wsd_kcc/target/*
+kcc/kps_kcc/target/*
+kcc/wsd_kcc/Cargo.lock
+kcc/kps_kcc/Cargo.lock

--- a/kcc/kps_kcc/Cargo.toml
+++ b/kcc/kps_kcc/Cargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "kps_kcc"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]

--- a/kcc/kps_kcc/src/lib.rs
+++ b/kcc/kps_kcc/src/lib.rs
@@ -1,0 +1,14 @@
+pub fn add(left: u64, right: u64) -> u64 {
+    left + right
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn it_works() {
+        let result = add(2, 2);
+        assert_eq!(result, 4);
+    }
+}

--- a/kcc/wsd_kcc/Cargo.toml
+++ b/kcc/wsd_kcc/Cargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "wsd_kcc"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]

--- a/kcc/wsd_kcc/src/lib.rs
+++ b/kcc/wsd_kcc/src/lib.rs
@@ -1,0 +1,14 @@
+pub fn add(left: u64, right: u64) -> u64 {
+    left + right
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn it_works() {
+        let result = add(2, 2);
+        assert_eq!(result, 4);
+    }
+}


### PR DESCRIPTION
KCC directory is having 2 sub directories, (1) `wsd_kcc`: this will have FFIs required for WSD (2) `kps_kcc`: this will have FFIs required for KPS.