### PR TITLE
Add device ROT manager to attestation agent for runtime device attestation orchestration

### DIFF
--- a/launcher/agent/agent.go
+++ b/launcher/agent/agent.go
@@ -34,6 +34,7 @@ import (
 	"github.com/google/go-tpm-tools/cel"
 	"github.com/google/go-tpm-tools/client"
 	"github.com/google/go-tpm-tools/internal"
+	"github.com/google/go-tpm-tools/launcher/device"
 	"github.com/google/go-tpm-tools/launcher/internal/logging"
 	"github.com/google/go-tpm-tools/launcher/internal/signaturediscovery"
 	"github.com/google/go-tpm-tools/launcher/spec"
@@ -72,28 +73,13 @@ type attestRoot interface {
 	Attest(nonce []byte) (any, error)
 	// ComputeNonce hashes the challenge and extraData using the algorithm preferred by the attestation root.
 	ComputeNonce(challenge []byte, extraData []byte) []byte
-	// AddDeviceROTs adds detected device RoTs(root of trust).
-	AddDeviceROTs([]DeviceROT)
-	// AttestDeviceROTs fetches a list of runtime device attestation report.
-	AttestDeviceROTs(nonce []byte) ([]any, error)
-}
-
-// DeviceROT defines an interface for all attached devices to collect attestation.
-type DeviceROT interface {
-	// Attest fetches an attestation from the attached device detected by launcher.
-	Attest(nonce []byte) (any, error)
 }
 
 // AttestAgentOpts contains user generated options when calling the
 // VerifyAttestation API
 type AttestAgentOpts struct {
-	TokenOptions *models.TokenOptions
-	*DeviceReportOpts
-}
-
-// DeviceReportOpts contains options for runtime device attestations.
-type DeviceReportOpts struct {
-	EnableRuntimeGPUAttestation bool
+	TokenOptions     *models.TokenOptions
+	DeviceReportOpts device.ReportOpts
 }
 
 type agent struct {
@@ -106,6 +92,7 @@ type agent struct {
 	launchSpec       spec.LaunchSpec
 	logger           logging.Logger
 	sigsCache        *sigsCache
+	deviceROTManager *device.ROTManager
 }
 
 // CreateAttestationAgent returns an agent capable of performing remote
@@ -115,7 +102,7 @@ type agent struct {
 // - principalFetcher is a func to fetch GCE principal tokens for a given audience.
 // - signaturesFetcher is a func to fetch container image signatures associated with the running workload.
 // - logger will log any partial errors returned by VerifyAttestation.
-func CreateAttestationAgent(tpm io.ReadWriteCloser, akFetcher util.TpmKeyFetcher, verifierClient verifier.Client, principalFetcher principalIDTokenFetcher, sigsFetcher signaturediscovery.Fetcher, launchSpec spec.LaunchSpec, logger logging.Logger, deviceROTs []DeviceROT) (AttestationAgent, error) {
+func CreateAttestationAgent(tpm io.ReadWriteCloser, akFetcher util.TpmKeyFetcher, verifierClient verifier.Client, principalFetcher principalIDTokenFetcher, sigsFetcher signaturediscovery.Fetcher, launchSpec spec.LaunchSpec, logger logging.Logger, deviceROTs []device.ROT) (AttestationAgent, error) {
 	// Fetched the AK and save it, so the agent doesn't need to create a new key everytime
 	ak, err := akFetcher(tpm)
 	if err != nil {
@@ -178,8 +165,8 @@ func CreateAttestationAgent(tpm io.ReadWriteCloser, akFetcher util.TpmKeyFetcher
 		attestAgent.avRot = tpmAR
 	}
 
-	// Add deviceRoTs to the CPU attestation root.
-	attestAgent.avRot.AddDeviceROTs(deviceROTs)
+	// Register device ROT manager to the attestAgent.
+	attestAgent.deviceROTManager = device.NewROTManager(deviceROTs)
 	return attestAgent, nil
 }
 
@@ -360,10 +347,7 @@ func (a *agent) AttestationEvidence(_ context.Context, challenge []byte, extraDa
 }
 
 func (a *agent) attestDeviceROTs(nonce []byte, opts AttestAgentOpts) ([]*attestationpb.DeviceAttestationReport, error) {
-	if opts.DeviceReportOpts == nil {
-		return nil, nil
-	}
-	deviceROTs, err := a.avRot.AttestDeviceROTs(nonce)
+	deviceROTs, err := a.deviceROTManager.AttestDeviceROTs(nonce, opts.DeviceReportOpts)
 	if err != nil {
 		return nil, err
 	}
@@ -411,12 +395,11 @@ func convertOCIToContainerSignature(ociSig oci.Signature) (*verifier.ContainerSi
 }
 
 type tpmAttestRoot struct {
-	tpmMu      sync.Mutex
-	fetchedAK  *client.Key
-	tpm        io.ReadWriteCloser
-	cosCel     gecel.CEL
-	hashAlgos  []crypto.Hash
-	deviceROTs []DeviceROT
+	tpmMu     sync.Mutex
+	fetchedAK *client.Key
+	tpm       io.ReadWriteCloser
+	cosCel    gecel.CEL
+	hashAlgos []crypto.Hash
 }
 
 func (t *tpmAttestRoot) GetCEL() gecel.CEL {
@@ -457,22 +440,10 @@ func (t *tpmAttestRoot) ComputeNonce(challenge []byte, extraData []byte) []byte 
 	return finalNonce[:]
 }
 
-func (t *tpmAttestRoot) AddDeviceROTs(deviceROTs []DeviceROT) {
-	t.deviceROTs = append(t.deviceROTs, deviceROTs...)
-}
-
-func (t *tpmAttestRoot) AttestDeviceROTs(nonce []byte) ([]any, error) {
-	t.tpmMu.Lock()
-	defer t.tpmMu.Unlock()
-
-	return doAttestDeviceROTs(t.deviceROTs, nonce)
-}
-
 type tdxAttestRoot struct {
-	tdxMu      sync.Mutex
-	qp         *tg.LinuxConfigFsQuoteProvider
-	cosCel     gecel.CEL
-	deviceROTs []DeviceROT
+	tdxMu  sync.Mutex
+	qp     *tg.LinuxConfigFsQuoteProvider
+	cosCel gecel.CEL
 }
 
 func (t *tdxAttestRoot) GetCEL() gecel.CEL {
@@ -513,13 +484,6 @@ func (t *tdxAttestRoot) Attest(nonce []byte) (any, error) {
 	}, nil
 }
 
-func (t *tdxAttestRoot) AttestDeviceROTs(nonce []byte) ([]any, error) {
-	t.tdxMu.Lock()
-	defer t.tdxMu.Unlock()
-
-	return doAttestDeviceROTs(t.deviceROTs, nonce)
-}
-
 func (t *tdxAttestRoot) ComputeNonce(challenge []byte, extraData []byte) []byte {
 	challengeData := challenge
 	if extraData != nil {
@@ -529,10 +493,6 @@ func (t *tdxAttestRoot) ComputeNonce(challenge []byte, extraData []byte) []byte 
 	challengeDigest := sha512.Sum512(challengeData)
 	finalNonce := sha512.Sum512(append([]byte(labels.WorkloadAttestation), challengeDigest[:]...))
 	return finalNonce[:]
-}
-
-func (t *tdxAttestRoot) AddDeviceROTs(deviceROTs []DeviceROT) {
-	t.deviceROTs = append(t.deviceROTs, deviceROTs...)
 }
 
 // Refresh refreshes the internal state of the attestation agent.
@@ -632,16 +592,4 @@ func convertToTPMQuote(v *pb.Attestation) *attestationpb.TpmQuote {
 			},
 		},
 	}
-}
-
-func doAttestDeviceROTs(deviceROTs []DeviceROT, nonce []byte) ([]any, error) {
-	var deviceReports []any
-	for _, deviceROT := range deviceROTs {
-		deviceReport, err := deviceROT.Attest(nonce)
-		if err != nil {
-			return nil, err
-		}
-		deviceReports = append(deviceReports, deviceReport)
-	}
-	return deviceReports, nil
 }

--- a/launcher/agent/agent_test.go
+++ b/launcher/agent/agent_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/google/go-tpm-tools/cel"
 	"github.com/google/go-tpm-tools/client"
 	"github.com/google/go-tpm-tools/internal/test"
+	"github.com/google/go-tpm-tools/launcher/device"
 	"github.com/google/go-tpm-tools/launcher/internal/experiments"
 	"github.com/google/go-tpm-tools/launcher/internal/logging"
 	"github.com/google/go-tpm-tools/launcher/internal/signaturediscovery"
@@ -659,7 +660,6 @@ type fakeTdxAttestRoot struct {
 	cel           gecel.CEL
 	receivedNonce []byte
 	tdxQuote      []byte
-	deviceROTs    []DeviceROT
 }
 
 func (f *fakeTdxAttestRoot) Extend(c gecel.Content) error {
@@ -690,29 +690,8 @@ func (f *fakeTdxAttestRoot) ComputeNonce(challenge []byte, extraData []byte) []b
 	return finalNonce[:]
 }
 
-func (f *fakeTdxAttestRoot) AttestDeviceROTs(nonce []byte) ([]any, error) {
-	var deviceReports []any
-	for _, deviceRoT := range f.deviceROTs {
-		att, err := deviceRoT.Attest(nonce)
-		if err != nil {
-			return nil, err
-		}
-		switch v := att.(type) {
-		case *attestationpb.NvidiaAttestationReport:
-			deviceReports = append(deviceReports, v)
-		default:
-			return nil, fmt.Errorf("unknown device attestation type: %T", v)
-		}
-	}
-	return deviceReports, nil
-}
-
 //go:embed testdata/cel.b64
 var celB64 string
-
-func (f *fakeTdxAttestRoot) AddDeviceROTs(deviceRoTS []DeviceROT) {
-	f.deviceROTs = append(f.deviceROTs, deviceRoTS...)
-}
 
 type fakeGPURoT struct{}
 
@@ -728,56 +707,9 @@ func (f *fakeGPURoT) Attest(nonce []byte) (any, error) {
 		},
 	}, nil
 }
-func TestTDXAttestDeviceROTs(t *testing.T) {
-	testCases := []struct {
-		name          string
-		tdxAttestRoot *fakeTdxAttestRoot
-		nonce         []byte
-		wantGPU       bool
-		wantPass      bool
-	}{
-		{
-			name:          "success tdxAttestRoot w/o GPU device",
-			tdxAttestRoot: &fakeTdxAttestRoot{},
-			nonce:         []byte("test-nonce"),
-			wantPass:      true,
-		},
-		{
-			name: "success tdxAttestRoot w/ GPU device",
-			tdxAttestRoot: &fakeTdxAttestRoot{
-				deviceROTs: []DeviceROT{&fakeGPURoT{}},
-			},
-			nonce:    []byte("test-nonce"),
-			wantGPU:  true,
-			wantPass: true,
-		},
-		{
-			name: "failed tdxAttestRoot w/ GPU device",
-			tdxAttestRoot: &fakeTdxAttestRoot{
-				deviceROTs: []DeviceROT{&fakeGPURoT{}},
-			},
-			nonce:    []byte(""),
-			wantPass: false,
-		},
-	}
 
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			deviceReports, err := tc.tdxAttestRoot.AttestDeviceROTs(tc.nonce)
-			if gotPass := err == nil; gotPass != tc.wantPass {
-				t.Errorf("tdxAttestRoot.AttestDeviceROTs() did not return expected attestation result, got %v, want %v", gotPass, tc.wantPass)
-			}
-			if tc.wantGPU {
-				if len(deviceReports) == 0 {
-					t.Fatalf("tdxAttestRoot.AttestDeviceROTs() didn't return any device reports")
-				}
-				if att := deviceReports[0].(*attestationpb.NvidiaAttestationReport); att == nil {
-					t.Errorf("tdxAttestRoot.AttestDeviceROTs() didn't return expected device report type, want %v, but got nil", &attestationpb.NvidiaAttestationReport{})
-				}
-			}
-		})
-	}
-
+func (f *fakeGPURoT) Vendor() device.Vendor {
+	return device.NvidiaGPU
 }
 
 func TestAttestationEvidence_TDX_Success(t *testing.T) {
@@ -816,8 +748,8 @@ func TestAttestationEvidence_TDX_Success(t *testing.T) {
 				EnableAttestationEvidence: true,
 			},
 		},
+		deviceROTManager: device.NewROTManager([]device.ROT{&fakeGPURoT{}}),
 	}
-	attestAgent.avRot.AddDeviceROTs([]DeviceROT{&fakeGPURoT{}})
 
 	if err := measureFakeEvents(attestAgent); err != nil {
 		t.Fatalf("failed to measure events: %v", err)
@@ -838,7 +770,7 @@ func TestAttestationEvidence_TDX_Success(t *testing.T) {
 		{
 			name: "TDX attestation + runtime GPU attestation",
 			opts: AttestAgentOpts{
-				DeviceReportOpts: &DeviceReportOpts{
+				DeviceReportOpts: device.ReportOpts{
 					EnableRuntimeGPUAttestation: true,
 				},
 			},
@@ -1146,6 +1078,7 @@ func TestAttestationEvidence_TDX_NilExtraData(t *testing.T) {
 				EnableAttestationEvidence: true,
 			},
 		},
+		deviceROTManager: device.NewROTManager(nil),
 	}
 
 	challenge := []byte("test-challenge")

--- a/launcher/container_runner.go
+++ b/launcher/container_runner.go
@@ -31,6 +31,7 @@ import (
 	"github.com/google/go-tpm-tools/client"
 	workloadservice "github.com/google/go-tpm-tools/keymanager/workload_service"
 	"github.com/google/go-tpm-tools/launcher/agent"
+	"github.com/google/go-tpm-tools/launcher/device"
 	"github.com/google/go-tpm-tools/launcher/internal/gpu"
 	"github.com/google/go-tpm-tools/launcher/internal/healthmonitoring/nodeproblemdetector"
 	"github.com/google/go-tpm-tools/launcher/internal/logging"
@@ -198,7 +199,7 @@ func NewRunner(ctx context.Context, cdClient *containerd.Client, token oauth2.To
 	}
 	specOpts = append(specOpts, cgroupOpts...)
 
-	var deviceROTs []agent.DeviceROT
+	var deviceROTs []device.ROT
 	nvidiaAttester := gpu.NewNvidiaAttester(launchSpec.InstallGpuDriver)
 	if launchSpec.InstallGpuDriver {
 		gpuMounts := []specs.Mount{

--- a/launcher/container_runner_test.go
+++ b/launcher/container_runner_test.go
@@ -25,6 +25,7 @@ import (
 	gecel "github.com/google/go-eventlog/cel"
 	"github.com/google/go-tpm-tools/cel"
 	"github.com/google/go-tpm-tools/launcher/agent"
+	"github.com/google/go-tpm-tools/launcher/device"
 	"github.com/google/go-tpm-tools/launcher/internal/gpu"
 	"github.com/google/go-tpm-tools/launcher/internal/logging"
 	"github.com/google/go-tpm-tools/launcher/launcherfile"
@@ -103,6 +104,10 @@ func (f *fakeGPUAttester) Attest(nonce []byte) (any, error) {
 
 func (f *fakeGPUAttester) EnableReadyState() error {
 	return nil
+}
+
+func (f *fakeGPUAttester) Vendor() device.Vendor {
+	return device.NvidiaGPU
 }
 
 type fakeClaims struct {

--- a/launcher/device/device.go
+++ b/launcher/device/device.go
@@ -1,0 +1,64 @@
+// Package device provides an interface and management for device Root of Trust (ROT) attestation in the launcher.
+package device
+
+import (
+	"sync"
+
+	"go.uber.org/multierr"
+)
+
+// Vendor defines the type for device Root of Trust (ROT) vendors.
+type Vendor int
+
+// Define constants for supported ROT vendors.
+const (
+	Unspecified Vendor = iota
+	NvidiaGPU
+)
+
+// ROT defines an interface for all attached devices to collect attestation.
+type ROT interface {
+	// Attest fetches an attestation from the attached device detected by launcher.
+	Attest(nonce []byte) (any, error)
+	// Vendor returns the device ROT vendor type.
+	Vendor() Vendor
+}
+
+// ROTManager manages the attestation of all attached device ROTs.
+type ROTManager struct {
+	deviceMu sync.Mutex
+	rots     []ROT
+}
+
+// ReportOpts defines the options for device attestation report generation.
+type ReportOpts struct {
+	// EnableRuntimeGPUAttestation indicates whether to include runtime GPU attestation in the device reports.
+	EnableRuntimeGPUAttestation bool
+}
+
+// NewROTManager creates a new ROTManager.
+func NewROTManager(rots []ROT) *ROTManager {
+	return &ROTManager{
+		rots: rots,
+	}
+}
+
+// AttestDeviceROTs fetches attestation reports from all detected device ROTs based on the provided options.
+func (m *ROTManager) AttestDeviceROTs(nonce []byte, opts ReportOpts) ([]any, error) {
+	m.deviceMu.Lock()
+	defer m.deviceMu.Unlock()
+
+	var deviceReports []any
+	var err error
+	for _, deviceROT := range m.rots {
+		if opts.EnableRuntimeGPUAttestation && deviceROT.Vendor() == NvidiaGPU {
+			deviceReport, e := deviceROT.Attest(nonce)
+			if e != nil {
+				err = multierr.Append(err, e)
+			} else {
+				deviceReports = append(deviceReports, deviceReport)
+			}
+		}
+	}
+	return deviceReports, err
+}

--- a/launcher/device/device_test.go
+++ b/launcher/device/device_test.go
@@ -1,0 +1,148 @@
+package device
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"go.uber.org/multierr"
+)
+
+type mockROT struct {
+	vendor Vendor
+	report any
+	err    error
+}
+
+func (m *mockROT) Attest(_ []byte) (any, error) {
+	return m.report, m.err
+}
+
+func (m *mockROT) Vendor() Vendor {
+	return m.vendor
+}
+
+func TestAttestDeviceROTs(t *testing.T) {
+	testCases := []struct {
+		name         string
+		rots         []ROT
+		opts         ReportOpts
+		wantReports  []any
+		wantErr      bool
+		wantErrCount int
+	}{
+		{
+			name: "NvidiaGPU with runtime attestation enabled",
+			rots: []ROT{
+				&mockROT{vendor: NvidiaGPU, report: "gpu-report"},
+			},
+			opts:        ReportOpts{EnableRuntimeGPUAttestation: true},
+			wantReports: []any{"gpu-report"},
+			wantErr:     false,
+		},
+		{
+			name: "NvidiaGPU with runtime attestation disabled",
+			rots: []ROT{
+				&mockROT{vendor: NvidiaGPU, report: "gpu-report"},
+			},
+			opts:        ReportOpts{EnableRuntimeGPUAttestation: false},
+			wantReports: nil,
+			wantErr:     false,
+		},
+		{
+			name: "Unspecified vendor is ignored",
+			rots: []ROT{
+				&mockROT{vendor: Unspecified, report: "some-report"},
+			},
+			opts:        ReportOpts{EnableRuntimeGPUAttestation: true},
+			wantReports: nil,
+			wantErr:     false,
+		},
+		{
+			name: "Multiple devices, one fails",
+			rots: []ROT{
+				&mockROT{vendor: NvidiaGPU, report: "gpu-report-1"},
+				&mockROT{vendor: NvidiaGPU, err: errors.New("attestation failed")},
+			},
+			opts:         ReportOpts{EnableRuntimeGPUAttestation: true},
+			wantReports:  []any{"gpu-report-1"},
+			wantErr:      true,
+			wantErrCount: 1,
+		},
+		{
+			name: "Multiple devices, multiple fail",
+			rots: []ROT{
+				&mockROT{vendor: NvidiaGPU, err: errors.New("error 1")},
+				&mockROT{vendor: NvidiaGPU, err: errors.New("error 2")},
+			},
+			opts:         ReportOpts{EnableRuntimeGPUAttestation: true},
+			wantReports:  nil,
+			wantErr:      true,
+			wantErrCount: 2,
+		},
+		{
+			name: "Multiple devices, both succeed",
+			rots: []ROT{
+				&mockROT{vendor: NvidiaGPU, report: "gpu-report-1"},
+				&mockROT{vendor: NvidiaGPU, report: "gpu-report-2"},
+			},
+			opts:        ReportOpts{EnableRuntimeGPUAttestation: true},
+			wantReports: []any{"gpu-report-1", "gpu-report-2"},
+			wantErr:     false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			m := NewROTManager(tc.rots)
+			gotReports, err := m.AttestDeviceROTs([]byte("nonce"), tc.opts)
+			if (err != nil) != tc.wantErr {
+				t.Errorf("AttestDeviceROTs() error = %v, wantErr %v", err, tc.wantErr)
+				return
+			}
+			if tc.wantErr {
+				errs := multierr.Errors(err)
+				if len(errs) != tc.wantErrCount {
+					t.Errorf("AttestDeviceROTs() error count = %d, want %d", len(errs), tc.wantErrCount)
+				}
+			}
+			if !cmp.Equal(gotReports, tc.wantReports) {
+				t.Errorf("AttestDeviceROTs() gotReports = %v, want %v", gotReports, tc.wantReports)
+			}
+		})
+	}
+}
+
+func TestAttestDeviceROTsRace(t *testing.T) {
+	rots := []ROT{
+		&mockROT{vendor: NvidiaGPU, report: "gpu-report-1"},
+		&mockROT{vendor: NvidiaGPU, report: "gpu-report-2"},
+	}
+	m := NewROTManager(rots)
+	opts := ReportOpts{EnableRuntimeGPUAttestation: true}
+	nonce := []byte("nonce")
+
+	const numGoroutines = 10
+	errCh := make(chan error, numGoroutines)
+
+	for i := 0; i < numGoroutines; i++ {
+		go func() {
+			reports, err := m.AttestDeviceROTs(nonce, opts)
+			if err != nil {
+				errCh <- err
+				return
+			}
+			if len(reports) != 2 {
+				errCh <- errors.New("unexpected number of reports")
+				return
+			}
+			errCh <- nil
+		}()
+	}
+
+	for i := 0; i < numGoroutines; i++ {
+		if err := <-errCh; err != nil {
+			t.Errorf("Race test failure: %v", err)
+		}
+	}
+}

--- a/launcher/internal/gpu/attestation.go
+++ b/launcher/internal/gpu/attestation.go
@@ -11,6 +11,7 @@ import (
 	"github.com/confidentsecurity/go-nvtrust/pkg/gonvtrust/gpu"
 
 	attestationpb "github.com/GoogleCloudPlatform/confidential-space/server/proto/gen/attestation"
+	"github.com/google/go-tpm-tools/launcher/device"
 	"github.com/google/go-tpm-tools/proto/attest"
 )
 
@@ -30,7 +31,7 @@ var getGpuTypeInfo = deviceinfo.GetGPUTypeInfo
 
 // Attester defines the interface for GPU attestation.
 type Attester interface {
-	Attest(nonce []byte) (any, error)
+	device.ROT
 	EnableReadyState() error
 }
 
@@ -55,6 +56,11 @@ func (a *NvidiaAttester) Attest(nonce []byte) (any, error) {
 		return nil, err
 	}
 	return gpuAttestation, nil
+}
+
+// Vendor returns the device ROT vendor type.
+func (a *NvidiaAttester) Vendor() device.Vendor {
+	return device.NvidiaGPU
 }
 
 // EnableReadyState checks the Confidential Computing mode and transitions the GPU to a READY state if CC is enabled.

--- a/launcher/teeserver/tee_server.go
+++ b/launcher/teeserver/tee_server.go
@@ -14,6 +14,7 @@ import (
 	keymanager "github.com/google/go-tpm-tools/keymanager/km_common/proto"
 	wsd "github.com/google/go-tpm-tools/keymanager/workload_service"
 	"github.com/google/go-tpm-tools/launcher/agent"
+	"github.com/google/go-tpm-tools/launcher/device"
 	"github.com/google/go-tpm-tools/launcher/internal/logging"
 	"github.com/google/go-tpm-tools/launcher/spec"
 	"github.com/google/go-tpm-tools/verifier"
@@ -177,7 +178,7 @@ func (a *attestHandler) getAttestationEvidence(w http.ResponseWriter, r *http.Re
 
 	fields := r.URL.Query().Get("fields")
 	attestOpts := agent.AttestAgentOpts{
-		DeviceReportOpts: &agent.DeviceReportOpts{
+		DeviceReportOpts: device.ReportOpts{
 			EnableRuntimeGPUAttestation: fields == "*" || strings.Contains(fields, "deviceReports"),
 		},
 	}

--- a/launcher/teeserver/tee_server_test.go
+++ b/launcher/teeserver/tee_server_test.go
@@ -65,7 +65,7 @@ func (f fakeAttestationAgent) AttestationEvidence(c context.Context, nonce []byt
 	if err != nil {
 		return nil, err
 	}
-	if opts.DeviceReportOpts != nil && opts.DeviceReportOpts.EnableRuntimeGPUAttestation {
+	if opts.DeviceReportOpts.EnableRuntimeGPUAttestation {
 		attestation.DeviceReports = append(attestation.DeviceReports, &attestationpb.DeviceAttestationReport{
 			Report: &attestationpb.DeviceAttestationReport_NvidiaReport{
 				NvidiaReport: &attestationpb.NvidiaAttestationReport{},


### PR DESCRIPTION
This PR introduces a new `DeviceROTManager` to the attestation agent, enabling the collection of attestation reports from attached hardware devices. This is a foundational change to support multi-device attestation, starting with initial support for Nvidia GPU attestation reports.

Some improvements have been made to avoid wasteful GPU attestation report call if `EnableRuntimeGPUAttestation` is disabled.