### PR TITLE
Adding network setup script to prioritize idpf nics and provide tap dev IP address

### DIFF
--- a/launcher/image/bc-guest/bc_network_setup.sh
+++ b/launcher/image/bc-guest/bc_network_setup.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+mkdir -p /etc/systemd/network/
+
+cat << 'EOF' > /etc/systemd/network/10-idpf.network
+[Match]
+Driver=idpf
+
+[Network]
+DHCP=yes
+IPv6AcceptRA=yes
+
+[DHCPv4]
+RouteMetric=100
+
+[DHCPv6]
+RouteMetric=100
+EOF
+
+cat << 'EOF' > /etc/systemd/network/10-virtio.network
+[Match]
+Driver=virtio_net
+
+[Network]
+Address=192.168.100.2/24
+
+[Route]
+Gateway=192.168.100.1
+Metric=1024
+EOF

--- a/launcher/image/bc-guest/bcentrypoint.sh
+++ b/launcher/image/bc-guest/bcentrypoint.sh
@@ -22,6 +22,13 @@ main() {
   cp /usr/share/oem/confidential_space/nodeproblemdetector/docker-monitor-cs.json /etc/node_problem_detector/docker-monitor.json
   # Override default kernel-monitor.json for node-problem-detector.
   cp /usr/share/oem/confidential_space/nodeproblemdetector/kernel-monitor-cs.json /etc/node_problem_detector/kernel-monitor.json
+
+  # Configure network priority for IDPF using systemd-networkd.
+  if [[ -f /usr/share/oem/confidential_space/bc_network_setup.sh ]]; then
+    /usr/share/oem/confidential_space/bc_network_setup.sh
+    systemctl restart systemd-networkd
+  fi
+
   systemctl daemon-reload
   systemctl enable container-runner.service
   systemctl start container-runner.service

--- a/launcher/image/bc_cloudbuild.yaml
+++ b/launcher/image/bc_cloudbuild.yaml
@@ -44,6 +44,7 @@ steps:
            ./launcher/image/container-runner.service \
            ./launcher/image/fluent-bit-cs.conf \
            ./launcher/image/exit_script.sh \
+           ./launcher/image/bc-guest/bc_network_setup.sh \
            /workspace/oem-install/confidential_space/
         cp ./launcher/image/nodeproblemdetector/* /workspace/oem-install/confidential_space/nodeproblemdetector/
 
@@ -52,6 +53,7 @@ steps:
         # cp ./launcher/image/bc-guest/meta-data /workspace/oem-install/meta-data
         chmod +x /workspace/oem-install/confidential_space/cs_container_launcher || true
         chmod +x /workspace/oem-install/confidential_space/exit_script.sh || true
+        chmod +x /workspace/oem-install/confidential_space/bc_network_setup.sh || true
         chmod +x /workspace/oem-install/entrypoint.sh || true
 
   - name: 'gcr.io/cloud-builders/gcloud'


### PR DESCRIPTION
Without this, tap devices try to take traffic that is meant to leave on the IDPF NIC. This prevents that by prioritizing IDPF with the metric number of 100. The default is 1024 and setting the number lower means higher priority Also providing static IP address to the tap device.

The script is placed into the OEM partition and then on boot, the entry point script will attempt to run the net setup script.

Wrapped into host image here: https://confidential-space-internal-review.git.corp.google.com/c/chewbacca/host-acos/+/2420?tab=checks

Tested on A4 machine and I see the IP route has the correct "metric 100" for the IDPF devices
```
jacobdw_google_com@jacobdw-a4-test ~ $ ip route show
default via 10.128.0.1 dev eth0 proto dhcp src 10.128.0.117 metric 100 
10.10.0.0/24 via 10.10.0.1 dev eth1 proto dhcp src 10.10.0.195 metric 100 
10.10.0.1 dev eth1 proto dhcp scope link src 10.10.0.195 metric 100 
10.128.0.0/20 via 10.128.0.1 dev eth0 proto dhcp src 10.128.0.117 metric 100 
10.128.0.1 dev eth0 proto dhcp scope link src 10.128.0.117 metric 100 
169.254.169.254 via 10.128.0.1 dev eth0 proto dhcp src 10.128.0.117 metric 100 
169.254.169.254 dev eth1 proto dhcp scope link src 10.10.0.195 metric 100 
```