### PR TITLE
[KeyManager] Cleanup expired keys from kemToBindingMap twice daily

### DIFF
--- a/keymanager/workload_service/server.go
+++ b/keymanager/workload_service/server.go
@@ -169,8 +169,10 @@ type Server struct {
 
 	claimsChan chan *ClaimsCall
 
-	httpServer *http.Server
-	listener   net.Listener
+	httpServer      *http.Server
+	listener        net.Listener
+	stopCleanup     chan struct{}
+	stopCleanupOnce sync.Once
 	// todo: add logging mechanism here
 }
 
@@ -181,6 +183,11 @@ var (
 	// ClaimsRequestTimeout is the maximum time to wait for enqueuing the request to
 	// claims channel for getting the key claims.
 	ClaimsRequestTimeout = 5 * time.Second
+	// CleanupInterval is the interval between expired key cleanup runs.
+	// Defaults to 12 hours (twice a day).
+	CleanupInterval = 12 * time.Hour
+	// cleanupPageSize is the number of keys to fetch per page during cleanup enumeration.
+	cleanupPageSize = 100
 )
 
 // New creates a new WSD Server listening on the given unix socket path.
@@ -196,6 +203,7 @@ func NewServer(keyProtectionService KeyProtectionService, workloadService Worklo
 		kemToBindingMap:      make(map[uuid.UUID]uuid.UUID),
 		mu:                   sync.RWMutex{},
 		claimsChan:           make(chan *ClaimsCall, 4),
+		stopCleanup:          make(chan struct{}),
 	}
 
 	mux := http.NewServeMux()
@@ -214,6 +222,7 @@ func NewServer(keyProtectionService KeyProtectionService, workloadService Worklo
 	s.listener = ln
 
 	go s.processClaims()
+	go s.cleanupLoop()
 
 	return s, nil
 }
@@ -225,6 +234,7 @@ func (s *Server) Serve() error {
 
 // Shutdown gracefully shuts down the server.
 func (s *Server) Shutdown(ctx context.Context) error {
+	s.stopCleanupOnce.Do(func() { close(s.stopCleanup) })
 	return s.httpServer.Shutdown(ctx)
 }
 
@@ -675,4 +685,51 @@ func (s *Server) GetKeyClaims(ctx context.Context, keyHandle string, keyType key
 	case <-time.After(ClaimsResponseTimeout):
 		return nil, fmt.Errorf("timed out waiting for processClaims to respond for key: %s", keyHandle)
 	}
+}
+
+// cleanupLoop periodically removes expired keys from kemToBindingMap.
+func (s *Server) cleanupLoop() {
+	ticker := time.NewTicker(CleanupInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ticker.C:
+			if err := s.cleanupExpiredKeys(); err != nil {
+				log.Printf("cleanupExpiredKeys: %v", err)
+			}
+		case <-s.stopCleanup:
+			return
+		}
+	}
+}
+
+// cleanupExpiredKeys enumerates active KEM keys from the Rust layer and removes
+// any kemToBindingMap entries whose KEM key is no longer active (expired).
+func (s *Server) cleanupExpiredKeys() error {
+	activeKeys := make(map[uuid.UUID]struct{})
+
+	offset := 0
+	for {
+		keys, hasMore, err := s.keyProtectionService.EnumerateKEMKeys(cleanupPageSize, offset)
+		if err != nil {
+			return fmt.Errorf("failed to enumerate KEM keys at offset %d: %w", offset, err)
+		}
+		for _, k := range keys {
+			activeKeys[k.ID] = struct{}{}
+		}
+		if !hasMore {
+			break
+		}
+		offset += len(keys)
+	}
+
+	s.mu.Lock()
+	for kemUUID := range s.kemToBindingMap {
+		if _, ok := activeKeys[kemUUID]; !ok {
+			delete(s.kemToBindingMap, kemUUID)
+		}
+	}
+	s.mu.Unlock()
+
+	return nil
 }

--- a/keymanager/workload_service/server_test.go
+++ b/keymanager/workload_service/server_test.go
@@ -30,6 +30,7 @@ func newTestServer(t *testing.T, kemGen kps.KeyProtectionService, bindingGen Wor
 		t.Fatalf("failed to create test server: %v", err)
 	}
 	t.Cleanup(func() {
+		srv.stopCleanupOnce.Do(func() { close(srv.stopCleanup) })
 		srv.listener.Close()
 		close(srv.claimsChan)
 	})
@@ -1455,4 +1456,121 @@ func TestGetClaimsFromChannel(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestCleanupExpiredKeys(t *testing.T) {
+	activeKEM := uuid.New()
+	expiredKEM := uuid.New()
+	activeBinding := uuid.New()
+	expiredBinding := uuid.New()
+
+	mockKPS := &mockKeyProtectionService{
+		enumeratedKeys: []kpskcc.KEMKeyInfo{
+			{ID: activeKEM},
+		},
+	}
+
+	srv := newTestServer(t, mockKPS, &mockWorkloadService{})
+
+	// Populate the map with both active and expired entries.
+	srv.mu.Lock()
+	srv.kemToBindingMap[activeKEM] = activeBinding
+	srv.kemToBindingMap[expiredKEM] = expiredBinding
+	srv.mu.Unlock()
+
+	if err := srv.cleanupExpiredKeys(); err != nil {
+		t.Fatalf("cleanupExpiredKeys() returned error: %v", err)
+	}
+
+	srv.mu.RLock()
+	defer srv.mu.RUnlock()
+
+	if _, ok := srv.kemToBindingMap[activeKEM]; !ok {
+		t.Error("active KEM key was incorrectly removed from kemToBindingMap")
+	}
+	if _, ok := srv.kemToBindingMap[expiredKEM]; ok {
+		t.Error("expired KEM key was not removed from kemToBindingMap")
+	}
+	if len(srv.kemToBindingMap) != 1 {
+		t.Errorf("expected 1 entry in kemToBindingMap, got %d", len(srv.kemToBindingMap))
+	}
+}
+
+func TestCleanupExpiredKeysEnumerateError(t *testing.T) {
+	mockKPS := &mockKeyProtectionService{
+		enumerateErr: fmt.Errorf("enumerate failed"),
+	}
+
+	srv := newTestServer(t, mockKPS, &mockWorkloadService{})
+
+	srv.mu.Lock()
+	srv.kemToBindingMap[uuid.New()] = uuid.New()
+	srv.mu.Unlock()
+
+	err := srv.cleanupExpiredKeys()
+	if err == nil {
+		t.Fatal("expected error from cleanupExpiredKeys, got nil")
+	}
+	if !strings.Contains(err.Error(), "enumerate failed") {
+		t.Errorf("unexpected error: %v", err)
+	}
+
+	// Map should be untouched on error.
+	srv.mu.RLock()
+	defer srv.mu.RUnlock()
+	if len(srv.kemToBindingMap) != 1 {
+		t.Errorf("expected map to be untouched on error, got %d entries", len(srv.kemToBindingMap))
+	}
+}
+
+func TestCleanupExpiredKeysEmptyMap(t *testing.T) {
+	mockKPS := &mockKeyProtectionService{}
+	srv := newTestServer(t, mockKPS, &mockWorkloadService{})
+
+	if err := srv.cleanupExpiredKeys(); err != nil {
+		t.Fatalf("cleanupExpiredKeys() on empty map returned error: %v", err)
+	}
+
+	srv.mu.RLock()
+	defer srv.mu.RUnlock()
+	if len(srv.kemToBindingMap) != 0 {
+		t.Errorf("expected empty map, got %d entries", len(srv.kemToBindingMap))
+	}
+}
+
+func TestCleanupExpiredKeysAllExpired(t *testing.T) {
+	// Enumerate returns no active keys.
+	mockKPS := &mockKeyProtectionService{
+		enumeratedKeys: []kpskcc.KEMKeyInfo{},
+	}
+
+	srv := newTestServer(t, mockKPS, &mockWorkloadService{})
+
+	srv.mu.Lock()
+	srv.kemToBindingMap[uuid.New()] = uuid.New()
+	srv.kemToBindingMap[uuid.New()] = uuid.New()
+	srv.kemToBindingMap[uuid.New()] = uuid.New()
+	srv.mu.Unlock()
+
+	if err := srv.cleanupExpiredKeys(); err != nil {
+		t.Fatalf("cleanupExpiredKeys() returned error: %v", err)
+	}
+
+	srv.mu.RLock()
+	defer srv.mu.RUnlock()
+	if len(srv.kemToBindingMap) != 0 {
+		t.Errorf("expected all entries removed, got %d", len(srv.kemToBindingMap))
+	}
+}
+
+func TestCleanupLoopStopsOnShutdown(t *testing.T) {
+	mockKPS := &mockKeyProtectionService{}
+	srv := newTestServer(t, mockKPS, &mockWorkloadService{})
+
+	// Signal the cleanup goroutine to exit via stopCleanupOnce.
+	srv.stopCleanupOnce.Do(func() { close(srv.stopCleanup) })
+
+	// Give the goroutine time to exit. If it doesn't stop, the test will
+	// hang (and eventually time out), which is the failure mode we're testing.
+	time.Sleep(50 * time.Millisecond)
 }


### PR DESCRIPTION
fixes: https://github.com/google/go-tpm-tools/issues/686

Add a background goroutine that periodically removes stale entries from kemToBindingMap by cross-referencing active KEM keys via EnumerateKEMKeys.
Expiration remains solely in the Rust layer; the Go layer only asks what is still alive. Runs every 12 hours and stops cleanly on server shutdown.