### PR TITLE
[Keymanager] Add go:generate directives to build Rust dependencies

### DIFF
--- a/keymanager/key_protection_service/key_custody_core/kps_key_custody_core_cgo.go
+++ b/keymanager/key_protection_service/key_custody_core/kps_key_custody_core_cgo.go
@@ -1,6 +1,8 @@
 //go:build cgo && linux && amd64
 
 // Package kpskcc implements the Key Protection Service Key Custody Core interface via Rust FFI.
+//
+//go:generate cargo build --manifest-path ../../Cargo.toml
 package kpskcc
 
 /*

--- a/keymanager/workload_service/key_custody_core/ws_key_custody_core_cgo.go
+++ b/keymanager/workload_service/key_custody_core/ws_key_custody_core_cgo.go
@@ -1,6 +1,8 @@
 //go:build cgo && linux && amd64
 
 // Package wskcc implements the Workload Service Key Custody Core interface via Rust FFI.
+//
+//go:generate cargo build --manifest-path ../../Cargo.toml
 package wskcc
 
 /*


### PR DESCRIPTION
This allows `go generate ./...` to automatically build the Cargo workspace, ensuring that the latest Rust libraries are built before running the Go integration tests.

Unit and Integration tests can then be run as below,
```bash
go generate ./... && go test ./... && go test -tags=integration ./...
```

