### PR TITLE
Add uki image measurement.

### DIFF
--- a/launcher/cloudbuild.yaml
+++ b/launcher/cloudbuild.yaml
@@ -204,7 +204,7 @@ steps:
 
 - name: 'gcr.io/cloud-builders/gcloud'
   id: DebugBcImageBuildAndExport
-  waitFor: ['BaseImageIdent', 'LauncherCompile', 'DownloadExpBinary']
+  waitFor: ['BaseImageIdent', 'LauncherCompile', 'DownloadExpBinary', 'DownloadGpuDrivers']
   env: 
   - 'BC_BASE_IMAGE=$_BC_DEBUG_IMAGE'
   - 'BC_BASE_IMAGE_PROJECT=$_BC_BASE_IMAGE_PROJECT'
@@ -231,7 +231,7 @@ steps:
 
 - name: 'gcr.io/cloud-builders/gcloud'
   id: HardenedBcImageBuildAndExport
-  waitFor: ['BaseImageIdent', 'LauncherCompile', 'DownloadExpBinary']
+  waitFor: ['BaseImageIdent', 'LauncherCompile', 'DownloadExpBinary', 'DownloadGpuDrivers']
   env: 
   - 'BC_BASE_IMAGE=$_BC_BASE_IMAGE'
   - 'BC_BASE_IMAGE_PROJECT=$_BC_BASE_IMAGE_PROJECT'
@@ -537,7 +537,7 @@ steps:
           '--image=${_OUTPUT_IMAGE_PREFIX}-debug-${_OUTPUT_IMAGE_SUFFIX}',
           '--project=${PROJECT_ID}']
 
-- name: 'us-docker.pkg.dev/confidential-space-images-dev/cs-tools/measure@sha256:b82c8ca459b863cfdf9faf8e4c06d506a50f3fe86ca1f3756ca6fee42a5cd7f4'
+- name: 'us-docker.pkg.dev/confidential-space-images-dev/cs-tools/measure@sha256:5c2eaaa70438126877de51b44914d3751ba242aed7f4d99d485833629f3958bc'
   id: MeasureHardenedImage
   waitFor: ['ExportHardenedImage']
   env:
@@ -550,11 +550,10 @@ steps:
     mkdir hardeneddisk
     tar xzf ${OUTPUT_IMAGE_NAME}.tar.gz -C hardeneddisk/
     echo "measuring image ${OUTPUT_IMAGE_NAME}"
-    /usr/local/bin/measure.sh hardeneddisk/disk.raw measure_output_hardened.json hardened x86_64
-    cat measure_output_hardened.json
+    /usr/local/bin/measure.sh hardeneddisk/disk.raw measure_output_hardened.json hardened x86_64 sha256
     gcloud storage cp measure_output_hardened.json gs://${PROJECT_ID}-rims/${OUTPUT_IMAGE_NAME}.json
 
-- name: 'us-docker.pkg.dev/confidential-space-images-dev/cs-tools/measure@sha256:b82c8ca459b863cfdf9faf8e4c06d506a50f3fe86ca1f3756ca6fee42a5cd7f4'
+- name: 'us-docker.pkg.dev/confidential-space-images-dev/cs-tools/measure@sha256:5c2eaaa70438126877de51b44914d3751ba242aed7f4d99d485833629f3958bc'
   id: MeasureDebugImage
   waitFor: ['ExportDebugImage']
   env:
@@ -567,8 +566,7 @@ steps:
     mkdir debugdisk
     tar xzf ${OUTPUT_IMAGE_NAME}.tar.gz -C debugdisk/
     echo "measuring image ${OUTPUT_IMAGE_NAME}"
-    /usr/local/bin/measure.sh debugdisk/disk.raw measure_output_debug.json debug x86_64
-    cat measure_output_debug.json
+    /usr/local/bin/measure.sh debugdisk/disk.raw measure_output_debug.json debug x86_64 sha256
     gsutil cp measure_output_debug.json gs://${PROJECT_ID}-rims/${OUTPUT_IMAGE_NAME}.json
 
 - name: 'gcr.io/cloud-builders/gcloud'
@@ -589,7 +587,7 @@ steps:
           '--image=${_OUTPUT_IMAGE_PREFIX}-vg-debug-${_OUTPUT_IMAGE_SUFFIX}',
           '--project=${PROJECT_ID}']
 
-- name: 'us-docker.pkg.dev/confidential-space-images-dev/cs-tools/measure@sha256:5dec9806530d3aaad4d6a03bed7f1ccd6433188e158cc5c60367c31efd4feaf7'
+- name: 'us-docker.pkg.dev/confidential-space-images-dev/cs-tools/measure@sha256:5c2eaaa70438126877de51b44914d3751ba242aed7f4d99d485833629f3958bc'
   id: MeasureVgHardenedImage
   waitFor: ['ExportVgHardenedImage']
   env:
@@ -609,7 +607,7 @@ steps:
     gcloud storage cp measure_output_vg_hardened_sha384.json gs://${PROJECT_ID}-rims/${OUTPUT_IMAGE_NAME}_sha384.json
 
 
-- name: 'us-docker.pkg.dev/confidential-space-images-dev/cs-tools/measure@sha256:5dec9806530d3aaad4d6a03bed7f1ccd6433188e158cc5c60367c31efd4feaf7'
+- name: 'us-docker.pkg.dev/confidential-space-images-dev/cs-tools/measure@sha256:5c2eaaa70438126877de51b44914d3751ba242aed7f4d99d485833629f3958bc'
   id: MeasureVgDebugImage
   waitFor: ['ExportVgDebugImage']
   env:
@@ -627,7 +625,6 @@ steps:
 
     gsutil cp measure_output_vg_debug.json gs://${PROJECT_ID}-rims/${OUTPUT_IMAGE_NAME}.json
     gsutil cp measure_output_vg_debug_sha384.json gs://${PROJECT_ID}-rims/${OUTPUT_IMAGE_NAME}_sha384.json
-
 
 options:
   pool:

--- a/launcher/image/bc_cloudbuild.yaml
+++ b/launcher/image/bc_cloudbuild.yaml
@@ -136,6 +136,23 @@ steps:
   - name: 'alpine'
     id: 'RenameOutputImage'
     args: ['mv', 'output.bin', 'disk.raw']
+  - name: 'us-docker.pkg.dev/confidential-space-images-dev/cs-tools/measure@sha256:5c2eaaa70438126877de51b44914d3751ba242aed7f4d99d485833629f3958bc'
+    id: 'MeasureImage'
+    env:
+      - 'IMAGE_ENV=${_IMAGE_ENV}'
+      - 'OUTPUT_IMAGE_NAME=${_OUTPUT_IMAGE_NAME}'
+    entrypoint: 'bash'
+    args:
+      - '-c'
+      - |
+        set -exuo pipefail
+        echo "measuring BC image $${OUTPUT_IMAGE_NAME} (env=$${IMAGE_ENV})"
+        /usr/local/bin/measure.sh ./disk.raw measure_output_bc_$${IMAGE_ENV}.json        "$${IMAGE_ENV}" x86_64 sha256
+        /usr/local/bin/measure.sh ./disk.raw measure_output_bc_$${IMAGE_ENV}_sha384.json "$${IMAGE_ENV}" x86_64 sha384
+
+        RIM_NAME="$${OUTPUT_IMAGE_NAME//-bc-/-}"
+        gcloud storage cp measure_output_bc_$${IMAGE_ENV}.json        gs://${PROJECT_ID}-rims/bc/$${RIM_NAME}.json
+        gcloud storage cp measure_output_bc_$${IMAGE_ENV}_sha384.json gs://${PROJECT_ID}-rims/bc/$${RIM_NAME}_sha384.json
   - name: 'alpine'
     id: 'TarOutputImage'
     args: ['tar', '-zcf', './out_image.tar.gz', 'disk.raw']

--- a/launcher/image/bc_cloudbuild.yaml
+++ b/launcher/image/bc_cloudbuild.yaml
@@ -150,9 +150,8 @@ steps:
         /usr/local/bin/measure.sh ./disk.raw measure_output_bc_$${IMAGE_ENV}.json        "$${IMAGE_ENV}" x86_64 sha256
         /usr/local/bin/measure.sh ./disk.raw measure_output_bc_$${IMAGE_ENV}_sha384.json "$${IMAGE_ENV}" x86_64 sha384
 
-        RIM_NAME="$${OUTPUT_IMAGE_NAME//-bc-/-}"
-        gcloud storage cp measure_output_bc_$${IMAGE_ENV}.json        gs://${PROJECT_ID}-rims/bc/$${RIM_NAME}.json
-        gcloud storage cp measure_output_bc_$${IMAGE_ENV}_sha384.json gs://${PROJECT_ID}-rims/bc/$${RIM_NAME}_sha384.json
+        gcloud storage cp measure_output_bc_$${IMAGE_ENV}.json        gs://${PROJECT_ID}-rims/bc/$${OUTPUT_IMAGE_NAME}.json
+        gcloud storage cp measure_output_bc_$${IMAGE_ENV}_sha384.json gs://${PROJECT_ID}-rims/bc/$${OUTPUT_IMAGE_NAME}_sha384.json
   - name: 'alpine'
     id: 'TarOutputImage'
     args: ['tar', '-zcf', './out_image.tar.gz', 'disk.raw']


### PR DESCRIPTION
1. **Add bc image measurements.** 
    * Updated `launcher/image/bc_cloudbuild.yaml` to run `measure.sh` for both debug and hardened bc images.
    * Calculates both SHA256 and SHA384 digests and uploads the resulting JSON manifests to `gs://${PROJECT_ID}-rims/bc/`.
    * Bumped the measure image digest in `launcher/cloudbuild.yaml` to the latest version.
2. **Fix serial log reading race condition (`read_serial.sh`)**  
Previously, `util/read_serial.sh` used a hardcoded, shared file (`/workspace/next_start.txt`). Because Cloud Build shares `/workspace` across all parallel steps, the concurrent polling loops were clobbering each other's `--start=<offset>` markers. A verification step for VM `A` would read VM `B`'s large byte offset, query gcloud out of bounds, get empty results, and prematurely fail the test.
    * Scoped the file to the unique VM instance name (`/workspace/next_start_$1.txt`). Each concurrent test step now gets an isolated bookmark file.

### Test
[BC cloud image build](https://pantheon.corp.google.com/cloud-build/builds;region=us-west1/5bfa171a-e801-40f3-8816-db5c8ad2e9d2?project=confidential-space-images-dev&e=13802955&mods=logs_tg_prod)
