### PR TITLE
Update BC base COS image

### DIFF
--- a/launcher/cloudbuild.yaml
+++ b/launcher/cloudbuild.yaml
@@ -8,8 +8,8 @@ substitutions:
   '_BUCKET_NAME': '${PROJECT_ID}_cloudbuild'
   '_VG_BASE_IMAGE': 'cos-125-19216-220-185'
   '_BC_BASE_IMAGE_PROJECT': 'confidential-space-images-dev'
-  '_BC_BASE_IMAGE': 'cos-bc-guest-125-19216-395-4'
-  '_BC_DEBUG_IMAGE': 'cos-bcdbg-guest-125-19216-395-4'
+  '_BC_BASE_IMAGE': 'cos-bc-guest-125-19216-395-47-tdx'
+  '_BC_DEBUG_IMAGE': 'cos-bcdbg-guest-125-19216-395-47-tdx'
 
 steps:
 # determine the base image

--- a/launcher/cloudbuild.yaml
+++ b/launcher/cloudbuild.yaml
@@ -8,8 +8,8 @@ substitutions:
   '_BUCKET_NAME': '${PROJECT_ID}_cloudbuild'
   '_VG_BASE_IMAGE': 'cos-125-19216-220-185'
   '_BC_BASE_IMAGE_PROJECT': 'confidential-space-images-dev'
-  '_BC_BASE_IMAGE': 'cos-bc-guest-125-19216-395-47'
-  '_BC_DEBUG_IMAGE': 'cos-bcdbg-guest-125-19216-395-47'
+  '_BC_BASE_IMAGE': 'cos-bc-guest-125-19216-395-4'
+  '_BC_DEBUG_IMAGE': 'cos-bcdbg-guest-125-19216-395-4'
 
 steps:
 # determine the base image


### PR DESCRIPTION
The current base COS image is missing the `TDX_CAPABLE` and `SNP_SVSM_CAPABLE` Guest OS features. Because bc aCOS build process inherits these features from the base image, their absence in base COS prevents them from being included in the bc aCOS image. Consequently, we cannot spin up TDX or SEV-enabled VMs using the new image.

**Solution:** Revert the base to cos-bc-guest-125-19216-395-4, which contains the required Guest OS attributes.