### PR TITLE
[keymanager] GenerateKey API - incorporate signature change

### DIFF
--- a/keymanager/km_common/src/key_types.rs
+++ b/keymanager/km_common/src/key_types.rs
@@ -213,33 +213,6 @@ mod tests {
     use super::*;
     use crate::algorithms::{AeadAlgorithm, KdfAlgorithm, KemAlgorithm};
 
-    fn create_key_record<F>(
-        algo: HpkeAlgorithm,
-        expiry_secs: u64,
-        spec_builder: F,
-    ) -> Result<KeyRecord, crypto::Error>
-    where
-        F: FnOnce(HpkeAlgorithm, PublicKey) -> KeySpec,
-    {
-        let (pub_key, priv_key) = crypto::generate_keypair(KemAlgorithm::DhkemX25519HkdfSha256)?;
-        let id = Uuid::new_v4();
-        let vault = Vault::new(secret_box::SecretBox::from(priv_key))
-            .map_err(|_| crypto::Error::CryptoError)?;
-        let now = Instant::now();
-        let delete_after = now
-            .checked_add(Duration::from_secs(expiry_secs))
-            .ok_or(crypto::Error::UnsupportedAlgorithm)?;
-        Ok(KeyRecord {
-            meta: KeyMetadata {
-                id,
-                created_at: now,
-                delete_after,
-                spec: spec_builder(algo, pub_key),
-            },
-            private_key: vault,
-        })
-    }
-
     #[test]
     fn test_create_binding_key_success() {
         let algo = HpkeAlgorithm {

--- a/keymanager/workload_service/integration_test.go
+++ b/keymanager/workload_service/integration_test.go
@@ -30,9 +30,8 @@ func TestIntegrationGenerateKeysEndToEnd(t *testing.T) {
 	srv := NewServer(kpsSvc, &realWorkloadService{})
 
 	reqBody, err := json.Marshal(GenerateKeyRequest{
-		Algorithm:              AlgorithmDetails{Type: "kem", Params: AlgorithmParams{KemID: KemAlgorithmDHKEMX25519HKDFSHA256}},
-		KeyProtectionMechanism: KeyProtectionMechanismVMEmulated,
-		Lifespan:               ProtoDuration{Seconds: 3600},
+		Algorithm: AlgorithmDetails{Type: "kem", Params: AlgorithmParams{KemID: KemAlgorithmDHKEMX25519HKDFSHA256}},
+		Lifespan:  ProtoDuration{Seconds: 3600},
 	})
 	if err != nil {
 		t.Fatalf("failed to marshal request: %v", err)
@@ -79,9 +78,8 @@ func TestIntegrationGenerateKeysUniqueMappings(t *testing.T) {
 	var kemUUIDs [2]uuid.UUID
 	for i := 0; i < 2; i++ {
 		reqBody, err := json.Marshal(GenerateKeyRequest{
-			Algorithm:              AlgorithmDetails{Type: "kem", Params: AlgorithmParams{KemID: KemAlgorithmDHKEMX25519HKDFSHA256}},
-			KeyProtectionMechanism: KeyProtectionMechanismVMEmulated,
-			Lifespan:               ProtoDuration{Seconds: 3600},
+			Algorithm: AlgorithmDetails{Type: "kem", Params: AlgorithmParams{KemID: KemAlgorithmDHKEMX25519HKDFSHA256}},
+			Lifespan:  ProtoDuration{Seconds: 3600},
 		})
 		if err != nil {
 			t.Fatalf("call %d: failed to marshal request: %v", i+1, err)

--- a/keymanager/workload_service/proto_enums.go
+++ b/keymanager/workload_service/proto_enums.go
@@ -57,68 +57,11 @@ func (k *KemAlgorithm) UnmarshalJSON(data []byte) error {
 	return fmt.Errorf("unknown KemAlgorithm: %q", s)
 }
 
-// KeyProtectionMechanism represents the requested key protection backend.
-type KeyProtectionMechanism int32
-
-const (
-	KeyProtectionMechanismUnspecified KeyProtectionMechanism = 0
-	// KeyProtectionMechanismDefault is the default but invalid value.
-	KeyProtectionMechanismDefault KeyProtectionMechanism = 1
-	// KeyProtectionMechanismVM specifies that the key is protected by the VM.
-	KeyProtectionMechanismVM         KeyProtectionMechanism = 2
-	KeyProtectionMechanismVMEmulated KeyProtectionMechanism = 3
-)
-
-var (
-	keyProtectionMechanismToString = map[KeyProtectionMechanism]string{
-		KeyProtectionMechanismUnspecified: "KEY_PROTECTION_UNSPECIFIED",
-		KeyProtectionMechanismDefault:     "DEFAULT",
-		KeyProtectionMechanismVM:          "KEY_PROTECTION_VM",
-		KeyProtectionMechanismVMEmulated:  "KEY_PROTECTION_VM_EMULATED",
-	}
-	stringToKeyProtectionMechanism = map[string]KeyProtectionMechanism{
-		"KEY_PROTECTION_UNSPECIFIED": KeyProtectionMechanismUnspecified,
-		"DEFAULT":                    KeyProtectionMechanismDefault,
-		"KEY_PROTECTION_VM":          KeyProtectionMechanismVM,
-		"KEY_PROTECTION_VM_EMULATED": KeyProtectionMechanismVMEmulated,
-	}
-)
-
-func (k KeyProtectionMechanism) String() string {
-	if s, ok := keyProtectionMechanismToString[k]; ok {
-		return s
-	}
-	return fmt.Sprintf("KEY_PROTECTION_MECHANISM_UNKNOWN(%d)", k)
-}
-
-// MarshalJSON converts a KeyProtectionMechanism enum value to its JSON string representation.
-func (k KeyProtectionMechanism) MarshalJSON() ([]byte, error) {
-	return json.Marshal(k.String())
-}
-
-// UnmarshalJSON parses a JSON string into a KeyProtectionMechanism enum value.
-func (k *KeyProtectionMechanism) UnmarshalJSON(data []byte) error {
-	var s string
-	if err := json.Unmarshal(data, &s); err != nil {
-		return fmt.Errorf("KeyProtectionMechanism must be a string")
-	}
-	if v, ok := stringToKeyProtectionMechanism[s]; ok {
-		*k = v
-		return nil
-	}
-	return fmt.Errorf("unknown KeyProtectionMechanism: %q", s)
-}
-
 // Supported algorithms and mechanisms.
 var (
 	// SupportedKemAlgorithms is the source of truth for supported algorithms.
 	SupportedKemAlgorithms = []KemAlgorithm{
 		KemAlgorithmDHKEMX25519HKDFSHA256,
-	}
-
-	// SupportedKeyProtectionMechanisms is the source of truth for supported mechanisms.
-	SupportedKeyProtectionMechanisms = []KeyProtectionMechanism{
-		KeyProtectionMechanismVMEmulated,
 	}
 )
 
@@ -132,17 +75,7 @@ func (k KemAlgorithm) IsSupported() bool {
 	return false
 }
 
-// IsSupported returns true if the key protection mechanism is supported.
-func (k KeyProtectionMechanism) IsSupported() bool {
-	for _, supported := range SupportedKeyProtectionMechanisms {
-		if k == supported {
-			return true
-		}
-	}
-	return false
-}
-
-// SupportedKemAlgorithmsString returns a comma-separated list of supported KEM keymanager.
+// SupportedKemAlgorithmsString returns a comma-separated list of supported KEM algorithms.
 func SupportedKemAlgorithmsString() string {
 	var names []string
 	for _, k := range SupportedKemAlgorithms {

--- a/keymanager/workload_service/server_test.go
+++ b/keymanager/workload_service/server_test.go
@@ -57,8 +57,7 @@ func validGenerateBody() []byte {
 				KemID: KemAlgorithmDHKEMX25519HKDFSHA256,
 			},
 		},
-		KeyProtectionMechanism: KeyProtectionMechanismVMEmulated,
-		Lifespan:               ProtoDuration{Seconds: 3600},
+		Lifespan: ProtoDuration{Seconds: 3600},
 	})
 	return body
 }
@@ -150,23 +149,19 @@ func TestHandleGenerateKeyBadRequest(t *testing.T) {
 	}{
 		{
 			name: "unsupported algorithm type",
-			body: GenerateKeyRequest{Algorithm: AlgorithmDetails{Type: "mac", Params: AlgorithmParams{KemID: KemAlgorithmDHKEMX25519HKDFSHA256}}, KeyProtectionMechanism: KeyProtectionMechanismVMEmulated, Lifespan: ProtoDuration{Seconds: 3600}},
+			body: GenerateKeyRequest{Algorithm: AlgorithmDetails{Type: "mac", Params: AlgorithmParams{KemID: KemAlgorithmDHKEMX25519HKDFSHA256}}, Lifespan: ProtoDuration{Seconds: 3600}},
 		},
 		{
 			name: "unsupported algorithm",
-			body: GenerateKeyRequest{Algorithm: AlgorithmDetails{Type: "kem", Params: AlgorithmParams{KemID: KemAlgorithmUnspecified}}, KeyProtectionMechanism: KeyProtectionMechanismVMEmulated, Lifespan: ProtoDuration{Seconds: 3600}},
-		},
-		{
-			name: "unsupported key protection mechanism",
-			body: GenerateKeyRequest{Algorithm: AlgorithmDetails{Type: "kem", Params: AlgorithmParams{KemID: KemAlgorithmDHKEMX25519HKDFSHA256}}, KeyProtectionMechanism: KeyProtectionMechanism(99), Lifespan: ProtoDuration{Seconds: 3600}},
+			body: GenerateKeyRequest{Algorithm: AlgorithmDetails{Type: "kem", Params: AlgorithmParams{KemID: KemAlgorithmUnspecified}}, Lifespan: ProtoDuration{Seconds: 3600}},
 		},
 		{
 			name: "zero lifespan",
-			body: GenerateKeyRequest{Algorithm: AlgorithmDetails{Type: "kem", Params: AlgorithmParams{KemID: KemAlgorithmDHKEMX25519HKDFSHA256}}, KeyProtectionMechanism: KeyProtectionMechanismVMEmulated, Lifespan: ProtoDuration{Seconds: 0}},
+			body: GenerateKeyRequest{Algorithm: AlgorithmDetails{Type: "kem", Params: AlgorithmParams{KemID: KemAlgorithmDHKEMX25519HKDFSHA256}}, Lifespan: ProtoDuration{Seconds: 0}},
 		},
 		{
 			name: "missing algorithm (defaults to 0, type empty)",
-			body: GenerateKeyRequest{KeyProtectionMechanism: KeyProtectionMechanismVMEmulated, Lifespan: ProtoDuration{Seconds: 3600}},
+			body: GenerateKeyRequest{Lifespan: ProtoDuration{Seconds: 3600}},
 		},
 	}
 
@@ -207,9 +202,9 @@ func TestHandleGenerateKeyBadJSON(t *testing.T) {
 		body string
 	}{
 		{"not json", "not json"},
-		{"lifespan as string", `{"algorithm":1,"key_protection_mechanism":2,"lifespan":"3600"}`},
-		{"lifespan as string with suffix", `{"algorithm":1,"key_protection_mechanism":2,"lifespan":"3600s"}`},
-		{"lifespan negative", `{"algorithm":1,"key_protection_mechanism":2,"lifespan":-1}`},
+		{"lifespan as string", `{"algorithm":1,"lifespan":"3600"}`},
+		{"lifespan as string with suffix", `{"algorithm":1,"lifespan":"3600s"}`},
+		{"lifespan negative", `{"algorithm":1,"lifespan":-1}`},
 	}
 
 	for _, tc := range badBodies {
@@ -255,17 +250,17 @@ func TestHandleGenerateKeyFlexibleLifespan(t *testing.T) {
 	}{
 		{
 			name:     "integer seconds",
-			body:     `{"algorithm":{"type":"kem","params":{"kem_id":"DHKEM_X25519_HKDF_SHA256"}},"key_protection_mechanism":"KEY_PROTECTION_VM_EMULATED","lifespan":3600}`,
+			body:     `{"algorithm":{"type":"kem","params":{"kem_id":"DHKEM_X25519_HKDF_SHA256"}},"lifespan":3600}`,
 			expected: 3600,
 		},
 		{
 			name:     "float seconds",
-			body:     `{"algorithm":{"type":"kem","params":{"kem_id":"DHKEM_X25519_HKDF_SHA256"}},"key_protection_mechanism":"KEY_PROTECTION_VM_EMULATED","lifespan":1.5}`,
+			body:     `{"algorithm":{"type":"kem","params":{"kem_id":"DHKEM_X25519_HKDF_SHA256"}},"lifespan":1.5}`,
 			expected: 1, // Truncated to 1
 		},
 		{
 			name:     "float seconds round down",
-			body:     `{"algorithm":{"type":"kem","params":{"kem_id":"DHKEM_X25519_HKDF_SHA256"}},"key_protection_mechanism":"KEY_PROTECTION_VM_EMULATED","lifespan":3600.9}`,
+			body:     `{"algorithm":{"type":"kem","params":{"kem_id":"DHKEM_X25519_HKDF_SHA256"}},"lifespan":3600.9}`,
 			expected: 3600,
 		},
 	}


### PR DESCRIPTION
- Renamed endpoint from /v1/keys:generate_kem to /v1/keys:generate_key.
- Restructured `GenerateKeyRequest` to use a nested `Algorithm` definition containing `Type` and an algorithm-specific `Params` object with `kem_id`.
- Added support for `KEY_PROTECTION_VM_EMULATED` in the KeyProtectionMechanism enum and established this as the default and only supported mechanism for Vanguard so far.
- Validated lifecycle configurations and parsed `Algorithm` appropriately according to updated schemas.
- Updated associated unit and integration tests (server_test.go, integration_test.go) to use the new endpoints and the new request signature.

Manually tested with : 
```py
payload = {
    "algorithm": {
        "type": "kem",
        "params": {
            "kem_id": "DHKEM_X25519_HKDF_SHA256"
        }
    },
    "lifespan": 3600
}
resp = session.post(f"{base_url}/v1/keys:generate_key", json=payload)
```

result:
```
Generated Key: 64baa919-0fa8-4211-b41d-70f4aa1edc40
```
