### PR TITLE
docs: add blank lines around code blocks in READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,21 +44,26 @@ tar xvf go-tpm-tools.tar.gz
 ./gotpm --help
 ```
 
+
 ### Building and Installing `gotpm`
 
 `gotpm` can be directly installed from this repo by running:
+
 ```bash
 go install github.com/google/go-tpm-tools/cmd/gotpm@latest
 # gotpm will be installed to $GOBIN
 gotpm --help
 ```
+
 Alternatively, to build `gotpm` from a cloned version of this repo, run:
+
 ```bash
 cd /my/path/to/cloned/go-tpm-tools/cmd/gotpm
 go build
 # gotpm will be in the cmd/gotpm subdirectory of the repo
 ./gotpm --help
 ```
+
 
 ## Minimum Required Go Version
 
@@ -67,12 +72,14 @@ This project currently requires Go 1.20 or newer. Any update to the minimum requ
 ## `openssl` errors when building `simulator`
 
 Similarly, when building the `simulator` library (or tests), you may get an error that looks like:
+
 ```
 fatal error: openssl/aes.h: No such file or directory
    47 | // #include <openssl/aes.h>
       |           ^~~~~~~~~~~~~~~~
 compilation terminated.
 ```
+
 This is because the `simulator` library depends on having the [OpenSSL](https://www.openssl.org/) headers installed. To fix this error, install the appropriate header package:
 
 ### Linux
@@ -86,19 +93,24 @@ sudo yum install openssl-devel
 sudo pacman -S openssl
 ```
 
+
 ### macOS
 
 First, install [Homebrew](https://brew.sh/). Then run:
+
 ```bash
 brew install openssl
 ```
 
+
 ### Windows
 
 First, install [Chocolatey](https://chocolatey.org/). Then run:
+
 ```bash
 choco install openssl
 ```
+
 
 ### Custom install location
 
@@ -110,6 +122,7 @@ point Go your installation. We will assume your installation is located at
 #### Add OpenSSL to the include and library path at the command line
 This solution does not require modifying go-tpm-tools code and is useful when
 working on other projects that depend on go-tpm-tools/simulator.
+
 ```
 C_INCLUDE_PATH="$OPENSSL_PATH/include" LIBRARY_PATH="$OPENSSL_PATH/lib" go test ...
 ```
@@ -121,10 +134,12 @@ and removes the need to provide the paths on the command line.
 Modify the `CFLAGS`/`LDFLAGS` options beginning with `#cgo darwin` or
 `#cgo windows` in `simulator/internal/internal.go` to point at your
 installation. This could look something like:
+
 ```diff
 // #cgo darwin CFLAGS: -I $OPENSSL_PATH/include
 // #cgo darwin LDFLAGS: -L $OPENSSL_PATH/lib
 ```
+
 Remember to revert your modifications to `simulator/internal/internal.go`
 before committing your changes.
 

--- a/proto/buf/validate/README.md
+++ b/proto/buf/validate/README.md
@@ -6,6 +6,7 @@ Because we use `protoc` instead of the `buf` CLI for protobuf generation, we mus
 
 ## How to update
 To update to a newer version of protovalidate, run:
+
 ```bash
 curl -sSL https://raw.githubusercontent.com/bufbuild/protovalidate/main/proto/protovalidate/buf/validate/validate.proto -o validate.proto
 ```

--- a/simulator/README.md
+++ b/simulator/README.md
@@ -24,10 +24,13 @@ To do this:
 1. Compile a test as a standalone binary. For example, if you were using a
   `go-tpm-tools/client` test (which all run against the simulator), compile
   the test binary named `client.test` by running:
+
     ```bash
     go test -c github.com/google/go-tpm-tools/client
     ```
+
 1. Now you can debug the binary using GDB:
+
     ```bash
     # Load the binary into GDB (fixing any errors/warnings you get)
     gdb ./client.test
@@ -65,6 +68,7 @@ is knowing where the headers are and what `#define` statements to use.
 For example, when using [VS Code](https://code.visualstudio.com/) with the
 [C/C++ extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools),
 add the following file to your workplace root at `.vscode/c_cpp_properties.json`:
+
 ```json
 {
     "configurations": [


### PR DESCRIPTION
Ensures blank lines exist before and after code blocks to improve rendering compatibility with various markdown renderers.