### PR TITLE
[launcher] add flag to disable GCA refresh

### DIFF
--- a/launcher/container_runner.go
+++ b/launcher/container_runner.go
@@ -621,8 +621,9 @@ func (r *ContainerRunner) Run(ctx context.Context) error {
 		return fmt.Errorf("failed to measure CEL events: %v", err)
 	}
 
-	// Only refresh token if agent has a default GCA client (not ITA use case).
-	if r.launchSpec.ITAConfig.ITARegion == "" {
+	// Only refresh token if agent has a default GCA client (not ITA use case)
+	// AND GcaRefresh is not disabled
+	if r.launchSpec.ITAConfig.ITARegion == "" && !r.launchSpec.DisableGcaRefresh {
 		if err := r.fetchAndWriteToken(ctx); err != nil {
 			return fmt.Errorf("failed to fetch and write OIDC token: %v", err)
 		}

--- a/launcher/spec/launch_spec.go
+++ b/launcher/spec/launch_spec.go
@@ -94,6 +94,7 @@ const (
 	cgroupNS                   = "tee-cgroup-ns"
 	gcaServiceEnv              = "gca-service-env"
 	installGpuDriver           = "tee-install-gpu-driver"
+	disableGcaRefreshKey       = "tee-disable-gca-refresh"
 )
 
 const (
@@ -135,11 +136,11 @@ type LaunchSpec struct {
 	LogRedirect                LogRedirectLocation
 	Mounts                     []launchermount.Mount
 	ITAConfig                  verifier.ITAConfig
-	// DevShmSize is specified in kiB.
-	DevShmSize        int64
-	AddedCapabilities []string
-	CgroupNamespace   bool
-	InstallGpuDriver  bool
+	DevShmSize                 int64 // DevShmSize is specified in kiB.
+	AddedCapabilities          []string
+	CgroupNamespace            bool
+	InstallGpuDriver           bool
+	DisableGcaRefresh          bool
 }
 
 // UnmarshalJSON unmarshals an instance attributes list in JSON format from the metadata
@@ -303,6 +304,13 @@ func (s *LaunchSpec) UnmarshalJSON(b []byte) error {
 		}
 		if cgroupOn {
 			s.CgroupNamespace = true
+		}
+	}
+
+	if val, ok := unmarshaledMap[disableGcaRefreshKey]; ok && val != "" {
+		var err error
+		if s.DisableGcaRefresh, err = strconv.ParseBool(val); err != nil {
+			return fmt.Errorf("invalid value for %v (not a boolean): %w", disableGcaRefreshKey, err)
 		}
 	}
 


### PR DESCRIPTION
The new flag allow user to disable the default initial and hourly GCA attestation token refresh.