### PR TITLE
Fix race condition in read_serial for concurrent tests

### DIFF
--- a/launcher/image/test/util/read_serial.sh
+++ b/launcher/image/test/util/read_serial.sh
@@ -3,7 +3,7 @@
 # read_serial attempts to read the serial output until the workload is finished
 # Use var=$(read_serial <VM_NAME> <ZONE>) to capture the output of this command into a variable.
 read_serial() {
-  local base_cmd='gcloud compute instances get-serial-port-output $1 --zone $2 2>/workspace/next_start.txt'
+  local base_cmd='gcloud compute instances get-serial-port-output $1 --zone $2 2>/workspace/next_start_$1.txt'
   local serial_out=$(eval ${base_cmd})
   local last=''
 
@@ -12,19 +12,19 @@ read_serial() {
   endtime=$(date -ud "$timeout" +%s)
 
   echo "Reading serial console..."
-  while [ -s /workspace/next_start.txt ]; do
+  while [ -s /workspace/next_start_$1.txt ]; do
     if [[ $(date -u +%s) -ge $endtime ]]; then
       echo "timed out reading serial console, or the workload is running more than ${timeout}"
       break
     fi
 
     # VM may already exit
-    if grep -qi 'Could not fetch serial port output' /workspace/next_start.txt; then
+    if grep -qi 'Could not fetch serial port output' /workspace/next_start_$1.txt; then
       serial_out="$serial_out $1 VM stopped"
       break
     fi
 
-    next=$(cat /workspace/next_start.txt | sed -n 2p | cut -d ' ' -f2)
+    next=$(cat /workspace/next_start_$1.txt | sed -n 2p | cut -d ' ' -f2)
     local next_cmd="${base_cmd} ${next}"
     
     # sleeping 5s for the next serial console read


### PR DESCRIPTION
When multiple integration test suites run concurrently (such as in test_health_monitoring.yaml), they parallelize VM creation and status checks.

Previously, the `read_serial` helper function in
launcher/image/test/util/read_serial.sh redirected gcloud serial port output's stderr to a static shared file `/workspace/next_start.txt`. Because /workspace is a shared volume across Cloud Build steps, parallel tasks overwrote and read from the same file simultaneously, corrupting the pagination cursor (`next`) and leading to false "Could not fetch serial port output" failures.

This change resolves the race condition by using a unique status file path per VM: `/workspace/next_start_$1.txt`, leveraging the VM name ($1) parameter.