### PR TITLE
chore: Rerun cbindgen for decap and seal ffi

### DIFF
--- a/keymanager/key_protection_service/key_custody_core/include/kps_key_custody_core.h
+++ b/keymanager/key_protection_service/key_custody_core/include/kps_key_custody_core.h
@@ -21,6 +21,16 @@ int32_t key_manager_generate_kem_keypair(const uint8_t *algo_ptr,
 
 int32_t key_manager_destroy_kem_key(const uint8_t *uuid_bytes);
 
+int32_t key_manager_decap_and_seal(const uint8_t *uuid_bytes,
+                                   const uint8_t *encapsulated_key,
+                                   size_t encapsulated_key_len,
+                                   const uint8_t *aad,
+                                   size_t aad_len,
+                                   uint8_t *out_encapsulated_key,
+                                   size_t out_encapsulated_key_len,
+                                   uint8_t *out_ciphertext,
+                                   size_t out_ciphertext_len);
+
 #ifdef __cplusplus
 }  // extern "C"
 #endif  // __cplusplus

--- a/keymanager/workload_service/key_custody_core/include/ws_key_custody_core.h
+++ b/keymanager/workload_service/key_custody_core/include/ws_key_custody_core.h
@@ -19,6 +19,16 @@ int32_t key_manager_generate_binding_keypair(const uint8_t *algo_ptr,
 
 int32_t key_manager_destroy_binding_key(const uint8_t *uuid_bytes);
 
+int32_t key_manager_open(const uint8_t *uuid_bytes,
+                         const uint8_t *enc,
+                         size_t enc_len,
+                         const uint8_t *ciphertext,
+                         size_t ciphertext_len,
+                         const uint8_t *aad,
+                         size_t aad_len,
+                         uint8_t *out_plaintext,
+                         size_t out_plaintext_len);
+
 #ifdef __cplusplus
 }  // extern "C"
 #endif  // __cplusplus


### PR DESCRIPTION
Rerunning cbindgen to update C headers with `key_manager_decap_and_seal` and `key_manager_open`.