### PR TITLE
Add SHA384 support for uki image EFI Authenticode hash

### DIFF
--- a/launcher/image/measure/measure.sh
+++ b/launcher/image/measure/measure.sh
@@ -94,6 +94,7 @@ extract_partition_12() {
 #
 extract_boot_components() {
     local arch="$1"
+    local image_mode="$2"
     local shim_path=""
 
     if [ "$arch" == "x86_64" ]; then
@@ -108,15 +109,17 @@ extract_boot_components() {
     echo "Copying files from partition image '$P12_FILE'..."
 
     declare -A files_to_copy=(
-        ["::/syslinux/vmlinuz.A"]="$VMLINUZ_A_FILE"
-        ["::/efi/boot/grub.cfg"]="$GRUB_CFG_FILE"
         ["$shim_path"]="$BOOT_EFI_FILE"
-        ["::/efi/boot/grub-lakitu.efi"]="$GRUB_EFI_FILE"
     )
 
-    # vmlinuz.B file exists on amd64 but not on arm64
-    if [ "$arch" == "x86_64" ]; then
-        files_to_copy["::/syslinux/vmlinuz.B"]="$VMLINUZ_B_FILE"
+    if [ "$image_mode" == "default" ]; then
+        files_to_copy["::/syslinux/vmlinuz.A"]="$VMLINUZ_A_FILE"
+        files_to_copy["::/efi/boot/grub.cfg"]="$GRUB_CFG_FILE"
+        files_to_copy["::/efi/boot/grub-lakitu.efi"]="$GRUB_EFI_FILE"
+        # vmlinuz.B file exists on amd64 but not on arm64
+        if [ "$arch" == "x86_64" ]; then
+            files_to_copy["::/syslinux/vmlinuz.B"]="$VMLINUZ_B_FILE"
+        fi
     fi
 
     for src in "${!files_to_copy[@]}"; do
@@ -206,6 +209,133 @@ print(''.join(f'{b:02x}' for b in digest))
 }
 
 ##
+# Computes the PE/COFF Authenticode hash of an EFI binary by parsing the
+# image directly, mirroring sbsigntools' image_pecoff_parse / image_find_regions.
+# This function walks the PE headers, skips the CheckSum and Certificate Table
+# data-directory entry, hashes sections in section-table order, appends any
+# endjunk, and zero-extends the buffer to an 8-byte alignment when required,
+# matching the on-disk bytes signed by sbsign.
+# @param $1: Path to the EFI file.
+# @return The hash string to stdout.
+#
+compute_efi_authenticode_hash() {
+    local efi_file="$1"
+    python3 - "$efi_file" "$HASH_ALG" <<'PY'
+import hashlib, struct, sys
+path, alg = sys.argv[1], sys.argv[2]
+with open(path, "rb") as f:
+    d = bytearray(f.read())
+
+def parse_and_find_regions(d):
+    # DOS header sanity (mirrors sbsigntools image_pecoff_parse).
+    if len(d) < 0x40:
+        sys.stderr.write("file is too small for DOS header\n"); sys.exit(1)
+    if d[0:2] != b"MZ":
+        sys.stderr.write("Invalid DOS header magic\n"); sys.exit(1)
+
+    e_lfanew = struct.unpack_from("<I", d, 0x3C)[0]
+    if e_lfanew >= len(d):
+        sys.stderr.write("pehdr is beyond end of file [0x%08x]\n" % e_lfanew); sys.exit(1)
+    # PE header is nt_signature(4) + COFF file header(20) = 24 bytes.
+    if e_lfanew + 24 > len(d):
+        sys.stderr.write("File not large enough to contain pehdr\n"); sys.exit(1)
+    if d[e_lfanew:e_lfanew+4] != b"PE\0\0":
+        sys.stderr.write("Invalid PE header signature\n"); sys.exit(1)
+
+    coff = e_lfanew + 4
+    nsec = struct.unpack_from("<H", d, coff + 2)[0]
+    size_opt = struct.unpack_from("<H", d, coff + 16)[0]
+    opt = coff + 20
+    if opt + size_opt > len(d):
+        sys.stderr.write("file is too small for a.out header\n"); sys.exit(1)
+    magic = struct.unpack_from("<H", d, opt)[0]
+    if magic not in (0x10b, 0x20b):
+        sys.stderr.write("Invalid PE optional header magic 0x%x\n" % magic); sys.exit(1)
+    sec_tbl = opt + size_opt
+    cksum_off = opt + 64
+    certdir = opt + (128 if magic == 0x10b else 144)
+    # opthdr must be large enough to contain the cert data directory entry.
+    cert_dir_end = (certdir - opt) + 8
+    if size_opt < cert_dir_end:
+        sys.stderr.write(
+            "PE opt header too small (%d bytes) to contain a suitable data directory (need %d bytes)\n"
+            % (size_opt, cert_dir_end)); sys.exit(1)
+    size_hdrs = struct.unpack_from("<I", d, opt + 60)[0]
+    cert_va, cert_table_size = struct.unpack_from("<II", d, certdir)
+
+    # Build the same hash regions sbsigntools' image_find_regions builds, and
+    # carry a cumulative byte counter (sbsigntools' `bytes`) the same way.
+    regions = []
+    # Region 0: begin -> CheckSum
+    regions.append((0, cksum_off))
+    bytes_total = cksum_off
+    bytes_total += 4  # skipped 4-byte CheckSum
+    # Region 1: CheckSum+4 -> CertDirEntry
+    r1_start, r1_size = cksum_off + 4, certdir - (cksum_off + 4)
+    regions.append((r1_start, r1_size))
+    bytes_total += r1_size
+    bytes_total += 8  # skipped 8-byte cert data-dir entry
+    # Region 2: CertDirEntry+8 -> SizeOfHeaders
+    r2_start, r2_size = certdir + 8, size_hdrs - (certdir + 8)
+    regions.append((r2_start, r2_size))
+    bytes_total += r2_size
+
+    # Walk sections in section-table order (matches sbsigntools image_find_regions:
+    # the gap-warn fires against the previously-appended section, before the qsort).
+    prev_end, prev_name = size_hdrs, "headers"
+    for i in range(nsec):
+        sh = sec_tbl + i * 40
+        name = bytes(d[sh:sh+8]).rstrip(b"\0").decode("ascii", errors="replace")
+        sz  = struct.unpack_from("<I", d, sh + 16)[0]
+        ptr = struct.unpack_from("<I", d, sh + 20)[0]
+        if sz == 0:
+            continue
+        if ptr != prev_end:
+            sys.stderr.write(
+                "warning: gap in section table between %s and %s\n" % (prev_name, name))
+        regions.append((ptr, sz))
+        bytes_total += sz
+        prev_end, prev_name = ptr + sz, name
+
+    # Match sbsigntools image_find_regions: qsort all regions by file offset.
+    regions.sort()
+
+    # Endjunk: [buf+bytes_total .. size - cert_table_size]. Appended after the
+    # sort, mirroring sbsigntools (the endjunk region becomes the last region).
+    ej_start = bytes_total
+    ej_end = len(d) - cert_table_size
+    if ej_end > ej_start:
+        regions.append((ej_start, ej_end - ej_start))
+        sys.stderr.write(
+            "warning: data remaining[%d vs %d]: gaps between PE/COFF sections?\n"
+            % (bytes_total + cert_table_size, len(d)))
+    elif ej_end < ej_start:
+        sys.stderr.write("warning: checksum areas are greater than image size\n")
+
+    # Tianocore multi-sign alignment: data_size = align_up(last_region_end, 8),
+    # matching sbsigntools image.c (`align_up((r->data - buf) + r->size, 8)`).
+    last_off, last_sz = regions[-1]
+    data_size = (last_off + last_sz + 7) & ~7
+    return regions, data_size
+
+# Mirror sbsigntools image_load: when data_size > image->size, zero-extend the
+# buffer up to data_size and re-run the parse. The pad bytes then fold into
+# the endjunk region naturally on the next pass.
+while True:
+    regions, data_size = parse_and_find_regions(d)
+    if data_size > len(d):
+        d.extend(b"\0" * (data_size - len(d)))
+        continue
+    break
+
+h = hashlib.new(alg)
+for off, sz in regions:
+    h.update(bytes(d[off:off+sz]))
+print(h.hexdigest())
+PY
+}
+
+##
 # Writes the collected hashes to a final JSON file.
 # @param $1: Output JSON file path.
 # @param $2: Channel name.
@@ -234,9 +364,12 @@ write_json_output() {
 		--arg cmd_b "${10}" \
 		--arg pe_a "${11}" \
 		--arg pe_b "${12}" \
+		--arg img_type "${13}" \
+		--arg uki_efi "${14}" \
 		'{
 			channel: $chan,
 			alg: $alg,
+			image_type: $img_type,
 			shim: $shim,
 			grub: $grub,
 			vmlinuz_a: $vml_a,
@@ -246,7 +379,8 @@ write_json_output() {
 			kernel_cmdline_a: $cmd_a,
 			kernel_cmdline_b: $cmd_b,
 			vmlinuz_a_pe: $pe_a,
-			vmlinuz_b_pe: $pe_b
+			vmlinuz_b_pe: $pe_b,
+			uki_efi: $uki_efi
 		}' > "$output_json_file"
 
 		if [[ $? -ne 0 || ! -s "$output_json_file" ]]; then
@@ -259,9 +393,10 @@ write_json_output() {
 
 main() {
     # 1. Parameter Handling & Initial Checks
-    if [[ "$#" -ne 5 ]]; then
-        echo "Usage: $0 <os_image_path> <output_json_file> <channel> <build_architecture> <hash_algo:sha256|sha384>"
-        echo "Example: $0 /path/to/image.bin /path/to/output.json stable x86_64"
+    if [[ "$#" -lt 5 || "$#" -gt 6 ]]; then
+        echo "Usage: $0 <os_image_path> <output_json_file> <channel> <build_architecture> <hash_algo:sha256|sha384> [image_mode:default|uki]"
+        echo "Example: $0 /path/to/image.bin /path/to/output.json stable x86_64 sha384"
+        echo "Example: $0 /path/to/image.bin /path/to/output.json hardened x86_64 sha384 uki"
         return 1
     fi
     local os_image_path="$1"
@@ -269,6 +404,7 @@ main() {
     local channel="$3"
     local arch="$4"
     HASH_ALG="$5"
+    local image_mode="${6:-default}"
 
     if [[ ! -f "$os_image_path" ]]; then
         echo "Error: OS image path '$os_image_path' not found."
@@ -281,45 +417,59 @@ main() {
         *) echo "Error: Unsupported hash algorithm '$HASH_ALG'. Use sha256 or sha384."; return 1 ;;
     esac
 
+    case "$image_mode" in
+        default|uki) ;;
+        *) echo "Error: Unsupported image mode '$image_mode'. Use 'default' or 'uki'."; return 1 ;;
+    esac
+
     check_dependencies || return 1
 
     # 2. Setup and Extraction
     setup_temp_dir
     extract_partition_12 "$os_image_path" || return 1
-    extract_boot_components "$arch" || return 1
+    extract_boot_components "$arch" "$image_mode" || return 1
 
     # 3. Compute All Hashes
-    echo "Computing all required hashes using $HASH_ALG..."
-    local vmlinuz_a_hash vmlinuz_b_hash="" kernel_cmdline_a_hash kernel_cmdline_b_hash shim_hash grub_hash vmlinuz_a_pe_hash vmlinuz_b_pe_hash=""
+    echo "Computing all required hashes using $HASH_ALG (image_mode=$image_mode)..."
+    local vmlinuz_a_hash="" vmlinuz_b_hash="" kernel_cmdline_a="" kernel_cmdline_b=""
+    local kernel_cmdline_a_hash="" kernel_cmdline_b_hash=""
+    local shim_hash="" grub_hash="" vmlinuz_a_pe_hash="" vmlinuz_b_pe_hash=""
+    local uki_efi_hash=""
 
-    vmlinuz_a_hash=$(compute_file_hash "$VMLINUZ_A_FILE")
-    vmlinuz_a_pe_hash=$(compute_efi_hash "$VMLINUZ_A_FILE")
-    if [ "$arch" == "x86_64" ]; then
-        vmlinuz_b_hash=$(compute_file_hash "$VMLINUZ_B_FILE")
-        vmlinuz_b_pe_hash=$(compute_efi_hash "$VMLINUZ_B_FILE")
+    if [ "$image_mode" == "uki" ]; then
+        uki_efi_hash=$(compute_efi_authenticode_hash "$BOOT_EFI_FILE") || return 1
+        echo "UKI bootx64.efi/bootaa64.efi hash: $uki_efi_hash"
+    else
+        vmlinuz_a_hash=$(compute_file_hash "$VMLINUZ_A_FILE")
+        vmlinuz_a_pe_hash=$(compute_efi_hash "$VMLINUZ_A_FILE")
+        if [ "$arch" == "x86_64" ]; then
+            vmlinuz_b_hash=$(compute_file_hash "$VMLINUZ_B_FILE")
+            vmlinuz_b_pe_hash=$(compute_efi_hash "$VMLINUZ_B_FILE")
+        fi
+        kernel_cmdline_a=$(compute_cmdline "$GRUB_CFG_FILE" "A")
+        kernel_cmdline_b=$(compute_cmdline "$GRUB_CFG_FILE" "B")
+        kernel_cmdline_a_hash=$(compute_cmdline_hash "$GRUB_CFG_FILE" "A")
+        kernel_cmdline_b_hash=$(compute_cmdline_hash "$GRUB_CFG_FILE" "B")
+        shim_hash=$(compute_efi_hash "$BOOT_EFI_FILE") || return 1
+        grub_hash=$(compute_efi_hash "$GRUB_EFI_FILE") || return 1
+
+        echo "Kernel (vmlinuz.A) hash: $vmlinuz_a_hash"
+        echo "Kernel (vmlinuz.B) hash: $vmlinuz_b_hash"
+        echo "Kernel (vmlinuz.A) PE hash: $vmlinuz_a_pe_hash"
+        echo "Kernel (vmlinuz.B) PE hash: $vmlinuz_b_pe_hash"
+        echo "Kernel cmdline (image A): $kernel_cmdline_a"
+        echo "Kernel cmdline (image B): $kernel_cmdline_b"
+        echo "Kernel cmdline (image A) hash: $kernel_cmdline_a_hash"
+        echo "Kernel cmdline (image B) hash: $kernel_cmdline_b_hash"
+        echo "bootx64.efi/bootaa64.efi (shim) hash: $shim_hash"
+        echo "grub-lakitu.efi (grub) hash: $grub_hash"
     fi
-    kernel_cmdline_a=$(compute_cmdline "$GRUB_CFG_FILE" "A")
-    kernel_cmdline_b=$(compute_cmdline "$GRUB_CFG_FILE" "B")
-    kernel_cmdline_a_hash=$(compute_cmdline_hash "$GRUB_CFG_FILE" "A")
-    kernel_cmdline_b_hash=$(compute_cmdline_hash "$GRUB_CFG_FILE" "B")
-    shim_hash=$(compute_efi_hash "$BOOT_EFI_FILE") || return 1
-    grub_hash=$(compute_efi_hash "$GRUB_EFI_FILE") || return 1
-
-    echo "Kernel (vmlinuz.A) hash: $vmlinuz_a_hash"
-    echo "Kernel (vmlinuz.B) hash: $vmlinuz_b_hash"
-    echo "Kernel (vmlinuz.A) PE hash: $vmlinuz_a_pe_hash"
-    echo "Kernel (vmlinuz.B) PE hash: $vmlinuz_b_pe_hash"
-    echo "Kernel cmdline (image A): $kernel_cmdline_a"
-    echo "Kernel cmdline (image B): $kernel_cmdline_b"
-    echo "Kernel cmdline (image A) hash: $kernel_cmdline_a_hash"
-    echo "Kernel cmdline (image B) hash: $kernel_cmdline_b_hash"
-    echo "bootx64.efi/bootaa64.efi (shim) hash: $shim_hash"
-    echo "grub-lakitu.efi (grub) hash: $grub_hash"
 
     # 4. Final Output with escaped kernel command line strings
     write_json_output "$output_json_file" "$channel" "$shim_hash" "$grub_hash" \
         "$vmlinuz_a_hash" "$vmlinuz_b_hash" "$kernel_cmdline_a_hash" "$kernel_cmdline_b_hash" \
-        "$kernel_cmdline_a" "$kernel_cmdline_b" "$vmlinuz_a_pe_hash" "$vmlinuz_b_pe_hash" || return 1
+        "$kernel_cmdline_a" "$kernel_cmdline_b" "$vmlinuz_a_pe_hash" "$vmlinuz_b_pe_hash" \
+        "$image_mode" "$uki_efi_hash" || return 1
 
     echo "Measured boot hashes successfully written to '$output_json_file'."
 }

--- a/launcher/image/measure/measure.sh
+++ b/launcher/image/measure/measure.sh
@@ -36,7 +36,7 @@ trap cleanup EXIT
 check_dependencies() {
     echo "Checking for required command-line utilities..."
     local missing_cmds=0
-    for cmd in cgpt dd mcopy sha256sum sbattach openssl jq awk grep printf dirname mkdir; do
+    for cmd in cgpt dd mcopy mdir sha256sum sbattach openssl jq awk grep printf dirname mkdir; do
         if ! command -v "$cmd" &>/dev/null; then
             echo "Error: Required command '$cmd' is not installed." >&2
             missing_cmds=1
@@ -90,36 +90,68 @@ extract_partition_12() {
 }
 
 ##
+# Detects the image mode by inspecting the boot EFI binary itself.
+# `default` images boot via shim, whose PE binary carries a `.sbat` section
+# referencing https://github.com/rhboot/shim. `uki` images ship a UKI PE with
+# no such section. Falls back to `uki` whenever the binary is not a shim
+# (parse failure, missing `.sbat`, or `.sbat` without the rhboot URL).
+#
+# As a side effect, extracts the boot EFI to $BOOT_EFI_FILE so
+# extract_boot_components does not need to copy it again.
+#
+# @param $1: build architecture ('x86_64' or 'aarch64').
+# @return The detected mode ('default' or 'uki') to stdout.
+#
+detect_image_mode() {
+    local arch="$1"
+    local shim_src
+    case "$arch" in
+        x86_64)   shim_src="::/efi/boot/bootx64.efi" ;;
+        aarch64)  shim_src="::/efi/boot/bootaa64.efi" ;;
+        *) echo "Error: Unknown arch '$arch'." >&2; return 1 ;;
+    esac
+
+    if ! mcopy -i "$P12_FILE" "$shim_src" "$BOOT_EFI_FILE" &>/dev/null; then
+        echo "Error: Failed to extract '$shim_src' from '$P12_FILE'." >&2
+        return 1
+    fi
+
+    python3 - "$BOOT_EFI_FILE" <<'PY'
+import sys, lief
+b = lief.parse(sys.argv[1])
+if b is None:
+    print("uki"); sys.exit(0)
+sec = b.get_section(".sbat")
+if sec is None:
+    print("uki"); sys.exit(0)
+content = bytes(sec.content)
+print("default" if b"https://github.com/rhboot/shim" in content else "uki")
+PY
+}
+
+##
 # Copies boot-related files from the extracted partition image using mcopy.
 #
 extract_boot_components() {
     local arch="$1"
     local image_mode="$2"
-    local shim_path=""
 
-    if [ "$arch" == "x86_64" ]; then
-        shim_path="::/efi/boot/bootx64.efi"
-    elif [ "$arch" == "aarch64" ]; then
-        shim_path="::/efi/boot/bootaa64.efi"
-    else
-        echo "Error: Unknown arch '$arch'."
-        return 1
+    # The boot EFI (bootx64.efi/bootaa64.efi) is already extracted by
+    # detect_image_mode; only the default-mode extras remain to copy.
+    if [ "$image_mode" != "default" ]; then
+        return 0
     fi
 
     echo "Copying files from partition image '$P12_FILE'..."
 
     declare -A files_to_copy=(
-        ["$shim_path"]="$BOOT_EFI_FILE"
+        ["::/syslinux/vmlinuz.A"]="$VMLINUZ_A_FILE"
+        ["::/efi/boot/grub.cfg"]="$GRUB_CFG_FILE"
+        ["::/efi/boot/grub-lakitu.efi"]="$GRUB_EFI_FILE"
     )
-
-    if [ "$image_mode" == "default" ]; then
-        files_to_copy["::/syslinux/vmlinuz.A"]="$VMLINUZ_A_FILE"
-        files_to_copy["::/efi/boot/grub.cfg"]="$GRUB_CFG_FILE"
-        files_to_copy["::/efi/boot/grub-lakitu.efi"]="$GRUB_EFI_FILE"
-        # vmlinuz.B file exists on amd64 but not on arm64
-        if [ "$arch" == "x86_64" ]; then
-            files_to_copy["::/syslinux/vmlinuz.B"]="$VMLINUZ_B_FILE"
-        fi
+    # vmlinuz.B file exists on amd64 but not on arm64
+    if [ "$arch" == "x86_64" ]; then
+        files_to_copy["::/syslinux/vmlinuz.B"]="$VMLINUZ_B_FILE"
     fi
 
     for src in "${!files_to_copy[@]}"; do
@@ -393,10 +425,9 @@ write_json_output() {
 
 main() {
     # 1. Parameter Handling & Initial Checks
-    if [[ "$#" -lt 5 || "$#" -gt 6 ]]; then
-        echo "Usage: $0 <os_image_path> <output_json_file> <channel> <build_architecture> <hash_algo:sha256|sha384> [image_mode:default|uki]"
+    if [[ "$#" -ne 5 ]]; then
+        echo "Usage: $0 <os_image_path> <output_json_file> <channel> <build_architecture> <hash_algo:sha256|sha384>"
         echo "Example: $0 /path/to/image.bin /path/to/output.json stable x86_64 sha384"
-        echo "Example: $0 /path/to/image.bin /path/to/output.json hardened x86_64 sha384 uki"
         return 1
     fi
     local os_image_path="$1"
@@ -404,7 +435,6 @@ main() {
     local channel="$3"
     local arch="$4"
     HASH_ALG="$5"
-    local image_mode="${6:-default}"
 
     if [[ ! -f "$os_image_path" ]]; then
         echo "Error: OS image path '$os_image_path' not found."
@@ -417,16 +447,14 @@ main() {
         *) echo "Error: Unsupported hash algorithm '$HASH_ALG'. Use sha256 or sha384."; return 1 ;;
     esac
 
-    case "$image_mode" in
-        default|uki) ;;
-        *) echo "Error: Unsupported image mode '$image_mode'. Use 'default' or 'uki'."; return 1 ;;
-    esac
-
     check_dependencies || return 1
 
     # 2. Setup and Extraction
     setup_temp_dir
     extract_partition_12 "$os_image_path" || return 1
+    local image_mode
+    image_mode=$(detect_image_mode "$arch") || return 1
+    echo "Auto-detected image_mode=$image_mode"
     extract_boot_components "$arch" "$image_mode" || return 1
 
     # 3. Compute All Hashes

--- a/launcher/image/measure/measure.sh
+++ b/launcher/image/measure/measure.sh
@@ -36,7 +36,7 @@ trap cleanup EXIT
 check_dependencies() {
     echo "Checking for required command-line utilities..."
     local missing_cmds=0
-    for cmd in cgpt dd mcopy mdir sha256sum sbattach openssl jq awk grep printf dirname mkdir; do
+    for cmd in cgpt dd mcopy sha256sum sha384sum sbattach openssl jq awk grep printf dirname mkdir; do
         if ! command -v "$cmd" &>/dev/null; then
             echo "Error: Required command '$cmd' is not installed." >&2
             missing_cmds=1
@@ -90,12 +90,28 @@ extract_partition_12() {
 }
 
 ##
-# Detects the image mode by inspecting the boot EFI binary itself.
-# `default` images boot via shim, whose PE binary carries a `.sbat` section
-# referencing https://github.com/rhboot/shim. `uki` images ship a UKI PE with
-# no such section. Falls back to `uki` whenever the binary is not a shim
-# (parse failure, missing `.sbat`, or `.sbat` without the rhboot URL).
+# Extracts a file from $P12_FILE using mcopy with a consistent error message.
+# @param $1: source path inside the FAT (e.g. '::/efi/boot/bootx64.efi').
+# @param $2: destination path on local disk.
 #
+mcopy_from_p12() {
+    local src="$1" dst="$2"
+    if ! mcopy -i "$P12_FILE" "$src" "$dst"; then
+        echo "Error: Failed to mcopy '$src' from '$P12_FILE'." >&2
+        return 1
+    fi
+}
+
+##
+# Detects the image mode by inspecting the boot EFI binary.
+# Uses conservative auto-detection: positive evidence is required on both
+# sides, with a hard error on anything unrecognized.
+#   .sbat present AND content contains 'https://github.com/rhboot/shim'
+#       => 'default' (shim + grub + kernel layout)
+#   .setup present (x86/x86_64 cos EFI-stub image)
+#       => 'uki' (single-blob: bootx64.efi w/ EFI stub)
+#   otherwise => hard error, listing sections found.
+# `.setup` is specific to the x86/x86_64 cos EFI-stub layout.
 # As a side effect, extracts the boot EFI to $BOOT_EFI_FILE so
 # extract_boot_components does not need to copy it again.
 #
@@ -104,28 +120,64 @@ extract_partition_12() {
 #
 detect_image_mode() {
     local arch="$1"
-    local shim_src
+    local boot_src
     case "$arch" in
-        x86_64)   shim_src="::/efi/boot/bootx64.efi" ;;
-        aarch64)  shim_src="::/efi/boot/bootaa64.efi" ;;
+        x86_64)   boot_src="::/efi/boot/bootx64.efi" ;;
+        aarch64)  boot_src="::/efi/boot/bootaa64.efi" ;;
         *) echo "Error: Unknown arch '$arch'." >&2; return 1 ;;
     esac
 
-    if ! mcopy -i "$P12_FILE" "$shim_src" "$BOOT_EFI_FILE" &>/dev/null; then
-        echo "Error: Failed to extract '$shim_src' from '$P12_FILE'." >&2
-        return 1
-    fi
+    mcopy_from_p12 "$boot_src" "$BOOT_EFI_FILE" || return 1
 
     python3 - "$BOOT_EFI_FILE" <<'PY'
-import sys, lief
-b = lief.parse(sys.argv[1])
-if b is None:
-    print("uki"); sys.exit(0)
-sec = b.get_section(".sbat")
-if sec is None:
-    print("uki"); sys.exit(0)
-content = bytes(sec.content)
-print("default" if b"https://github.com/rhboot/shim" in content else "uki")
+import struct, sys
+path = sys.argv[1]
+with open(path, "rb") as f:
+    d = f.read()
+
+# Walk the PE headers directly with stdlib struct, read the section table from raw bytes.
+if len(d) < 0x40 or d[:2] != b"MZ":
+    sys.stderr.write("Error: '%s' is not a PE binary (bad DOS header)\n" % path)
+    sys.exit(1)
+e_lfanew = struct.unpack_from("<I", d, 0x3C)[0]
+if e_lfanew + 24 > len(d) or d[e_lfanew:e_lfanew+4] != b"PE\0\0":
+    sys.stderr.write("Error: '%s' has invalid PE signature\n" % path)
+    sys.exit(1)
+coff = e_lfanew + 4
+nsec = struct.unpack_from("<H", d, coff + 2)[0]
+size_opt = struct.unpack_from("<H", d, coff + 16)[0]
+sec_tbl = coff + 20 + size_opt
+if sec_tbl + nsec * 40 > len(d):
+    sys.stderr.write("Error: '%s' has malformed PE section table\n" % path)
+    sys.exit(1)
+
+sections = {}  # name -> (ptr, size)
+for i in range(nsec):
+    sh = sec_tbl + i * 40
+    name = bytes(d[sh:sh+8]).rstrip(b"\0").decode("ascii", errors="replace")
+    sz  = struct.unpack_from("<I", d, sh + 16)[0]
+    ptr = struct.unpack_from("<I", d, sh + 20)[0]
+    sections[name] = (ptr, sz)
+
+SHIM_URL = b"https://github.com/rhboot/shim"
+if ".sbat" in sections:
+    ptr, sz = sections[".sbat"]
+    if ptr + sz > len(d):
+        sys.stderr.write(
+            "Error: '%s' .sbat section extends past EOF\n" % path)
+        sys.exit(1)
+    if SHIM_URL in bytes(d[ptr:ptr+sz]):
+        print("default")
+        sys.exit(0)
+if ".setup" in sections:
+    print("uki")
+    sys.exit(0)
+sys.stderr.write(
+    "Error: '%s' did not match any known boot-EFI layout. "
+    "Recognized markers: '.sbat' containing %r (shim), or '.setup' "
+    "(x86 cos EFI-stub). Sections found: %s\n"
+    % (path, SHIM_URL.decode(), sorted(sections)))
+sys.exit(1)
 PY
 }
 
@@ -157,10 +209,7 @@ extract_boot_components() {
     for src in "${!files_to_copy[@]}"; do
         local dest="${files_to_copy[$src]}"
         echo "Copying '$src' to '$dest'..."
-        if ! mcopy -i "$P12_FILE" "$src" "$dest"; then
-            echo "Error: Failed to mcopy '$src' from '$P12_FILE'."
-            return 1
-        fi
+        mcopy_from_p12 "$src" "$dest" || return 1
     done
     echo "All boot components copied successfully."
 }

--- a/launcher/image/measure/measure.sh
+++ b/launcher/image/measure/measure.sh
@@ -103,7 +103,8 @@ mcopy_from_p12() {
 }
 
 ##
-# Detects the image mode by inspecting the boot EFI binary.
+# Detects the image mode by inspecting the boot EFI binary already extracted
+# to $BOOT_EFI_FILE by extract_boot_components.
 # Uses conservative auto-detection: positive evidence is required on both
 # sides, with a hard error on anything unrecognized.
 #   .sbat present AND content contains 'https://github.com/rhboot/shim'
@@ -112,23 +113,10 @@ mcopy_from_p12() {
 #       => 'uki' (single-blob: bootx64.efi w/ EFI stub)
 #   otherwise => hard error, listing sections found.
 # `.setup` is specific to the x86/x86_64 cos EFI-stub layout.
-# As a side effect, extracts the boot EFI to $BOOT_EFI_FILE so
-# extract_boot_components does not need to copy it again.
 #
-# @param $1: build architecture ('x86_64' or 'aarch64').
 # @return The detected mode ('default' or 'uki') to stdout.
 #
 detect_image_mode() {
-    local arch="$1"
-    local boot_src
-    case "$arch" in
-        x86_64)   boot_src="::/efi/boot/bootx64.efi" ;;
-        aarch64)  boot_src="::/efi/boot/bootaa64.efi" ;;
-        *) echo "Error: Unknown arch '$arch'." >&2; return 1 ;;
-    esac
-
-    mcopy_from_p12 "$boot_src" "$BOOT_EFI_FILE" || return 1
-
     python3 - "$BOOT_EFI_FILE" <<'PY'
 import struct, sys
 path = sys.argv[1]
@@ -183,35 +171,47 @@ PY
 
 ##
 # Copies boot-related files from the extracted partition image using mcopy.
+# The boot EFI (bootx64.efi/bootaa64.efi) is required and is a hard error if
+# missing. The default-mode extras (vmlinuz.A/B, grub.cfg, grub-lakitu.efi)
+# are best-effort: uki images don't have them, and absence is silently
+# skipped here. If a default-mode image is missing one, the downstream
+# hashing step will fail when it tries to read the file.
+#
+# @param $1: build architecture ('x86_64' or 'aarch64').
 #
 extract_boot_components() {
     local arch="$1"
-    local image_mode="$2"
-
-    # The boot EFI (bootx64.efi/bootaa64.efi) is already extracted by
-    # detect_image_mode; only the default-mode extras remain to copy.
-    if [ "$image_mode" != "default" ]; then
-        return 0
-    fi
+    local boot_src
+    case "$arch" in
+        x86_64)   boot_src="::/efi/boot/bootx64.efi" ;;
+        aarch64)  boot_src="::/efi/boot/bootaa64.efi" ;;
+        *) echo "Error: Unknown arch '$arch'." >&2; return 1 ;;
+    esac
 
     echo "Copying files from partition image '$P12_FILE'..."
 
-    declare -A files_to_copy=(
+    # Required: boot EFI binary.
+    mcopy_from_p12 "$boot_src" "$BOOT_EFI_FILE" || return 1
+
+    # Best-effort: default-mode extras. Skip silently when absent (uki).
+    declare -A optional_files=(
         ["::/syslinux/vmlinuz.A"]="$VMLINUZ_A_FILE"
         ["::/efi/boot/grub.cfg"]="$GRUB_CFG_FILE"
         ["::/efi/boot/grub-lakitu.efi"]="$GRUB_EFI_FILE"
     )
     # vmlinuz.B file exists on amd64 but not on arm64
     if [ "$arch" == "x86_64" ]; then
-        files_to_copy["::/syslinux/vmlinuz.B"]="$VMLINUZ_B_FILE"
+        optional_files["::/syslinux/vmlinuz.B"]="$VMLINUZ_B_FILE"
     fi
 
-    for src in "${!files_to_copy[@]}"; do
-        local dest="${files_to_copy[$src]}"
-        echo "Copying '$src' to '$dest'..."
-        mcopy_from_p12 "$src" "$dest" || return 1
+    for src in "${!optional_files[@]}"; do
+        local dest="${optional_files[$src]}"
+        if mcopy -i "$P12_FILE" "$src" "$dest" 2>/dev/null; then
+            echo "Copied '$src' to '$dest'."
+        else
+            echo "Skipped '$src' (not present in this image)."
+        fi
     done
-    echo "All boot components copied successfully."
 }
 
 # --- Hash Calculation Functions ---
@@ -501,10 +501,10 @@ main() {
     # 2. Setup and Extraction
     setup_temp_dir
     extract_partition_12 "$os_image_path" || return 1
+    extract_boot_components "$arch" || return 1
     local image_mode
-    image_mode=$(detect_image_mode "$arch") || return 1
+    image_mode=$(detect_image_mode) || return 1
     echo "Auto-detected image_mode=$image_mode"
-    extract_boot_components "$arch" "$image_mode" || return 1
 
     # 3. Compute All Hashes
     echo "Computing all required hashes using $HASH_ALG (image_mode=$image_mode)..."
@@ -529,17 +529,6 @@ main() {
         kernel_cmdline_b_hash=$(compute_cmdline_hash "$GRUB_CFG_FILE" "B")
         shim_hash=$(compute_efi_hash "$BOOT_EFI_FILE") || return 1
         grub_hash=$(compute_efi_hash "$GRUB_EFI_FILE") || return 1
-
-        echo "Kernel (vmlinuz.A) hash: $vmlinuz_a_hash"
-        echo "Kernel (vmlinuz.B) hash: $vmlinuz_b_hash"
-        echo "Kernel (vmlinuz.A) PE hash: $vmlinuz_a_pe_hash"
-        echo "Kernel (vmlinuz.B) PE hash: $vmlinuz_b_pe_hash"
-        echo "Kernel cmdline (image A): $kernel_cmdline_a"
-        echo "Kernel cmdline (image B): $kernel_cmdline_b"
-        echo "Kernel cmdline (image A) hash: $kernel_cmdline_a_hash"
-        echo "Kernel cmdline (image B) hash: $kernel_cmdline_b_hash"
-        echo "bootx64.efi/bootaa64.efi (shim) hash: $shim_hash"
-        echo "grub-lakitu.efi (grub) hash: $grub_hash"
     fi
 
     # 4. Final Output with escaped kernel command line strings


### PR DESCRIPTION
The new `compute_efi_authenticode_hash` function in measure.sh, computes the PE/COFF Authenticode hash by parsing the EFI binary directly in Python, mirroring sbsigntools' image.c. It
 - walks the DOS / PE / optional headers,
 - skips the CheckSum field and the Certificate Table data-directory entry,
 - hashes sections in section-table order,
 - appends trailing endjunk and zero-extends to an 8-byte alignment,

The image type (`default` vs `uki`) is now auto-detected by inspecting the boot EFI binary's PE section table (parsed with the stdlib `struct` module). Detection requires **positive evidence on both sides**:
 - `.sbat` present **and** containing `https://github.com/rhboot/shim` → `default` (shim + grub + kernel layout)
 - `.setup` present (x86/x86_64 COS EFI-stub layout) → `uki` (single-blob `bootx64.efi` with EFI stub)
 - anything else (parse failure, missing markers, unknown layout) → hard error that lists the sections found, rather than silently falling back

The extraction and detection steps were also reordered for clarity. `extract_boot_components` now runs first and attempts to copy every component from partition 12, silently skipping any that aren't present, only the boot EFI fails hard. `detect_image_mode` then infers the image type from the extracted boot EFI as a pure inspection step. If a default type image is missing any required component, the subsequent hashing step fails loudly when it tries to read the file.

Example output:
```
{
  "channel": "hardened",
  "alg": "sha384",
  "image_type": "uki",
  "shim": "",
  "grub": "",
  "vmlinuz_a": "",
  "vmlinuz_b": "",
  "kernel_cmdline_a_hash": "",
  "kernel_cmdline_b_hash": "",
  "kernel_cmdline_a": "",
  "kernel_cmdline_b": "",
  "vmlinuz_a_pe": "",
  "vmlinuz_b_pe": "",
  "uki_efi": "fe01a800be3214ae1a27d9e8bda56284292923b54c3478d49309c273e04249d058a3ad96d10dc0e622e745755ccc2ad3"
}
```
In Cloudbuild, command to run this will be like
`    /usr/local/bin/measure.sh bchardeneddisk/disk.raw measure_output_bc_hardened_sha384.json hardened x86_64 sha384
`

Note: this change was generated with AI and carefully reviewed by the author.

## Tested on debug images
- Regression (default): ran the bumped measure container against the previous release image and verified the kernel digest in the RIM matches the event log on a booted VM.
  - Image: confidential-space-debug-260400
  - Compared output vmlinuz.B against the RIM.
- UKI mode: verified the EFI Authenticode hash for debug images.
  - Compared .uki_efi against EV_EFI_BOOT_SERVICES_APPLICATION (PCR 4) in the event log.
- Auto-detect: confirmed `default` is selected for the shim-based debug image and `uki` is selected for the bc/UKI debug image, and that the resulting JSON matches the explicit-flag output from the prior commit.

Prompt for AI review
To review `compute_efi_authenticode_hash`
```
Compare the compute_efi_authenticode_hash Python implementation in launcher/image/measure/measure.sh against the reference C implementation in sbsigntools image.c (https://git.kernel.org/pub/scm/linux/kernel/git/jejb/sbsigntools.git/tree/src/image.c). Flag any divergence that would change the resulting digest for a given EFI binary.
```

To review `detect_image_mode`
```
Review the `detect_image_mode` function in launcher/image/measure/measure.sh, which classifies the boot EFI binary as `default` (shim) or `uki` (EFI-stub) by inspecting PE sections. Flag any case where the detection logic would misclassify a real boot EFI binary, hard-error on a valid one, or crash on a malformed one.
```
