### PR TITLE
[launcher] cache gpu driver installer files

### DIFF
--- a/launcher/cloudbuild.yaml
+++ b/launcher/cloudbuild.yaml
@@ -1,5 +1,5 @@
 substitutions:
-  '_BASE_IMAGE': '' # If left empty, will use the latest image in _BASE_IMAGE_FAMILY of _BASE_IMAGE_PROJECT
+  '_BASE_IMAGE': 'cos-125-19216-220-180' # If left empty, will use the latest image in _BASE_IMAGE_FAMILY of _BASE_IMAGE_PROJECT
   '_BASE_IMAGE_FAMILY': 'cos-125-lts'
   '_BASE_IMAGE_PROJECT': 'cos-cloud'
   '_OUTPUT_IMAGE_PREFIX': 'confidential-space'
@@ -81,8 +81,17 @@ steps:
           './launcher/image/confidential_space_experiments']
 
 - name: 'gcr.io/cloud-builders/gcloud'
+  id: DownloadGpuDrivers
+  entrypoint: 'gcloud'
+  args: ['storage', 'cp',
+          'gs://cos-nvidia-gpu-drivers/NVIDIA-Linux-x86_64-595.58.03.run',
+          'gs://cos-tools/19216.220.180/lakitu/gpu_driver_versions.bin',
+          'gs://cos-tools/19216.220.180/lakitu/nvidia-drivers-595.58.03.tgz',
+          './launcher/image/']
+
+- name: 'gcr.io/cloud-builders/gcloud'
   id: DebugVgImageBuild
-  waitFor: ['BaseImageIdent', 'LauncherCompile', 'DownloadExpBinary']
+  waitFor: ['BaseImageIdent', 'LauncherCompile', 'DownloadExpBinary', 'DownloadGpuDrivers']
   env:
   - 'OUTPUT_IMAGE_NAME=${_OUTPUT_IMAGE_PREFIX}-vg-debug-${_OUTPUT_IMAGE_SUFFIX}'
   - 'OUTPUT_IMAGE_FAMILY=${_OUTPUT_IMAGE_FAMILY}-vg'
@@ -109,7 +118,7 @@ steps:
 
 - name: 'gcr.io/cloud-builders/gcloud'
   id: HardenedVgImageBuild
-  waitFor: ['BaseImageIdent', 'LauncherCompile', 'DownloadExpBinary']
+  waitFor: ['BaseImageIdent', 'LauncherCompile', 'DownloadExpBinary', 'DownloadGpuDrivers']
   env:
   - 'OUTPUT_IMAGE_NAME=${_OUTPUT_IMAGE_PREFIX}-vg-hardened-${_OUTPUT_IMAGE_SUFFIX}'
   - 'OUTPUT_IMAGE_FAMILY=${_OUTPUT_IMAGE_FAMILY}-vg'
@@ -137,7 +146,7 @@ steps:
 
 - name: 'gcr.io/cloud-builders/gcloud'
   id: DebugImageBuild
-  waitFor: ['BaseImageIdent', 'LauncherCompile', 'DownloadExpBinary']
+  waitFor: ['BaseImageIdent', 'LauncherCompile', 'DownloadExpBinary', 'DownloadGpuDrivers']
   env:
   - 'OUTPUT_IMAGE_NAME=${_OUTPUT_IMAGE_PREFIX}-debug-${_OUTPUT_IMAGE_SUFFIX}'
   - 'OUTPUT_IMAGE_FAMILY=${_OUTPUT_IMAGE_FAMILY}'
@@ -164,7 +173,7 @@ steps:
 
 - name: 'gcr.io/cloud-builders/gcloud'
   id: HardenedImageBuild
-  waitFor: ['BaseImageIdent', 'LauncherCompile', 'DownloadExpBinary']
+  waitFor: ['BaseImageIdent', 'LauncherCompile', 'DownloadExpBinary', 'DownloadGpuDrivers']
   env:
   - 'OUTPUT_IMAGE_NAME=${_OUTPUT_IMAGE_PREFIX}-hardened-${_OUTPUT_IMAGE_SUFFIX}'
   - 'OUTPUT_IMAGE_FAMILY=${_OUTPUT_IMAGE_FAMILY}'

--- a/launcher/image/cloudbuild.yaml
+++ b/launcher/image/cloudbuild.yaml
@@ -27,8 +27,8 @@ steps:
            '-script=fixup_oem.sh']
   - name: 'gcr.io/cos-cloud/cos-customizer'
     args: ['finish-image-build',
-           '-oem-size=500M',
-           '-disk-size-gb=11',
+           '-oem-size=900M',
+           '-disk-size-gb=12',
            '-image-name=${_OUTPUT_IMAGE_NAME}',
            '-image-family=${_OUTPUT_IMAGE_FAMILY}',
            '-image-project=${PROJECT_ID}',

--- a/launcher/image/preload.sh
+++ b/launcher/image/preload.sh
@@ -8,6 +8,13 @@ copy_launcher() {
   cp launcher "${CS_PATH}/cs_container_launcher"
 }
 
+copy_gpu_driver() {
+  mkdir ${OEM_PATH}/gpu_driver
+  cp NVIDIA-Linux-x86_64-595.58.03.run ${OEM_PATH}/gpu_driver
+  cp gpu_driver_versions.bin ${OEM_PATH}/gpu_driver
+  cp nvidia-drivers-595.58.03.tgz ${OEM_PATH}/gpu_driver
+}
+
 copy_experiment_client() {
   # DownloadExpBinary creates the file at EXPERIMENTS_BINARY.
   cp $EXPERIMENTS_BINARY "${CS_PATH}/${EXPERIMENTS_BINARY}"
@@ -109,6 +116,7 @@ main() {
   mount -o remount,rw ${OEM_PATH}
   mkdir ${CS_PATH}
 
+  copy_gpu_driver
   # Install container launcher entrypoint.
   configure_entrypoint "entrypoint.sh"
   # Install experiment client.

--- a/launcher/image/test/create_vm.sh
+++ b/launcher/image/test/create_vm.sh
@@ -58,7 +58,7 @@ create_vm() {
   gcloud auth list
 
   # Max disk for n2d-standard-2 (8GB memory) at 1% memory overhead.
-  MIN_DISK_SIZE=11
+  MIN_DISK_SIZE=12
   MAX_DISK_SIZE_GB=80
   ADDTL_DISK_RANGE=$(($MAX_DISK_SIZE_GB - $MIN_DISK_SIZE + 1))
   DISK_SIZE_GB=$(($MIN_DISK_SIZE + ($RANDOM % $ADDTL_DISK_RANGE)))

--- a/launcher/image/vgpreload.sh
+++ b/launcher/image/vgpreload.sh
@@ -7,6 +7,13 @@ copy_launcher() {
   cp launcher "${CS_PATH}/cs_container_launcher"
 }
 
+copy_gpu_driver() {
+  mkdir ${OEM_PATH}/gpu_driver
+  cp NVIDIA-Linux-x86_64-595.58.03.run ${OEM_PATH}/gpu_driver
+  cp gpu_driver_versions.bin ${OEM_PATH}/gpu_driver
+  cp nvidia-drivers-595.58.03.tgz ${OEM_PATH}/gpu_driver
+}
+
 copy_experiment_file() {
   cp vgexperiment.json ${CS_PATH}/vgexperiment.json
 }
@@ -106,6 +113,7 @@ main() {
   mount -o remount,rw ${OEM_PATH}
   mkdir ${CS_PATH}
 
+  copy_gpu_driver
   # Install container launcher entrypoint.
   configure_entrypoint "vgentrypoint.sh"
   # Copy experiment file.

--- a/launcher/internal/gpu/config.go
+++ b/launcher/internal/gpu/config.go
@@ -11,9 +11,6 @@ const (
 	InstallerDigest = "sha256:31f36d9ba262d7181c624fdeaab4b2148d6e0f8101671e583efe153792116b8d"
 	// NvDriverVer590_48_01 is the version string for the driver
 	NvDriverVer590_48_01 = "590.48.01"
-	// NvDriverVer590_48_01Digest is driver run file digest downloaded from
-	// cos-nvidia-gpu-drivers/sha256/NVIDIA-Linux-x86_64-590.48.01.run.sha256
-	NvDriverVer590_48_01Digest = "b9e2f80693781431cc87f4cd29109e133dcecb50a50d6b68d4b3bf2d696bd689"
-	// NvDriverVer590_48_01Runfile is the driver run file name
-	NvDriverVer590_48_01Runfile = "NVIDIA-Linux-x86_64-590.48.01.run"
+	// NvDriverVer595_58_03 is the version string for the driver
+	NvDriverVer595_58_03 = "595.58.03"
 )

--- a/launcher/internal/gpu/driverinstaller.go
+++ b/launcher/internal/gpu/driverinstaller.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
-	"path"
 	"strings"
 
 	"cos.googlesource.com/cos/tools.git/src/cmd/cos_gpu_installer/deviceinfo"
@@ -109,7 +108,8 @@ func (di *DriverInstaller) InstallGPUDrivers(ctx context.Context) error {
 			// It would not be possible to start the nvidia-persistenced process amidst GPU driver installation flow via cos_gpu_installer.
 			// For this reason, the GPU driver installation need to be triggered with --skip-nvidia-smi flag to skip the GPU driver verification step.
 			oci.WithProcessArgs("/cos-gpu-installer", "install",
-				fmt.Sprintf("-version=%s", NvDriverVer590_48_01),
+				fmt.Sprintf("-version=%s", NvDriverVer595_58_03),
+				fmt.Sprintf("-local-artifacts-dir=%s", "/root/usr/share/oem/gpu_driver/"),
 				fmt.Sprintf("-host-dir=%s", InstallationHostDir),
 				"--no-verify"),
 			oci.WithAllDevicesAllowed,
@@ -146,10 +146,6 @@ func (di *DriverInstaller) InstallGPUDrivers(ctx context.Context) error {
 	if code != 0 {
 		di.logger.Error(fmt.Sprintf("GPU driver installation task ended and returned non-zero status code %d", code))
 		return fmt.Errorf("GPU driver installation task ended with non-zero status code %d", code)
-	}
-
-	if err = verifyDriverDigest(path.Join(InstallationHostDir, NvDriverVer590_48_01Runfile), NvDriverVer590_48_01Digest); err != nil {
-		return fmt.Errorf("failed to verify GPU driver digest: %v", err)
 	}
 
 	cmds := [][]string{


### PR DESCRIPTION
cache the driver files so no need to download at run time.

From now on we need to manually update the base image and gpu driver version.