### PR TITLE
Add CreateSigningKeyImportBlob support for ECC keys

### DIFF
--- a/server/import_test.go
+++ b/server/import_test.go
@@ -3,6 +3,8 @@ package server
 import (
 	"bytes"
 	"crypto"
+	"crypto/ecdsa"
+	"crypto/elliptic"
 	"crypto/rand"
 	"crypto/rsa"
 	"errors"
@@ -193,7 +195,11 @@ func TestSigningKeyImport(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer ek.Close()
-	signingKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	rsaSigningKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatal(err)
+	}
+	eccSigningKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -215,13 +221,13 @@ func TestSigningKeyImport(t *testing.T) {
 		{"Bad-PCR", &pb.PCRs{Hash: pb.HashAlgo_SHA256, Pcrs: map[uint32][]byte{0: badPCR}}, false},
 	}
 	for _, subtest := range subtests {
-		t.Run(subtest.name, func(t *testing.T) {
-			blob, err := CreateSigningKeyImportBlob(ek.PublicKey(), signingKey, subtest.pcrs)
+		// RSA signing key
+		t.Run(subtest.name+"-RSA", func(t *testing.T) {
+			rsaBlob, err := CreateSigningKeyImportBlob(ek.PublicKey(), rsaSigningKey, subtest.pcrs)
 			if err != nil {
-				t.Fatalf("creating import blob failed: %v", err)
+				t.Fatalf("creating RSA import blob failed: %v", err)
 			}
-
-			importedKey, err := ek.ImportSigningKey(blob)
+			importedKey, err := ek.ImportSigningKey(rsaBlob)
 			if err != nil {
 				t.Fatalf("import failed: %v", err)
 			}
@@ -237,8 +243,38 @@ func TestSigningKeyImport(t *testing.T) {
 				if err != nil {
 					t.Fatalf("import failed: %v", err)
 				}
-				if err = rsa.VerifyPKCS1v15(&signingKey.PublicKey, crypto.SHA256, digest[:], sig); err != nil {
+				if err = rsa.VerifyPKCS1v15(&rsaSigningKey.PublicKey, crypto.SHA256, digest[:], sig); err != nil {
 					t.Error(err)
+				}
+				return
+			} else if err == nil {
+				t.Error("expected Import to fail but it did not")
+			}
+		})
+		// ECC signing key
+		t.Run(subtest.name+"-ECC", func(t *testing.T) {
+			eccBlob, err := CreateSigningKeyImportBlob(ek.PublicKey(), eccSigningKey, subtest.pcrs)
+			if err != nil {
+				t.Fatalf("creating ECC import blob failed: %v", err)
+			}
+			importedKey, err := ek.ImportSigningKey(eccBlob)
+			if err != nil {
+				t.Fatalf("import failed: %v", err)
+			}
+			defer importedKey.Close()
+			signer, err := importedKey.GetSigner()
+			if err != nil {
+				t.Fatalf("could not create signer: %v", err)
+			}
+			var digest [32]byte
+
+			sig, err := signer.Sign(nil, digest[:], crypto.SHA256)
+			if subtest.expectSuccess {
+				if err != nil {
+					t.Fatalf("import failed: %v", err)
+				}
+				if !ecdsa.VerifyASN1(&eccSigningKey.PublicKey, digest[:], sig) {
+					t.Error("ECDSA verification failed")
 				}
 				return
 			} else if err == nil {

--- a/server/key_conversion.go
+++ b/server/key_conversion.go
@@ -5,6 +5,7 @@ import (
 	"crypto/ecdsa"
 	"crypto/rand"
 	"crypto/rsa"
+	"errors"
 	"fmt"
 	"io"
 
@@ -76,10 +77,9 @@ func createPrivate(sensitive []byte) tpm2.Private {
 	return private
 }
 
-func createPublicPrivateSign(signingKey crypto.PrivateKey) (tpm2.Public, tpm2.Private, error) {
-	rsaPriv, ok := signingKey.(*rsa.PrivateKey)
-	if !ok {
-		return tpm2.Public{}, tpm2.Private{}, fmt.Errorf("unsupported signing key type: %T", signingKey)
+func createPublicPrivateSignRSA(rsaPriv *rsa.PrivateKey) (tpm2.Public, tpm2.Private, error) {
+	if rsaPriv == nil {
+		return tpm2.Public{}, tpm2.Private{}, errors.New("nil RSA private key")
 	}
 
 	rsaPub := rsaPriv.PublicKey
@@ -105,4 +105,52 @@ func createPublicPrivateSign(signingKey crypto.PrivateKey) (tpm2.Public, tpm2.Pr
 	}
 
 	return public, private, nil
+}
+
+func createPublicPrivateSignECC(eccPriv *ecdsa.PrivateKey) (tpm2.Public, tpm2.Private, error) {
+	if eccPriv == nil {
+		return tpm2.Public{}, tpm2.Private{}, errors.New("nil ECC private key")
+	}
+
+	eccCurveID, err := goCurveToCurveID(eccPriv.Curve)
+	if err != nil {
+		return tpm2.Public{}, tpm2.Private{}, fmt.Errorf("unsupported ECC curve: %s", eccPriv.Curve.Params().Name)
+	}
+
+	eccPub := eccPriv.PublicKey
+	public := tpm2.Public{
+		Type:       tpm2.AlgECC,
+		NameAlg:    defaultNameAlg,
+		Attributes: tpm2.FlagSign,
+		ECCParameters: &tpm2.ECCParams{
+			CurveID: eccCurveID,
+			Point: tpm2.ECPoint{
+				XRaw: eccIntToBytes(eccPub.Curve, eccPub.X),
+				YRaw: eccIntToBytes(eccPub.Curve, eccPub.Y),
+			},
+			Sign: &tpm2.SigScheme{
+				Alg:  tpm2.AlgECDSA,
+				Hash: tpm2.AlgSHA256,
+			},
+		},
+	}
+	private := tpm2.Private{
+		Type:      tpm2.AlgECC,
+		AuthValue: nil,
+		SeedValue: nil, // Only Storage Keys need a seed value. See part 3 TPM2_CREATE b.3.
+		Sensitive: eccPriv.D.Bytes(),
+	}
+
+	return public, private, nil
+}
+
+func createPublicPrivateSign(signingKey crypto.PrivateKey) (tpm2.Public, tpm2.Private, error) {
+	switch key := signingKey.(type) {
+	case *rsa.PrivateKey:
+		return createPublicPrivateSignRSA(key)
+	case *ecdsa.PrivateKey:
+		return createPublicPrivateSignECC(key)
+	default:
+		return tpm2.Public{}, tpm2.Private{}, fmt.Errorf("unsupported signing key type: %T", key)
+	}
 }


### PR DESCRIPTION
Extended `CreateSigningKeyImportBlob` to accept `crypto.PrivateKey` instead of `*rsa.PrivateKey`, adding support for ECC signing keys in addition to RSA.

Added `createPublicPrivateSignECC` to build the TPM2 public and private areas for ECC keys, following TPM 2.0 Part 2 structures (TPMT_PUBLIC, TPMT_SENSITIVE).

Extended `TestSigningKeyImport` to cover ECC key import and signing, tested against a physical TPM 2.0 device.

Closes #215