### PR TITLE
 launcher: Pin Google CA in GCP TLS connections

### DIFF
--- a/cmd/token.go
+++ b/cmd/token.go
@@ -18,6 +18,7 @@ import (
 	"github.com/google/go-tpm-tools/verifier/util"
 	"github.com/google/go-tpm/legacy/tpm2"
 	"github.com/spf13/cobra"
+	"golang.org/x/oauth2/google"
 	"google.golang.org/api/option"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
@@ -60,7 +61,12 @@ The OIDC token includes claims regarding the GCE VM, which is verified by Attest
 			return fmt.Errorf("failed to retrieve ProjectID from MDS: %v", err)
 		}
 
-		verifierClient, err := util.NewRESTClient(ctx, asAddress, projectID, region)
+		httpClient, err := google.DefaultClient(ctx)
+		if err != nil {
+			return fmt.Errorf("failed to create HTTP client: %v", err)
+		}
+
+		verifierClient, err := util.NewRESTClient(ctx, asAddress, projectID, region, option.WithHTTPClient(httpClient))
 		if err != nil {
 			return fmt.Errorf("failed to create REST verifier client: %v", err)
 		}

--- a/launcher/cloudbuild.yaml
+++ b/launcher/cloudbuild.yaml
@@ -14,6 +14,10 @@ substitutions:
 
 
 steps:
+- name: 'gcr.io/cloud-builders/curl'
+  id: DownloadGoogleRoots
+  args: ['-sSL', 'https://pki.goog/roots.pem', '-o', 'launcher/image/google_roots.pem']
+
 # determine the base image
 - name: 'gcr.io/cloud-builders/gcloud'
   id: BaseImageIdent
@@ -110,7 +114,7 @@ steps:
 
 - name: 'gcr.io/cloud-builders/gcloud'
   id: DebugVgImageBuild
-  waitFor: ['BaseImageIdent', 'LauncherCompile', 'DownloadExpBinary', 'DownloadGpuDrivers']
+  waitFor: ['BaseImageIdent', 'LauncherCompile', 'DownloadExpBinary', 'DownloadGpuDrivers', 'DownloadGoogleRoots']
   env:
   - 'OUTPUT_IMAGE_NAME=${_OUTPUT_IMAGE_PREFIX}-vg-debug-${_OUTPUT_IMAGE_SUFFIX}'
   - 'OUTPUT_IMAGE_FAMILY=${_OUTPUT_IMAGE_FAMILY}-vg'
@@ -139,7 +143,7 @@ steps:
 
 - name: 'gcr.io/cloud-builders/gcloud'
   id: HardenedVgImageBuild
-  waitFor: ['BaseImageIdent', 'LauncherCompile', 'DownloadExpBinary', 'DownloadGpuDrivers']
+  waitFor: ['BaseImageIdent', 'LauncherCompile', 'DownloadExpBinary', 'DownloadGpuDrivers', 'DownloadGoogleRoots']
   env:
   - 'OUTPUT_IMAGE_NAME=${_OUTPUT_IMAGE_PREFIX}-vg-hardened-${_OUTPUT_IMAGE_SUFFIX}'
   - 'OUTPUT_IMAGE_FAMILY=${_OUTPUT_IMAGE_FAMILY}-vg'
@@ -169,7 +173,7 @@ steps:
 
 - name: 'gcr.io/cloud-builders/gcloud'
   id: DebugImageBuild
-  waitFor: ['BaseImageIdent', 'LauncherCompile', 'DownloadExpBinary', 'DownloadGpuDrivers']
+  waitFor: ['BaseImageIdent', 'LauncherCompile', 'DownloadExpBinary', 'DownloadGpuDrivers', 'DownloadGoogleRoots']
   env:
   - 'OUTPUT_IMAGE_NAME=${_OUTPUT_IMAGE_PREFIX}-debug-${_OUTPUT_IMAGE_SUFFIX}'
   - 'OUTPUT_IMAGE_FAMILY=${_OUTPUT_IMAGE_FAMILY}'
@@ -198,7 +202,7 @@ steps:
 
 - name: 'gcr.io/cloud-builders/gcloud'
   id: HardenedImageBuild
-  waitFor: ['BaseImageIdent', 'LauncherCompile', 'DownloadExpBinary', 'DownloadGpuDrivers']
+  waitFor: ['BaseImageIdent', 'LauncherCompile', 'DownloadExpBinary', 'DownloadGpuDrivers', 'DownloadGoogleRoots']
   env:
   - 'OUTPUT_IMAGE_NAME=${_OUTPUT_IMAGE_PREFIX}-hardened-${_OUTPUT_IMAGE_SUFFIX}'
   - 'OUTPUT_IMAGE_FAMILY=${_OUTPUT_IMAGE_FAMILY}'
@@ -228,7 +232,7 @@ steps:
 
 - name: 'gcr.io/cloud-builders/gcloud'
   id: DebugBcImageBuildAndExport
-  waitFor: ['BaseImageIdent', 'LauncherCompile', 'DownloadExpBinary', 'DownloadGpuDrivers']
+  waitFor: ['BaseImageIdent', 'LauncherCompile', 'DownloadExpBinary', 'DownloadGpuDrivers', 'DownloadGoogleRoots']
   env:
   - 'BC_BASE_IMAGE=$_BC_DEBUG_IMAGE'
   - 'BC_BASE_IMAGE_PROJECT=$_BC_BASE_IMAGE_PROJECT'
@@ -257,7 +261,7 @@ steps:
 
 - name: 'gcr.io/cloud-builders/gcloud'
   id: HardenedBcImageBuildAndExport
-  waitFor: ['BaseImageIdent', 'LauncherCompile', 'DownloadExpBinary', 'DownloadGpuDrivers']
+  waitFor: ['BaseImageIdent', 'LauncherCompile', 'DownloadExpBinary', 'DownloadGpuDrivers', 'DownloadGoogleRoots']
   env:
   - 'BC_BASE_IMAGE=$_BC_BASE_IMAGE'
   - 'BC_BASE_IMAGE_PROJECT=$_BC_BASE_IMAGE_PROJECT'

--- a/launcher/container_runner.go
+++ b/launcher/container_runner.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"io"
 	"math/rand"
+	"net/http"
 	"os"
 	"os/exec"
 	"os/signal"
@@ -49,6 +50,7 @@ import (
 	v1 "github.com/opencontainers/image-spec/specs-go/v1"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
 	"golang.org/x/oauth2"
+	"google.golang.org/api/option"
 	"google.golang.org/protobuf/proto"
 )
 
@@ -61,6 +63,7 @@ type ContainerRunner struct {
 	gpuAttester   gpu.Attester
 	serialConsole *os.File
 	powerButton   *powerButtonListener // Populated only for a hardened image
+	clientOpts    []option.ClientOption
 }
 
 const tokenFileTmp = ".token.tmp"
@@ -93,8 +96,8 @@ const (
 const defaultOOMScore = 1000
 
 // NewRunner returns a runner.
-func NewRunner(ctx context.Context, cdClient *containerd.Client, token oauth2.Token, launchSpec spec.LaunchSpec, mdsClient *metadata.Client, tpm io.ReadWriteCloser, logger logging.Logger, serialConsole *os.File) (*ContainerRunner, error) {
-	image, err := initImage(ctx, cdClient, launchSpec, token)
+func NewRunner(ctx context.Context, cdClient *containerd.Client, token oauth2.Token, launchSpec spec.LaunchSpec, mdsClient *metadata.Client, tpm io.ReadWriteCloser, logger logging.Logger, serialConsole *os.File, googleClient *http.Client, opts ...option.ClientOption) (*ContainerRunner, error) {
+	image, err := initImage(ctx, cdClient, launchSpec, token, googleClient)
 	if err != nil {
 		return nil, err
 	}
@@ -304,7 +307,7 @@ func NewRunner(ctx context.Context, cdClient *containerd.Client, token oauth2.To
 
 		// Fetch impersonated ID tokens.
 		for _, sa := range launchSpec.ImpersonateServiceAccounts {
-			idToken, err := FetchImpersonatedToken(ctx, sa, audience)
+			idToken, err := FetchImpersonatedToken(ctx, sa, audience, opts...)
 			if err != nil {
 				return nil, fmt.Errorf("failed to get impersonated token for %v: %w", sa, err)
 			}
@@ -320,7 +323,7 @@ func NewRunner(ctx context.Context, cdClient *containerd.Client, token oauth2.To
 	if launchSpec.FakeVerifierEnabled {
 		verifierClient = fake.NewClient(nil)
 	} else if launchSpec.ITAConfig.ITARegion == "" {
-		gcaClient, err := util.NewRESTClient(ctx, asAddr, launchSpec.ProjectID, launchSpec.Region)
+		gcaClient, err := util.NewRESTClient(ctx, asAddr, launchSpec.ProjectID, launchSpec.Region, opts...)
 		if err != nil {
 			if !launchSpec.DisableGcaRefresh {
 				return nil, fmt.Errorf("failed to create REST verifier client: %v", err)
@@ -334,7 +337,7 @@ func NewRunner(ctx context.Context, cdClient *containerd.Client, token oauth2.To
 	}
 
 	// Create a new signaturediscovery client to fetch signatures.
-	sdClient := getSignatureDiscoveryClient(cdClient, mdsClient, image.Target())
+	sdClient := getSignatureDiscoveryClient(cdClient, mdsClient, image.Target(), googleClient)
 
 	exps := agent.Experiments{
 		EnableAttestationEvidence: launchSpec.Experiments.EnableAttestationEvidence,
@@ -362,6 +365,7 @@ func NewRunner(ctx context.Context, cdClient *containerd.Client, token oauth2.To
 		nvidiaAttester,
 		serialConsole,
 		powerButton,
+		opts,
 	}, nil
 }
 
@@ -390,9 +394,9 @@ func enableMonitoring(enabled spec.MonitoringType, logger logging.Logger) error 
 	return nil
 }
 
-func getSignatureDiscoveryClient(cdClient *containerd.Client, mdsClient *metadata.Client, imageDesc v1.Descriptor) signaturediscovery.Fetcher {
+func getSignatureDiscoveryClient(cdClient *containerd.Client, mdsClient *metadata.Client, imageDesc v1.Descriptor, googleHTTPClient *http.Client) signaturediscovery.Fetcher {
 	resolverFetcher := func(ctx context.Context) (remotes.Resolver, error) {
-		return registryauth.RefreshResolver(ctx, mdsClient)
+		return registryauth.RefreshResolver(ctx, mdsClient, googleHTTPClient)
 	}
 	imageFetcher := func(ctx context.Context, imageRef string, opts ...containerd.RemoteOpt) (containerd.Image, error) {
 		image, err := pullImageWithRetries(
@@ -753,7 +757,7 @@ func (r *ContainerRunner) Run(ctx context.Context) error {
 
 		attestClients.ITA = itaClient
 	} else {
-		gcaClient, err := util.NewRESTClient(ctx, r.launchSpec.GcaAddress, r.launchSpec.ProjectID, r.launchSpec.Region)
+		gcaClient, err := util.NewRESTClient(ctx, r.launchSpec.GcaAddress, r.launchSpec.ProjectID, r.launchSpec.Region, r.clientOpts...)
 		if err != nil {
 			if !r.launchSpec.DisableGcaRefresh {
 				return fmt.Errorf("failed to create REST verifier client: %v", err)
@@ -906,27 +910,23 @@ func pullImageWithRetries(f func() (containerd.Image, error), retry func() backo
 	return image, nil
 }
 
-func initImage(ctx context.Context, cdClient *containerd.Client, launchSpec spec.LaunchSpec, token oauth2.Token) (containerd.Image, error) {
+func initImage(ctx context.Context, cdClient *containerd.Client, launchSpec spec.LaunchSpec, token oauth2.Token, googleClient *http.Client) (containerd.Image, error) {
+	var accessToken string
 	if token.Valid() {
-		remoteOpt := containerd.WithResolver(registryauth.Resolver(token.AccessToken))
-		image, err := pullImageWithRetries(
-			func() (containerd.Image, error) {
-				return cdClient.Pull(ctx, launchSpec.ImageRef, containerd.WithPullUnpack, remoteOpt)
-			},
-			pullImageBackoffPolicy,
-		)
-		if err != nil {
-			return nil, fmt.Errorf("cannot pull the image: %w", err)
-		}
-		return image, nil
+		accessToken = token.AccessToken
 	}
+
+	remoteOpt := containerd.WithResolver(registryauth.Resolver(accessToken, googleClient))
 	image, err := pullImageWithRetries(
 		func() (containerd.Image, error) {
-			return cdClient.Pull(ctx, launchSpec.ImageRef, containerd.WithPullUnpack)
+			return cdClient.Pull(ctx, launchSpec.ImageRef, containerd.WithPullUnpack, remoteOpt)
 		},
 		pullImageBackoffPolicy,
 	)
 	if err != nil {
+		if accessToken != "" {
+			return nil, fmt.Errorf("cannot pull the image: %w", err)
+		}
 		return nil, fmt.Errorf("cannot pull the image (no token, only works for a public image): %w", err)
 	}
 	return image, nil

--- a/launcher/container_runner_test.go
+++ b/launcher/container_runner_test.go
@@ -7,6 +7,7 @@ import (
 	"crypto/rsa"
 	"errors"
 	"fmt"
+	"net/http"
 	"os"
 	"path"
 	"strconv"
@@ -647,7 +648,7 @@ func TestInitImageDockerPublic(t *testing.T) {
 	ctx := namespaces.WithNamespace(context.Background(), "test")
 	// This is a "valid" token (formatwise)
 	validToken := oauth2.Token{AccessToken: "000000", Expiry: time.Now().Add(time.Hour)}
-	if _, err := initImage(ctx, containerdClient, spec.LaunchSpec{ImageRef: "docker.io/library/hello-world:latest"}, validToken); err != nil {
+	if _, err := initImage(ctx, containerdClient, spec.LaunchSpec{ImageRef: "docker.io/library/hello-world:latest"}, validToken, http.DefaultClient); err != nil {
 		t.Error(err)
 	} else {
 		if err := containerdClient.ImageService().Delete(ctx, "docker.io/library/hello-world:latest"); err != nil {
@@ -656,7 +657,7 @@ func TestInitImageDockerPublic(t *testing.T) {
 	}
 
 	invalidToken := oauth2.Token{}
-	if _, err := initImage(ctx, containerdClient, spec.LaunchSpec{ImageRef: "docker.io/library/hello-world:latest"}, invalidToken); err != nil {
+	if _, err := initImage(ctx, containerdClient, spec.LaunchSpec{ImageRef: "docker.io/library/hello-world:latest"}, invalidToken, http.DefaultClient); err != nil {
 		t.Error(err)
 	} else {
 		if err := containerdClient.ImageService().Delete(ctx, "docker.io/library/hello-world:latest"); err != nil {

--- a/launcher/google_roots.go
+++ b/launcher/google_roots.go
@@ -1,0 +1,61 @@
+// Package launcher provides the entry point and core orchestration logic for the TEE container launcher.
+package launcher
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"fmt"
+	"net/http"
+	"os"
+)
+
+// GoogleRootsPath is the path to the Google roots PEM file on the OEM partition.
+const GoogleRootsPath = "/usr/share/oem/google_roots.pem"
+
+// GoogleHTTPClient creates an HTTP client that only trusts the roots required for connecting to Google.
+func GoogleHTTPClient() (*http.Client, error) {
+	return googleHTTPClientWithRoots(GoogleRootsPath)
+}
+
+// googleHTTPClientWithRoots allows internal tests to inject mock certificate paths.
+func googleHTTPClientWithRoots(rootsPath string) (*http.Client, error) {
+	pool, err := loadCertPool(rootsPath)
+	if err != nil {
+		return nil, err
+	}
+
+	// We copy the default transport so we get all the proxy, keep-alive,
+	// and timeout default settings, but overwrite the TLSClientConfig.RootCAs.
+	defaultTransport, ok := http.DefaultTransport.(*http.Transport)
+	if !ok {
+		return nil, fmt.Errorf("http.DefaultTransport is not of type *http.Transport")
+	}
+
+	customTransport := defaultTransport.Clone()
+	if customTransport.TLSClientConfig == nil {
+		customTransport.TLSClientConfig = &tls.Config{}
+	}
+	customTransport.TLSClientConfig.RootCAs = pool
+
+	return &http.Client{
+		Transport: customTransport,
+	}, nil
+}
+
+// GoogleCertPool loads the Google root certificates into an x509.CertPool.
+func GoogleCertPool() (*x509.CertPool, error) {
+	return loadCertPool(GoogleRootsPath)
+}
+
+func loadCertPool(rootsPath string) (*x509.CertPool, error) {
+	rootsPEM, err := os.ReadFile(rootsPath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read Google roots bundle at %q: %w", rootsPath, err)
+	}
+
+	pool := x509.NewCertPool()
+	if ok := pool.AppendCertsFromPEM(rootsPEM); !ok {
+		return nil, fmt.Errorf("failed to parse Google roots bundle from %q: no valid certificates found", rootsPath)
+	}
+	return pool, nil
+}

--- a/launcher/google_roots_test.go
+++ b/launcher/google_roots_test.go
@@ -1,0 +1,138 @@
+package launcher
+
+import (
+	"net/http"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestGoogleHTTPClientWithRoots(t *testing.T) {
+	t.Run("empty path", func(t *testing.T) {
+		_, err := googleHTTPClientWithRoots("")
+		if err == nil {
+			t.Errorf("googleHTTPClientWithRoots() expected error for empty path, got nil")
+		}
+	})
+
+	t.Run("missing file", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "missing.pem")
+		_, err := googleHTTPClientWithRoots(path)
+		if err == nil {
+			t.Errorf("googleHTTPClientWithRoots() expected error for missing file, got nil")
+		}
+	})
+
+	t.Run("malformed pem", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "malformed.pem")
+		if err := os.WriteFile(path, []byte("-----BEGIN CERTIFICATE-----\nBAD\n-----END CERTIFICATE-----"), 0644); err != nil {
+			t.Fatalf("failed to create malformed file: %v", err)
+		}
+
+		_, err := googleHTTPClientWithRoots(path)
+		if err == nil {
+			t.Errorf("googleHTTPClientWithRoots() expected error for malformed pem, got nil")
+		}
+	})
+
+	t.Run("valid pem", func(t *testing.T) {
+		validPEM := `-----BEGIN CERTIFICATE-----
+MIIDczCCAlugAwIBAgIUC1mdNsdB4jmUzAB7WdcMybyxXI8wDQYJKoZIhvcNAQEL
+BQAwSTELMAkGA1UEBhMCVVMxCzAJBgNVBAgMAkNBMQswCQYDVQQHDAJTRjENMAsG
+A1UECgwEVGVzdDERMA8GA1UEAwwIdGVzdC5jb20wHhcNMjYwNjA0MTgyMjAwWhcN
+MjcwNjA0MTgyMjAwWjBJMQswCQYDVQQGEwJVUzELMAkGA1UECAwCQ0ExCzAJBgNV
+BAcMAlNGMQ0wCwYDVQQKDARUZXN0MREwDwYDVQQDDAh0ZXN0LmNvbTCCASIwDQYJ
+KoZIhvcNAQEBBQADggEPADCCAQoCggEBANKeU3d0HUzqx/4uONKgsnK+1GzvxqOI
+rSL/CDez53MiPAnnRdc6EJHR0OTzjbCXyfWL1vFcMMbYHT1uT8KM106c56vwYObb
+TRxcA3WNImbCFRLCKrGQilBoEJYfwGee1ickMb1NbrlFWEtXa+GT9WLKLcg0lWen
+2bdf4E7gghwkNj4Cub9TBF6vZSvbHwm8Ih/KLGgP985HNHiYAAwAkLAQ8iO+x2oU
+O/JZqeIv0mLHgIvlbrv5pdF3Oo/d5PkRVS4lqgXH9BAfsf64T7VEb4AWmkadXgVo
+/jlm7jBLT165zGfqpAtY525kABiYGD/uIeqzoEfP7h9XOBGI8PLaN7cCAwEAAaNT
+MFEwHQYDVR0OBBYEFGoh2THvsCQMut95N5cfF92FUwyJMB8GA1UdIwQYMBaAFGoh
+2THvsCQMut95N5cfF92FUwyJMA8GA1UdEwEB/wQFMAMBAf8wDQYJKoZIhvcNAQEL
+BQADggEBAJx+/18F/QHmhDHp2mf+7quqsYX3fKjRwKv/jXUvPiSk12pI3LeeaSyz
+YbGr8fOrLfVRQLPKnT0jHD/Jzns+nZT48QDYWO3CGWV7M2xi/FZA8t5I0JqE0nq6
+qZb1AdGtsNJVOKd/brKufZtz4gw1MtyVoHKBtfJQ231iaUkJlULMoXkdmvK0j+2F
+Y0qMAYDF3rfMMENrUpLt9ptzTeSMgwDX/uQch1oH0BYp40jqaTHzTmueNrXfvU+E
+/VhcGdpik2wHW94NfXEH5hp+54AI3wEQ8F3e4U86ZeI0Flt11Cz+yrG/7A0PjHqY
+OAMM+8xw+XONUalCCur/u3GfKPMBqvk=
+-----END CERTIFICATE-----`
+
+		path := filepath.Join(t.TempDir(), "valid.pem")
+		if err := os.WriteFile(path, []byte(validPEM), 0644); err != nil {
+			t.Fatalf("failed to create valid pem file: %v", err)
+		}
+
+		client, err := googleHTTPClientWithRoots(path)
+		if err != nil {
+			t.Fatalf("googleHTTPClientWithRoots() failed for valid pem: %v", err)
+		}
+
+		// Verify the underlying transport has TLS config set
+		transport, ok := client.Transport.(*http.Transport)
+		if !ok {
+			t.Fatalf("client.Transport is not *http.Transport")
+		}
+		if transport.TLSClientConfig == nil {
+			t.Fatalf("transport.TLSClientConfig is nil")
+		}
+		if transport.TLSClientConfig.RootCAs == nil {
+			t.Fatalf("transport.TLSClientConfig.RootCAs is nil")
+		}
+	})
+}
+
+func TestLoadCertPool(t *testing.T) {
+	t.Run("empty path", func(t *testing.T) {
+		_, err := loadCertPool("")
+		if err == nil {
+			t.Errorf("loadCertPool() expected error for empty path, got nil")
+		}
+	})
+
+	t.Run("missing file", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "missing.pem")
+		_, err := loadCertPool(path)
+		if err == nil {
+			t.Errorf("loadCertPool() expected error for missing file, got nil")
+		}
+	})
+
+	t.Run("valid pem", func(t *testing.T) {
+		validPEM := `-----BEGIN CERTIFICATE-----
+MIIDczCCAlugAwIBAgIUC1mdNsdB4jmUzAB7WdcMybyxXI8wDQYJKoZIhvcNAQEL
+BQAwSTELMAkGA1UEBhMCVVMxCzAJBgNVBAgMAkNBMQswCQYDVQQHDAJTRjENMAsG
+A1UECgwEVGVzdDERMA8GA1UEAwwIdGVzdC5jb20wHhcNMjYwNjA0MTgyMjAwWhcN
+MjcwNjA0MTgyMjAwWjBJMQswCQYDVQQGEwJVUzELMAkGA1UECAwCQ0ExCzAJBgNV
+BAcMAlNGMQ0wCwYDVQQKDARUZXN0MREwDwYDVQQDDAh0ZXN0LmNvbTCCASIwDQYJ
+KoZIhvcNAQEBBQADggEPADCCAQoCggEBANKeU3d0HUzqx/4uONKgsnK+1GzvxqOI
+rSL/CDez53MiPAnnRdc6EJHR0OTzjbCXyfWL1vFcMMbYHT1uT8KM106c56vwYObb
+TRxcA3WNImbCFRLCKrGQilBoEJYfwGee1ickMb1NbrlFWEtXa+GT9WLKLcg0lWen
+2bdf4E7gghwkNj4Cub9TBF6vZSvbHwm8Ih/KLGgP985HNHiYAAwAkLAQ8iO+x2oU
+O/JZqeIv0mLHgIvlbrv5pdF3Oo/d5PkRVS4lqgXH9BAfsf64T7VEb4AWmkadXgVo
+/jlm7jBLT165zGfqpAtY525kABiYGD/uIeqzoEfP7h9XOBGI8PLaN7cCAwEAAaNT
+MFEwHQYDVR0OBBYEFGoh2THvsCQMut95N5cfF92FUwyJMB8GA1UdIwQYMBaAFGoh
+2THvsCQMut95N5cfF92FUwyJMA8GA1UdEwEB/wQFMAMBAf8wDQYJKoZIhvcNAQEL
+BQADggEBAJx+/18F/QHmhDHp2mf+7quqsYX3fKjRwKv/jXUvPiSk12pI3LeeaSyz
+YbGr8fOrLfVRQLPKnT0jHD/Jzns+nZT48QDYWO3CGWV7M2xi/FZA8t5I0JqE0nq6
+qZb1AdGtsNJVOKd/brKufZtz4gw1MtyVoHKBtfJQ231iaUkJlULMoXkdmvK0j+2F
+Y0qMAYDF3rfMMENrUpLt9ptzTeSMgwDX/uQch1oH0BYp40jqaTHzTmueNrXfvU+E
+/VhcGdpik2wHW94NfXEH5hp+54AI3wEQ8F3e4U86ZeI0Flt11Cz+yrG/7A0PjHqY
+OAMM+8xw+XONUalCCur/u3GfKPMBqvk=
+-----END CERTIFICATE-----`
+
+		path := filepath.Join(t.TempDir(), "valid.pem")
+		if err := os.WriteFile(path, []byte(validPEM), 0644); err != nil {
+			t.Fatalf("failed to create valid pem file: %v", err)
+		}
+
+		pool, err := loadCertPool(path)
+		if err != nil {
+			t.Fatalf("loadCertPool() failed for valid pem: %v", err)
+		}
+
+		if pool == nil {
+			t.Fatalf("loadCertPool() returned nil pool")
+		}
+	})
+}

--- a/launcher/image/bc_cloudbuild.yaml
+++ b/launcher/image/bc_cloudbuild.yaml
@@ -77,6 +77,7 @@ steps:
            /workspace/oem-install/confidential_space/
         cp ./launcher/image/nodeproblemdetector/* /workspace/oem-install/confidential_space/nodeproblemdetector/
         cp ./launcher/image/bc-guest/wsd/* /workspace/oem-install/wsd/
+        cp ./launcher/image/google_roots.pem /workspace/oem-install/google_roots.pem
 
         # Extract WSD rootfs
         if [ -f /workspace/wsd_rootfs.tar ]; then

--- a/launcher/image/fluent-bit-cs.conf
+++ b/launcher/image/fluent-bit-cs.conf
@@ -63,3 +63,6 @@
     Match       *
     Resource    gce_instance
     severity_key severity
+    tls         On
+    tls.ca_file /usr/share/oem/google_roots.pem
+

--- a/launcher/image/preload.sh
+++ b/launcher/image/preload.sh
@@ -8,6 +8,9 @@ copy_launcher() {
   cp launcher "${CS_PATH}/cs_container_launcher"
 }
 
+copy_google_roots() {
+  cp google_roots.pem "${OEM_PATH}/google_roots.pem"
+}
 copy_experiment_client() {
   # DownloadExpBinary creates the file at EXPERIMENTS_BINARY.
   cp $EXPERIMENTS_BINARY "${CS_PATH}/${EXPERIMENTS_BINARY}"
@@ -115,6 +118,8 @@ main() {
   copy_experiment_client
   # Install container launcher.
   copy_launcher
+  # Copy Google Root bundle.
+  copy_google_roots
   setup_launcher_systemd_unit
   # Minimum required COS version for 'e': cos-dev-105-17222-0-0.
   # Minimum required COS version for 'm': cos-dev-113-18203-0-0.

--- a/launcher/image/vgpreload.sh
+++ b/launcher/image/vgpreload.sh
@@ -7,6 +7,10 @@ copy_launcher() {
   cp launcher "${CS_PATH}/cs_container_launcher"
 }
 
+copy_google_roots() {
+  cp google_roots.pem "${OEM_PATH}/google_roots.pem"
+}
+
 copy_gpu_driver() {
   mkdir ${OEM_PATH}/gpu_driver
   cp NVIDIA-Linux-x86_64-595.58.03.run ${OEM_PATH}/gpu_driver
@@ -120,6 +124,8 @@ main() {
   copy_experiment_file
   # Install container launcher.
   copy_launcher
+  # Copy Google Root bundle.
+  copy_google_roots
   setup_launcher_systemd_unit
   # Minimum required COS version for 'e': cos-dev-105-17222-0-0.
   # Minimum required COS version for 'm': cos-dev-113-18203-0-0.

--- a/launcher/internal/logging/logging.go
+++ b/launcher/internal/logging/logging.go
@@ -4,13 +4,18 @@ package logging
 
 import (
 	"context"
+	"crypto/tls"
+	"crypto/x509"
 	"fmt"
 	"log/slog"
 	"os"
 
 	"cloud.google.com/go/compute/metadata"
 	clogging "cloud.google.com/go/logging"
+	"google.golang.org/api/option"
 	mrpb "google.golang.org/genproto/googleapis/api/monitoredres"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials"
 )
 
 const (
@@ -51,7 +56,7 @@ type logger struct {
 type payload map[string]any
 
 // NewLogger returns a Logger with Cloud and Serial Console logging configured.
-func NewLogger(ctx context.Context) (Logger, error) {
+func NewLogger(ctx context.Context, pool *x509.CertPool) (Logger, error) {
 	// Retrieve monitored resource information.
 	mdsClient := metadata.NewClient(nil)
 
@@ -76,7 +81,15 @@ func NewLogger(ctx context.Context) (Logger, error) {
 	}
 
 	// Configure Cloud Logging client/logger.
-	cloggingClient, err := clogging.NewClient(ctx, projectID)
+	var opts []option.ClientOption
+	if pool != nil {
+		creds := credentials.NewTLS(&tls.Config{
+			RootCAs: pool,
+		})
+		opts = append(opts, option.WithGRPCDialOption(grpc.WithTransportCredentials(creds)))
+	}
+
+	cloggingClient, err := clogging.NewClient(ctx, projectID, opts...)
 	if err != nil {
 		return nil, err
 	}

--- a/launcher/internal/rest_network_test.go
+++ b/launcher/internal/rest_network_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/google/go-tpm-tools/verifier/util"
 	"golang.org/x/oauth2"
 	"golang.org/x/oauth2/google"
+	"google.golang.org/api/option"
 )
 
 func TestNewRESTClient(t *testing.T) {
@@ -37,7 +38,12 @@ func TestNewRESTClient(t *testing.T) {
 	}
 	defer mockAttestationServer.Stop()
 
-	restClient, err := util.NewRESTClient(ctx, mockAttestationServer.Server.URL, "test-project", "us-central")
+	httpClient, err := google.DefaultClient(ctx)
+	if err != nil {
+		t.Errorf("Failed to create HTTP client %s", err)
+	}
+
+	restClient, err := util.NewRESTClient(ctx, mockAttestationServer.Server.URL, "test-project", "us-central", option.WithHTTPClient(httpClient))
 	if err != nil {
 		t.Errorf("Failed to create rest client %s", err)
 	}

--- a/launcher/internal/signaturediscovery/client_test.go
+++ b/launcher/internal/signaturediscovery/client_test.go
@@ -3,6 +3,7 @@ package signaturediscovery
 import (
 	"context"
 	"fmt"
+	"net/http"
 	"testing"
 
 	"github.com/containerd/containerd"
@@ -110,7 +111,7 @@ func TestPullSignatureImage(t *testing.T) {
 		{
 			name: "valid resolver",
 			resolverFetcher: func(_ context.Context) (remotes.Resolver, error) {
-				return registryauth.Resolver("valid access"), nil
+				return registryauth.Resolver("valid access", http.DefaultClient), nil
 			},
 			wantErr: false,
 		},
@@ -155,7 +156,7 @@ func createTestClient(t *testing.T, originalImageDesc v1.Descriptor) *Client {
 	t.Cleanup(func() { containerdClient.Close() })
 
 	resolverFetcher := func(_ context.Context) (remotes.Resolver, error) {
-		return registryauth.Resolver("valid token"), nil
+		return registryauth.Resolver("valid token", http.DefaultClient), nil
 	}
 	imageFetcher := func(ctx context.Context, imageRef string, opts ...containerd.RemoteOpt) (containerd.Image, error) {
 		return containerdClient.Pull(ctx, imageRef, opts...)

--- a/launcher/launcher/main.go
+++ b/launcher/launcher/main.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"log"
+	"net/http"
 	"os"
 	"os/exec"
 	"regexp"
@@ -27,6 +28,7 @@ import (
 	"github.com/google/go-tpm-tools/launcher/registryauth"
 	"github.com/google/go-tpm-tools/launcher/spec"
 	"github.com/google/go-tpm/legacy/tpm2"
+	"google.golang.org/api/option"
 )
 
 const (
@@ -77,7 +79,24 @@ func main() {
 		os.Exit(exitCode)
 	}()
 
-	logger, err = logging.NewLogger(ctx)
+	googleClient, err := launcher.GoogleHTTPClient()
+	if err != nil {
+		log.Default().Printf("Failed to initialize Google root HTTP client: %v", err)
+		exitCode = failRC
+		log.Default().Printf("%s, exit code: %d (%s)\n", exitMessage, exitCode, rcMessage[exitCode])
+		return
+	}
+	clientOpts := []option.ClientOption{option.WithHTTPClient(googleClient)}
+
+	pool, err := launcher.GoogleCertPool()
+	if err != nil {
+		log.Default().Printf("Failed to load Google root certificates: %v", err)
+		exitCode = failRC
+		log.Default().Printf("%s, exit code: %d (%s)\n", exitMessage, exitCode, rcMessage[exitCode])
+		return
+	}
+
+	logger, err = logging.NewLogger(ctx, pool)
 	if err != nil {
 		log.Default().Printf("failed to initialize logging: %v", err)
 		exitCode = failRC
@@ -124,7 +143,7 @@ func main() {
 			logger.Info(exitMessage, "exit_code", exitCode)
 		}
 	}()
-	if err = startLauncher(launchSpec, logger.SerialConsoleFile()); err != nil {
+	if err = startLauncher(launchSpec, logger.SerialConsoleFile(), googleClient, clientOpts...); err != nil {
 		logger.Error(err.Error())
 	}
 
@@ -184,7 +203,7 @@ func getUptime() (string, error) {
 	return string(split[0]), nil
 }
 
-func startLauncher(launchSpec spec.LaunchSpec, serialConsole *os.File) error {
+func startLauncher(launchSpec spec.LaunchSpec, serialConsole *os.File, googleClient *http.Client, clientOpts ...option.ClientOption) error {
 	logger.Info(fmt.Sprintf("Launch Spec: %+v", launchSpec.LogFriendly()))
 	containerdClient, err := containerd.New(defaults.DefaultAddress)
 	if err != nil {
@@ -227,7 +246,7 @@ func startLauncher(launchSpec spec.LaunchSpec, serialConsole *os.File) error {
 	logger.Info("Launch started", "duration_sec", time.Since(start).Seconds())
 
 	// tpm is nil when running in BC mode.
-	r, err := launcher.NewRunner(ctx, containerdClient, token, launchSpec, mdsClient, tpm, logger, serialConsole)
+	r, err := launcher.NewRunner(ctx, containerdClient, token, launchSpec, mdsClient, tpm, logger, serialConsole, googleClient, clientOpts...)
 	if err != nil {
 		return err
 	}

--- a/launcher/registryauth/auth.go
+++ b/launcher/registryauth/auth.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net/http"
 	"strings"
 
 	"cloud.google.com/go/compute/metadata"
@@ -30,8 +31,9 @@ func RetrieveAuthToken(ctx context.Context, client *metadata.Client) (oauth2.Tok
 }
 
 // Resolver returns a custom resolver that can use the token to authenticate with
-// the repo.
-func Resolver(token string) remotes.Resolver {
+// the repo, and forces Google Artifact/Container registry to use the custom Google
+// HTTP client with pinned roots.
+func Resolver(token string, googleClient *http.Client) remotes.Resolver {
 	options := docker.ResolverOptions{}
 
 	credentials := func(host string) (string, string, error) {
@@ -43,7 +45,25 @@ func Resolver(token string) remotes.Resolver {
 	}
 	authOpts := []docker.AuthorizerOpt{docker.WithAuthCreds(credentials)}
 	//nolint:staticcheck
-	options.Authorizer = docker.NewDockerAuthorizer(authOpts...)
+	authorizer := docker.NewDockerAuthorizer(authOpts...)
+
+	// Construct the handlers once upfront
+	defaultHosts := docker.ConfigureDefaultRegistries(
+		docker.WithAuthorizer(authorizer),
+	)
+	googleHosts := docker.ConfigureDefaultRegistries(
+		docker.WithAuthorizer(authorizer),
+		docker.WithClient(googleClient),
+	)
+
+	options.Hosts = func(host string) ([]docker.RegistryHost, error) {
+		// Delegate to the pinned Google client handler for Google artifact registries
+		if strings.HasSuffix(host, "docker.pkg.dev") || host == "pkg.dev" || host == "gcr.io" || strings.HasSuffix(host, ".gcr.io") {
+			return googleHosts(host)
+		}
+		// Fallback to the default OS trust store handler for all other registries
+		return defaultHosts(host)
+	}
 
 	return docker.NewResolver(options)
 }
@@ -51,14 +71,14 @@ func Resolver(token string) remotes.Resolver {
 // RefreshResolver takes in a metadata server client, uses it to refresh the default service
 // account token, and returns a custom resolver that can use the token to authenticate with
 // the repo.
-func RefreshResolver(ctx context.Context, client *metadata.Client) (remotes.Resolver, error) {
+func RefreshResolver(ctx context.Context, client *metadata.Client, googleClient *http.Client) (remotes.Resolver, error) {
 	token, err := RetrieveAuthToken(ctx, client)
 	if err != nil {
 		return nil, fmt.Errorf("failed to retrieve auth token from metadata server: %v", err)
 	}
 
 	if token.Valid() {
-		return Resolver(token.AccessToken), nil
+		return Resolver(token.AccessToken, googleClient), nil
 	}
 
 	return nil, fmt.Errorf("invalid token from metadata server: %v", token)

--- a/verifier/util/util.go
+++ b/verifier/util/util.go
@@ -12,7 +12,6 @@ import (
 	"github.com/google/go-tpm-tools/client"
 	"github.com/google/go-tpm-tools/verifier"
 	"github.com/google/go-tpm-tools/verifier/rest"
-	"golang.org/x/oauth2/google"
 	"google.golang.org/api/option"
 )
 
@@ -41,13 +40,7 @@ func PrincipalFetcher(audience string, mdsClient *metadata.Client) ([][]byte, er
 // NewRESTClient returns a REST verifier.Client that points to the given address.
 // It defaults to the Attestation Verifier instance at
 // https://confidentialcomputing.googleapis.com.
-func NewRESTClient(ctx context.Context, asAddr string, ProjectID string, Region string) (verifier.Client, error) {
-	httpClient, err := google.DefaultClient(ctx)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create HTTP client: %v", err)
-	}
-
-	opts := []option.ClientOption{option.WithHTTPClient(httpClient)}
+func NewRESTClient(ctx context.Context, asAddr string, ProjectID string, Region string, opts ...option.ClientOption) (verifier.Client, error) {
 	if asAddr != "" {
 		opts = append(opts, option.WithEndpoint(asAddr))
 	}


### PR DESCRIPTION
 This change creates a HTTP client configured with `pki.goog/roots.pem` as
 its trust bundle ensuring rogue CAs cannot be used to MiTM connections
 to Google owned services from the launcher.

 During image compilation, `roots.pem` is dropped into the OEM partition
 and used by all Gcloud SDK calls.