### PR TITLE
Generate SHA384 ref values as part of image build

### DIFF
--- a/launcher/cloudbuild.yaml
+++ b/launcher/cloudbuild.yaml
@@ -523,7 +523,7 @@ steps:
           '--image=${_OUTPUT_IMAGE_PREFIX}-vg-debug-${_OUTPUT_IMAGE_SUFFIX}',
           '--project=${PROJECT_ID}']
 
-- name: 'us-docker.pkg.dev/confidential-space-images-dev/cs-tools/measure@sha256:b82c8ca459b863cfdf9faf8e4c06d506a50f3fe86ca1f3756ca6fee42a5cd7f4'
+- name: 'us-docker.pkg.dev/confidential-space-images-dev/cs-tools/measure@sha256:5dec9806530d3aaad4d6a03bed7f1ccd6433188e158cc5c60367c31efd4feaf7'
   id: MeasureVgHardenedImage
   waitFor: ['ExportVgHardenedImage']
   env:
@@ -536,11 +536,14 @@ steps:
     mkdir vghardeneddisk
     tar xzf ${OUTPUT_IMAGE_NAME}.tar.gz -C vghardeneddisk/
     echo "measuring image ${OUTPUT_IMAGE_NAME}"
-    /usr/local/bin/measure.sh vghardeneddisk/disk.raw measure_output_vg_hardened.json hardened x86_64
-    cat measure_output_hardened.json
-    gcloud storage cp measure_output_vg_hardened.json gs://${PROJECT_ID}-rims/${OUTPUT_IMAGE_NAME}.json
+    /usr/local/bin/measure.sh vghardeneddisk/disk.raw measure_output_vg_hardened.json hardened x86_64 sha256
+    /usr/local/bin/measure.sh vghardeneddisk/disk.raw measure_output_vg_hardened_sha384.json hardened x86_64 sha384
 
-- name: 'us-docker.pkg.dev/confidential-space-images-dev/cs-tools/measure@sha256:b82c8ca459b863cfdf9faf8e4c06d506a50f3fe86ca1f3756ca6fee42a5cd7f4'
+    gcloud storage cp measure_output_vg_hardened.json gs://${PROJECT_ID}-rims/${OUTPUT_IMAGE_NAME}.json
+    gcloud storage cp measure_output_vg_hardened_sha384.json gs://${PROJECT_ID}-rims/${OUTPUT_IMAGE_NAME}_sha384.json
+
+
+- name: 'us-docker.pkg.dev/confidential-space-images-dev/cs-tools/measure@sha256:5dec9806530d3aaad4d6a03bed7f1ccd6433188e158cc5c60367c31efd4feaf7'
   id: MeasureVgDebugImage
   waitFor: ['ExportVgDebugImage']
   env:
@@ -553,9 +556,12 @@ steps:
     mkdir vgdebugdisk
     tar xzf ${OUTPUT_IMAGE_NAME}.tar.gz -C vgdebugdisk/
     echo "measuring image ${OUTPUT_IMAGE_NAME}"
-    /usr/local/bin/measure.sh vgdebugdisk/disk.raw measure_output_vg_debug.json debug x86_64
-    cat measure_output_debug.json
+    /usr/local/bin/measure.sh vgdebugdisk/disk.raw measure_output_vg_debug.json debug x86_64 sha256
+    /usr/local/bin/measure.sh vgdebugdisk/disk.raw measure_output_vg_debug_sha384.json debug x86_64 sha384
+
     gsutil cp measure_output_vg_debug.json gs://${PROJECT_ID}-rims/${OUTPUT_IMAGE_NAME}.json
+    gsutil cp measure_output_vg_debug_sha384.json gs://${PROJECT_ID}-rims/${OUTPUT_IMAGE_NAME}_sha384.json
+
 
 options:
   pool:


### PR DESCRIPTION
https://pantheon.corp.google.com/storage/browser/_details/confidential-space-images-dev-rims/confidential-space-vg-hardened-0-presubmit-59e28f9.json

https://pantheon.corp.google.com/storage/browser/_details/confidential-space-images-dev-rims/confidential-space-vg-hardened-0-presubmit-59e28f9_sha384.json

https://pantheon.corp.google.com/storage/browser/_details/confidential-space-images-dev-rims/confidential-space-vg-debug-0-presubmit-59e28f9.json

https://pantheon.corp.google.com/storage/browser/_details/confidential-space-images-dev-rims/confidential-space-vg-debug-0-presubmit-59e28f9_sha384.json