### PR TITLE
Update BC build 

### DIFF
--- a/launcher/image/bc_cloudbuild.yaml
+++ b/launcher/image/bc_cloudbuild.yaml
@@ -164,10 +164,11 @@ steps:
         if [ -z "$$FEATURES" ]; then
           FEATURES="UEFI_COMPATIBLE"
         fi
+        gcloud compute images delete ${_OUTPUT_IMAGE_NAME} --quiet || true
         gcloud compute images create ${_OUTPUT_IMAGE_NAME} \
           --family=${_OUTPUT_IMAGE_FAMILY} \
           --source-uri=gs://${_BUCKET_NAME}/oem-preloader-${BUILD_ID}/${_OUTPUT_IMAGE_NAME}.tar.gz \
-          --guest-os-features="$$FEATURES" \
+          --guest-os-features="$$FEATURES" 
   - name: 'gcr.io/cloud-builders/gcloud'
     id: 'RemoveGCSFiles'
     entrypoint: 'gcloud'

--- a/launcher/image/bc_cloudbuild.yaml
+++ b/launcher/image/bc_cloudbuild.yaml
@@ -164,11 +164,14 @@ steps:
         if [ -z "$$FEATURES" ]; then
           FEATURES="UEFI_COMPATIBLE"
         fi
-        gcloud compute images delete ${_OUTPUT_IMAGE_NAME} --quiet || true
+        if gcloud compute images describe ${_OUTPUT_IMAGE_NAME} > /dev/null 2>&1; then
+          echo "Result image ${_OUTPUT_IMAGE_NAME} already exists in project. Exiting."
+          exit 0
+        fi
         gcloud compute images create ${_OUTPUT_IMAGE_NAME} \
           --family=${_OUTPUT_IMAGE_FAMILY} \
           --source-uri=gs://${_BUCKET_NAME}/oem-preloader-${BUILD_ID}/${_OUTPUT_IMAGE_NAME}.tar.gz \
-          --guest-os-features="$$FEATURES" 
+          --guest-os-features="$$FEATURES"
   - name: 'gcr.io/cloud-builders/gcloud'
     id: 'RemoveGCSFiles'
     entrypoint: 'gcloud'


### PR DESCRIPTION
Update the BC build process to skip GCE image creation if the image already exists with that name.  Currently this is causing re-runs of the presubmits tests for the same commit to fail.