### PR TITLE
[launcher] Allow GCA client creation failure

### DIFF
--- a/launcher/container_runner.go
+++ b/launcher/container_runner.go
@@ -652,9 +652,13 @@ func (r *ContainerRunner) Run(ctx context.Context) error {
 	} else {
 		gcaClient, err := util.NewRESTClient(ctx, r.launchSpec.GcaAddress, r.launchSpec.ProjectID, r.launchSpec.Region)
 		if err != nil {
-			return fmt.Errorf("failed to create REST verifier client: %v", err)
+			if !r.launchSpec.DisableGcaRefresh {
+				return fmt.Errorf("failed to create REST verifier client: %v", err)
+			}
+			// If GCA refresh is disabled, swallow the error and continue.
+			r.logger.Info("Failed to create the GCA client, but GCA refresh is disabled so the launch will continue: %v", err)
+			gcaClient = nil
 		}
-
 		attestClients.GCA = gcaClient
 	}
 

--- a/launcher/teeserver/tee_server.go
+++ b/launcher/teeserver/tee_server.go
@@ -111,7 +111,6 @@ func (a *attestHandler) getToken(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "text/html")
 
 	a.logger.Info(fmt.Sprintf("%s called", gcaEndpoint))
-	// If the handler does not have a GCA client, create one.
 	if a.clients.GCA == nil {
 		errStr := "no GCA verifier client present, please try rebooting your VM"
 		a.logAndWriteError(errStr, http.StatusInternalServerError, w)


### PR DESCRIPTION
If GCA refresh is disabled, we should allow GCA client creation to fail (e.g., due to the API not being enabled).