### PR TITLE
fix: prevent panic on all-0xFF CCEL data and limit issuing cert body reads

### DIFF
--- a/internal/cert.go
+++ b/internal/cert.go
@@ -10,6 +10,9 @@ import (
 const (
 	maxIssuingCertificateURLs = 3
 	maxCertChainLength        = 4
+	// maxCertBodyBytes limits HTTP response reads when fetching issuing
+	// certificates to prevent OOM on malicious or misbehaving CA servers.
+	maxCertBodyBytes = 1 * 1024 * 1024 // 1 MiB
 )
 
 // GetCertificateChain constructs the certificate chain for the key's certificate.
@@ -60,7 +63,7 @@ func fetchIssuingCertificate(client *http.Client, cert *x509.Certificate) (*x509
 			lastErr = fmt.Errorf("certificate retrieval from %s returned non-OK status: %v", url, resp.StatusCode)
 			continue
 		}
-		certBytes, err := io.ReadAll(resp.Body)
+		certBytes, err := io.ReadAll(io.LimitReader(resp.Body, maxCertBodyBytes))
 		resp.Body.Close()
 		if err != nil {
 			lastErr = fmt.Errorf("failed to read response body from %s: %w", url, err)

--- a/internal/cert_test.go
+++ b/internal/cert_test.go
@@ -74,3 +74,28 @@ func TestGetCertificateChainSucceeds(t *testing.T) {
 		t.Fatalf("GetCertificateChain did not return the expected number of certificates: got %v, want 2", len(certChain))
 	}
 }
+
+// TestFetchIssuingCertificateLargeBodyTruncated verifies that a server
+// returning a very large body does not cause OOM; the response is limited
+// to maxCertBodyBytes and the truncated body fails certificate parsing,
+// returning an error rather than exhausting memory.
+func TestFetchIssuingCertificateLargeBodyTruncated(t *testing.T) {
+	// Serve a body that exceeds maxCertBodyBytes.
+	bigServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/pkix-cert")
+		// Write maxCertBodyBytes + 1 MiB of data.
+		payload := make([]byte, maxCertBodyBytes+1024*1024)
+		w.Write(payload)
+	}))
+	defer bigServer.Close()
+
+	testCA, caKey := test.GetTestCert(t, nil, nil, nil)
+	leafCert, _ := test.GetTestCert(t, []string{bigServer.URL}, testCA, caKey)
+
+	// GetCertificateChain will fetch the URL and attempt to parse the truncated
+	// response as a DER certificate; it must fail with a parse error, not panic.
+	_, err := GetCertificateChain(leafCert, localClient)
+	if err == nil {
+		t.Fatal("expected error parsing oversized body, got nil")
+	}
+}

--- a/verifier/ita/client.go
+++ b/verifier/ita/client.go
@@ -207,7 +207,7 @@ func convertRequestToTokenRequest(request verifier.VerifyAttestationRequest) tok
 	data := request.TDCCELAttestation.CcelData
 	trimIndex := len(data)
 
-	for ; trimIndex >= 0; trimIndex-- {
+	for ; trimIndex > 0; trimIndex-- {
 		c := data[trimIndex-1]
 		// Proceed until 0xFF padding ends.
 		if c != byte(255) {

--- a/verifier/ita/client_test.go
+++ b/verifier/ita/client_test.go
@@ -389,3 +389,25 @@ func TestURLFromRegionError(t *testing.T) {
 		})
 	}
 }
+
+// TestConvertRequestToTokenRequestAllPaddedCCELData verifies that CCEL data
+// consisting entirely of 0xFF bytes (e.g. an uninitialized ACPI table) does
+// not cause an index-out-of-range panic. Previously the trim loop used
+// trimIndex >= 0 as its condition, causing data[-1] when trimIndex reached 0.
+func TestConvertRequestToTokenRequestAllPaddedCCELData(t *testing.T) {
+	allFF := bytes.Repeat([]byte{0xFF}, 64)
+	request := verifier.VerifyAttestationRequest{
+		TDCCELAttestation: &verifier.TDCCELAttestation{
+			CcelData:          allFF,
+			CanonicalEventLog: []byte("test-cel"),
+			TdQuote:           []byte("test-quote"),
+			AkCert:            []byte("test-akcert"),
+		},
+		Challenge: testVerifierRequest.Challenge,
+	}
+	// Must not panic; all padding trimmed → empty EventLog.
+	converted := convertRequestToTokenRequest(request)
+	if len(converted.TDX.EventLog) != 0 {
+		t.Errorf("expected empty EventLog after trimming all-0xFF CCEL data, got %d bytes", len(converted.TDX.EventLog))
+	}
+}


### PR DESCRIPTION
## Summary

Two independent security fixes:

### 1. Index-out-of-range panic on all-0xFF CCEL data (`verifier/ita/client.go`)

The padding-trim loop in `convertRequestToTokenRequest` uses `trimIndex >= 0` as its guard:

```go
for ; trimIndex >= 0; trimIndex-- {
    c := data[trimIndex-1]  // panics when trimIndex == 0: data[-1]
```

When `trimIndex` reaches `0`, the loop body executes `data[-1]`, triggering an index-out-of-range panic. This happens unconditionally when `CcelData` consists entirely of `0xFF` bytes — for example, an uninitialized or all-padding ACPI CCEL table from a TDX platform. A crash here takes down the attestation service for the VM.

**Fix:** Change the loop guard to `trimIndex > 0`.

### 2. Unbounded `io.ReadAll` on issuing certificate URLs (`internal/cert.go`)

`fetchIssuingCertificate` fetches URLs taken from `cert.IssuingCertificateURL` — which originates from the AK certificate field in client-supplied `pb.Attestation` protobufs. There was no size limit on the HTTP response body:

```go
certBytes, err := io.ReadAll(resp.Body)  // no size limit
```

An attacker-controlled certificate pointing to a server returning an arbitrarily large body causes the process to exhaust memory (OOM-kill).

**Fix:** Wrap with `io.LimitReader` capped at 1 MiB — sufficient for any real DER certificate.

## Tests

- `TestConvertRequestToTokenRequestAllPaddedCCELData`: verifies all-`0xFF` CCEL data is handled without panic.
- `TestFetchIssuingCertificateLargeBodyTruncated`: verifies oversized cert bodies are truncated and return an error rather than OOM.