### PR TITLE
Update ci.yml to show line number for failure in go linter job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -152,6 +152,7 @@ jobs:
             -E revive
             -E gofmt
             -E goimports
+            --out-format=colored-line-number
             --exclude-use-default=false
             --max-same-issues=0
             --max-issues-per-linter=0


### PR DESCRIPTION
Updated go linter job to show line number where linter failed.