### PR TITLE
[KeyManager] Update API signatures for key generation and enumeration

### DIFF
--- a/keymanager/workload_service/integration_test.go
+++ b/keymanager/workload_service/integration_test.go
@@ -47,7 +47,7 @@ func TestIntegrationGenerateKeysEndToEnd(t *testing.T) {
 
 	reqBody, err := json.Marshal(GenerateKeyRequest{
 		Algorithm: AlgorithmDetails{Type: "kem", Params: AlgorithmParams{KemID: KemAlgorithmDHKEMX25519HKDFSHA256}},
-		Lifespan:  ProtoDuration{Seconds: 3600},
+		Lifespan:  3600,
 	})
 	if err != nil {
 		t.Fatalf("failed to marshal request: %v", err)
@@ -98,7 +98,7 @@ func TestIntegrationGenerateKeysUniqueMappings(t *testing.T) {
 	for i := 0; i < 2; i++ {
 		reqBody, err := json.Marshal(GenerateKeyRequest{
 			Algorithm: AlgorithmDetails{Type: "kem", Params: AlgorithmParams{KemID: KemAlgorithmDHKEMX25519HKDFSHA256}},
-			Lifespan:  ProtoDuration{Seconds: 3600},
+			Lifespan:  3600,
 		})
 		if err != nil {
 			t.Fatalf("call %d: failed to marshal request: %v", i+1, err)
@@ -149,7 +149,7 @@ func TestIntegrationDestroyKey(t *testing.T) {
 	// 1. Generate a key first
 	reqBody, _ := json.Marshal(GenerateKeyRequest{
 		Algorithm: AlgorithmDetails{Type: "kem", Params: AlgorithmParams{KemID: KemAlgorithmDHKEMX25519HKDFSHA256}},
-		Lifespan:  ProtoDuration{Seconds: 3600},
+		Lifespan:  3600,
 	})
 	reqGen := httptest.NewRequest(http.MethodPost, "/v1/keys:generate_key", bytes.NewReader(reqBody))
 	reqGen.Header.Set("Content-Type", "application/json")
@@ -217,7 +217,7 @@ func TestIntegrationAutoDestroy(t *testing.T) {
 	// 1. Generate a key with 1-second lifespan
 	reqBody, _ := json.Marshal(GenerateKeyRequest{
 		Algorithm: AlgorithmDetails{Type: "kem", Params: AlgorithmParams{KemID: KemAlgorithmDHKEMX25519HKDFSHA256}},
-		Lifespan:  ProtoDuration{Seconds: 1},
+		Lifespan:  1,
 	})
 	reqGen := httptest.NewRequest(http.MethodPost, "/v1/keys:generate_key", bytes.NewReader(reqBody))
 	reqGen.Header.Set("Content-Type", "application/json")
@@ -264,7 +264,7 @@ func TestIntegrationKeyClaims(t *testing.T) {
 	// 1. Generate a KEM key
 	reqBody, _ := json.Marshal(GenerateKeyRequest{
 		Algorithm: AlgorithmDetails{Type: "kem", Params: AlgorithmParams{KemID: KemAlgorithmDHKEMX25519HKDFSHA256}},
-		Lifespan:  ProtoDuration{Seconds: 3600},
+		Lifespan:  3600,
 	})
 	req := httptest.NewRequest(http.MethodPost, "/v1/keys:generate_key", bytes.NewReader(reqBody))
 	w := httptest.NewRecorder()

--- a/keymanager/workload_service/server.go
+++ b/keymanager/workload_service/server.go
@@ -160,33 +160,10 @@ type KeyHandle struct {
 	Handle string `json:"handle"`
 }
 
-// ProtoDuration represents a google.protobuf.Duration in JSON (e.g. "3600s").
-type ProtoDuration struct {
-	Seconds uint64
-}
-
-// UnmarshalJSON parses a proto3 Duration JSON number (as seconds).
-func (d *ProtoDuration) UnmarshalJSON(data []byte) error {
-	var v float64
-	if err := json.Unmarshal(data, &v); err != nil {
-		return fmt.Errorf("duration must be a numeric value (seconds): %w", err)
-	}
-	if v < 0 || v > math.MaxUint64 {
-		return fmt.Errorf("duration %f out of range", v)
-	}
-	d.Seconds = uint64(v)
-	return nil
-}
-
-// MarshalJSON encodes as a proto3 Duration JSON number (as seconds).
-func (d ProtoDuration) MarshalJSON() ([]byte, error) {
-	return json.Marshal(d.Seconds)
-}
-
 // GenerateKeyRequest is the JSON body for POST /v1/keys:generate_key.
 type GenerateKeyRequest struct {
 	Algorithm AlgorithmDetails `json:"algorithm"`
-	Lifespan  ProtoDuration    `json:"lifespan"`
+	Lifespan  uint64           `json:"lifespan"`
 }
 
 // DestroyRequest is the JSON body for POST /v1/keys:destroy.
@@ -196,7 +173,10 @@ type DestroyRequest struct {
 
 // GenerateKeyResponse is returned by POST /v1/keys:generate_key.
 type GenerateKeyResponse struct {
-	KeyHandle KeyHandle `json:"key_handle"`
+	KeyHandle              KeyHandle  `json:"key_handle"`
+	PubKey                 PubKeyInfo `json:"pub_key"`
+	KeyProtectionMechanism string     `json:"key_protection_mechanism"`
+	ExpirationTime         int64      `json:"expiration_time"`
 }
 
 // AlgorithmParams represents the parameters for a specific algorithm type.
@@ -227,9 +207,10 @@ type EnumerateKeysResponse struct {
 
 // KeyInfo contains information about a single key.
 type KeyInfo struct {
-	KeyHandle         KeyHandle     `json:"key_handle"`
-	PubKey            PubKeyInfo    `json:"pub_key"`
-	RemainingLifespan ProtoDuration `json:"remaining_lifespan"`
+	KeyHandle              KeyHandle  `json:"key_handle"`
+	PubKey                 PubKeyInfo `json:"pub_key"`
+	KeyProtectionMechanism string     `json:"key_protection_mechanism"`
+	ExpirationTime         int64      `json:"expiration_time"`
 }
 
 // PubKeyInfo contains the public key and its algorithm.
@@ -416,9 +397,13 @@ func (s *Server) handleGenerateKey(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Validate lifespan is positive.
-	if req.Lifespan.Seconds == 0 {
+	// Validate lifespan is positive and does not cause int64 overflow.
+	if req.Lifespan == 0 {
 		writeError(w, "lifespan must be greater than 0s", http.StatusBadRequest)
+		return
+	}
+	if req.Lifespan > math.MaxInt64 {
+		writeError(w, "lifespan exceeds maximum allowed value", http.StatusBadRequest)
 		return
 	}
 
@@ -446,14 +431,14 @@ func (s *Server) generateKEMKey(w http.ResponseWriter, req GenerateKeyRequest) {
 	}
 
 	// Generate binding keypair via WSD KCC FFI.
-	bindingUUID, bindingPubKey, err := s.workloadService.GenerateBindingKeypair(algo, req.Lifespan.Seconds)
+	bindingUUID, bindingPubKey, err := s.workloadService.GenerateBindingKeypair(algo, req.Lifespan)
 	if err != nil {
 		writeError(w, fmt.Sprintf("failed to generate binding keypair: %v", err), http.StatusInternalServerError)
 		return
 	}
 
 	// Generate KEM keypair via KPS KOL, passing the binding public key.
-	kemUUID, _, err := s.keyProtectionService.GenerateKEMKeypair(algo, bindingPubKey, req.Lifespan.Seconds)
+	kemUUID, kemPubKey, err := s.keyProtectionService.GenerateKEMKeypair(algo, bindingPubKey, req.Lifespan)
 	if err != nil {
 		writeError(w, fmt.Sprintf("failed to generate KEM keypair: %v", err), http.StatusInternalServerError)
 		return
@@ -467,6 +452,17 @@ func (s *Server) generateKEMKey(w http.ResponseWriter, req GenerateKeyRequest) {
 	// Return KEM UUID to workload.
 	resp := GenerateKeyResponse{
 		KeyHandle: KeyHandle{Handle: kemUUID.String()},
+		PubKey: PubKeyInfo{
+			Algorithm: AlgorithmDetails{
+				Type: "kem",
+				Params: AlgorithmParams{
+					KemID: req.Algorithm.Params.KemID,
+				},
+			},
+			PublicKey: base64.StdEncoding.EncodeToString(kemPubKey),
+		},
+		KeyProtectionMechanism: keymanager.KeyProtectionMechanism_KEY_PROTECTION_VM_EMULATED.String(),
+		ExpirationTime:         time.Now().Unix() + int64(req.Lifespan),
 	}
 	writeJSON(w, resp, http.StatusOK)
 }
@@ -520,7 +516,8 @@ func (s *Server) handleEnumerateKeys(w http.ResponseWriter, _ *http.Request) {
 				},
 				PublicKey: base64.StdEncoding.EncodeToString(key.KEMPubKey),
 			},
-			RemainingLifespan: ProtoDuration{Seconds: key.RemainingLifespanSecs},
+			KeyProtectionMechanism: keymanager.KeyProtectionMechanism_KEY_PROTECTION_VM_EMULATED.String(),
+			ExpirationTime:         time.Now().Unix() + int64(key.RemainingLifespanSecs),
 		})
 	}
 

--- a/keymanager/workload_service/server_test.go
+++ b/keymanager/workload_service/server_test.go
@@ -122,7 +122,7 @@ func validGenerateBody() []byte {
 				KemID: KemAlgorithmDHKEMX25519HKDFSHA256,
 			},
 		},
-		Lifespan: ProtoDuration{Seconds: 3600},
+		Lifespan: 3600,
 	})
 	return body
 }
@@ -162,6 +162,15 @@ func TestHandleGenerateKeySuccess(t *testing.T) {
 	}
 	if resp.KeyHandle.Handle != kemUUID.String() {
 		t.Fatalf("expected KEM UUID %s, got %s", kemUUID, resp.KeyHandle.Handle)
+	}
+	if resp.PubKey.PublicKey != base64.StdEncoding.EncodeToString(kemPubKey) {
+		t.Fatalf("expected KEM pub key %s, got %s", base64.StdEncoding.EncodeToString(kemPubKey), resp.PubKey.PublicKey)
+	}
+	if resp.KeyProtectionMechanism != keymanager.KeyProtectionMechanism_KEY_PROTECTION_VM_EMULATED.String() {
+		t.Fatalf("expected %s, got %s", keymanager.KeyProtectionMechanism_KEY_PROTECTION_VM_EMULATED.String(), resp.KeyProtectionMechanism)
+	}
+	if resp.ExpirationTime <= time.Now().Unix() {
+		t.Fatalf("expected expiration time in the future, got %d", resp.ExpirationTime)
 	}
 
 	// Verify the binding public key was passed to KEM generator.
@@ -216,19 +225,19 @@ func TestHandleGenerateKeyBadRequest(t *testing.T) {
 	}{
 		{
 			name: "unsupported algorithm type",
-			body: GenerateKeyRequest{Algorithm: AlgorithmDetails{Type: "mac", Params: AlgorithmParams{KemID: KemAlgorithmDHKEMX25519HKDFSHA256}}, Lifespan: ProtoDuration{Seconds: 3600}},
+			body: GenerateKeyRequest{Algorithm: AlgorithmDetails{Type: "mac", Params: AlgorithmParams{KemID: KemAlgorithmDHKEMX25519HKDFSHA256}}, Lifespan: 3600},
 		},
 		{
 			name: "unsupported algorithm",
-			body: GenerateKeyRequest{Algorithm: AlgorithmDetails{Type: "kem", Params: AlgorithmParams{KemID: KemAlgorithmUnspecified}}, Lifespan: ProtoDuration{Seconds: 3600}},
+			body: GenerateKeyRequest{Algorithm: AlgorithmDetails{Type: "kem", Params: AlgorithmParams{KemID: KemAlgorithmUnspecified}}, Lifespan: 3600},
 		},
 		{
 			name: "zero lifespan",
-			body: GenerateKeyRequest{Algorithm: AlgorithmDetails{Type: "kem", Params: AlgorithmParams{KemID: KemAlgorithmDHKEMX25519HKDFSHA256}}, Lifespan: ProtoDuration{Seconds: 0}},
+			body: GenerateKeyRequest{Algorithm: AlgorithmDetails{Type: "kem", Params: AlgorithmParams{KemID: KemAlgorithmDHKEMX25519HKDFSHA256}}, Lifespan: 0},
 		},
 		{
 			name: "missing algorithm (defaults to 0, type empty)",
-			body: GenerateKeyRequest{Lifespan: ProtoDuration{Seconds: 3600}},
+			body: GenerateKeyRequest{Lifespan: 3600},
 		},
 	}
 
@@ -272,6 +281,7 @@ func TestHandleGenerateKeyBadJSON(t *testing.T) {
 		{"lifespan as string", `{"algorithm":{"type":"kem","params":{"kem_id":"DHKEM_X25519_HKDF_SHA256"}},"lifespan":"3600"}`},
 		{"lifespan as string with suffix", `{"algorithm":{"type":"kem","params":{"kem_id":"DHKEM_X25519_HKDF_SHA256"}},"lifespan":"3600s"}`},
 		{"lifespan negative", `{"algorithm":{"type":"kem","params":{"kem_id":"DHKEM_X25519_HKDF_SHA256"}},"lifespan":-1}`},
+		{"lifespan too large", `{"algorithm":{"type":"kem","params":{"kem_id":"DHKEM_X25519_HKDF_SHA256"}},"lifespan":9223372036854775808}`},
 	}
 
 	for _, tc := range badBodies {
@@ -318,16 +328,6 @@ func TestHandleGenerateKeyFlexibleLifespan(t *testing.T) {
 		{
 			name:     "integer seconds",
 			body:     `{"algorithm":{"type":"kem","params":{"kem_id":"DHKEM_X25519_HKDF_SHA256"}},"lifespan":3600}`,
-			expected: 3600,
-		},
-		{
-			name:     "float seconds",
-			body:     `{"algorithm":{"type":"kem","params":{"kem_id":"DHKEM_X25519_HKDF_SHA256"}},"lifespan":1.5}`,
-			expected: 1, // Truncated to 1
-		},
-		{
-			name:     "float seconds round down",
-			body:     `{"algorithm":{"type":"kem","params":{"kem_id":"DHKEM_X25519_HKDF_SHA256"}},"lifespan":3600.9}`,
 			expected: 3600,
 		},
 	}
@@ -522,9 +522,12 @@ func TestHandleEnumerateKeysWithKeys(t *testing.T) {
 	if info1.PubKey.PublicKey != base64.StdEncoding.EncodeToString(kemPubKey1) {
 		t.Fatalf("KEM pub key mismatch for kem1")
 	}
-	// BindingPubKey check removed
-	if info1.RemainingLifespan.Seconds != 3500 {
-		t.Fatalf("expected remaining lifespan 3500, got %d", info1.RemainingLifespan.Seconds)
+	if info1.KeyProtectionMechanism != keymanager.KeyProtectionMechanism_KEY_PROTECTION_VM_EMULATED.String() {
+		t.Fatalf("expected key protection mechanism %s, got %s", keymanager.KeyProtectionMechanism_KEY_PROTECTION_VM_EMULATED.String(), info1.KeyProtectionMechanism)
+	}
+	// Approximate check for expiration time
+	if info1.ExpirationTime <= time.Now().Unix() {
+		t.Fatalf("expected expiration time in the future, got %d", info1.ExpirationTime)
 	}
 
 	// Verify key 2.
@@ -532,8 +535,9 @@ func TestHandleEnumerateKeysWithKeys(t *testing.T) {
 	if !ok {
 		t.Fatalf("expected kem2 %s in response", kem2)
 	}
-	if info2.RemainingLifespan.Seconds != 7100 {
-		t.Fatalf("expected remaining lifespan 7100, got %d", info2.RemainingLifespan.Seconds)
+	// Approximate check for expiration time
+	if info2.ExpirationTime <= time.Now().Unix() {
+		t.Fatalf("expected expiration time in the future, got %d", info2.ExpirationTime)
 	}
 }
 


### PR DESCRIPTION
Modify the GenerateKeyResponse and KeyInfo structs to align with the latest API specifications.

Changes:
- Add PubKey field containing the algorithm details and public key.
- Add KeyProtectionMechanism field set to KEY_PROTECTION_VM_EMULATED.
- Replace RemainingLifespan with ExpirationTime (Unix timestamp).
- Update server implementation and tests to populate and verify these new fields accordingly.

New responses example:

1. Generate Key
```json
{
  "key_handle": {
    "handle": "450e21df-03c3-445e-b55a-2f1331206aeb"
  },
  "pub_key": {
    "algorithm": {
      "type": "kem",
      "params": {
        "kem_id": "DHKEM_X25519_HKDF_SHA256"
      }
    },
    "public_key": "csP6T6pZgdGpYpD/LwRA0U5HQfKmO0TH3SzPl2jGpUw="
  },
  "key_protection_mechanism": "KEY_PROTECTION_VM_EMULATED",
  "expiration_time": 1773155677
}
```

2. enumerate:
```json
{
  "key_infos": [
    {
      "key_handle": {
        "handle": "450e21df-03c3-445e-b55a-2f1331206aeb"
      },
      "pub_key": {
        "algorithm": {
          "type": "kem",
          "params": {
            "kem_id": "DHKEM_X25519_HKDF_SHA256"
          }
        },
        "public_key": "csP6T6pZgdGpYpD/LwRA0U5HQfKmO0TH3SzPl2jGpUw="
      },
      "key_protection_mechanism": "KEY_PROTECTION_VM_EMULATED",
      "expiration_time": 1773155676
    }
  ]
}
```