### PR TITLE
launcher/teeserver: return 400 for AWS_PRINCIPALTAGS without aws_principal_tag_options

### DIFF
--- a/launcher/teeserver/tee_server.go
+++ b/launcher/teeserver/tee_server.go
@@ -384,6 +384,16 @@ func (a *attestHandler) attest(w http.ResponseWriter, r *http.Request, client ve
 			return
 		}
 
+		// The AWS_PRINCIPALTAGS token type cannot be served without its companion
+		// aws_principal_tag_options. Reject the request here with a 400 instead of
+		// forwarding it downstream, where the missing field surfaces as a closed
+		// connection with no HTTP response (empty reply) rather than a clean error.
+		if tokenOptions.TokenType == "AWS_PRINCIPALTAGS" && tokenOptions.PrincipalTagOptions == nil {
+			err := fmt.Errorf("aws_principal_tag_options is required when token_type=AWS_PRINCIPALTAGS")
+			a.logAndWriteHTTPError(w, http.StatusBadRequest, err)
+			return
+		}
+
 		// Do not check that TokenTypeOptions matches TokenType in the launcher.
 		opts := agent.AttestAgentOpts{
 			TokenOptions:     &tokenOptions,

--- a/launcher/teeserver/tee_server_test.go
+++ b/launcher/teeserver/tee_server_test.go
@@ -174,6 +174,7 @@ func TestCustomToken(t *testing.T) {
 		body                 string
 		attestWithClientFunc func(context.Context, agent.AttestAgentOpts, verifier.Client) ([]byte, error)
 		want                 int
+		wantBodyContains     string
 	}{
 		{
 			testName: "TestNoAudiencePostRequest",
@@ -244,6 +245,51 @@ func TestCustomToken(t *testing.T) {
 			},
 			want: http.StatusOK,
 		},
+		{
+			testName: "TestAwsPrincipalTagsMissingOptions",
+			body: `{
+				"audience": "https://x",
+				"token_type": "AWS_PRINCIPALTAGS"
+			}`,
+			attestWithClientFunc: func(context.Context, agent.AttestAgentOpts, verifier.Client) ([]byte, error) {
+				t.Errorf("This method should not be called")
+				return nil, nil
+			},
+			want:             http.StatusBadRequest,
+			wantBodyContains: "aws_principal_tag_options is required when token_type=AWS_PRINCIPALTAGS",
+		},
+		{
+			testName: "TestAwsPrincipalTagsMissingOptionsWithNonces",
+			body: `{
+				"audience": "https://x",
+				"token_type": "AWS_PRINCIPALTAGS",
+				"nonces": ["AAAA1111AAAA1111AAAA1111AAAA1111AAAA1111A"]
+			}`,
+			attestWithClientFunc: func(context.Context, agent.AttestAgentOpts, verifier.Client) ([]byte, error) {
+				t.Errorf("This method should not be called")
+				return nil, nil
+			},
+			want:             http.StatusBadRequest,
+			wantBodyContains: "aws_principal_tag_options is required when token_type=AWS_PRINCIPALTAGS",
+		},
+		{
+			testName: "TestAwsPrincipalTagsWithOptionsSucceeds",
+			body: `{
+				"audience": "https://x",
+				"token_type": "AWS_PRINCIPALTAGS",
+				"aws_principal_tag_options": {
+					"allowed_principal_tags": {
+						"container_image_signatures": {
+							"key_ids": ["test1"]
+						}
+					}
+				}
+			}`,
+			attestWithClientFunc: func(context.Context, agent.AttestAgentOpts, verifier.Client) ([]byte, error) {
+				return []byte{}, nil
+			},
+			want: http.StatusOK,
+		},
 	}
 
 	verifiers := []struct {
@@ -283,13 +329,17 @@ func TestCustomToken(t *testing.T) {
 
 				vf.tokenMethod(&ah, w, req)
 
-				_, err := io.ReadAll(w.Result().Body)
+				bodyBytes, err := io.ReadAll(w.Result().Body)
 				if err != nil {
 					t.Error(err)
 				}
 
 				if w.Code != test.want {
 					t.Errorf("testcase '%v': got return code: %d, want: %d", test.testName, w.Code, test.want)
+				}
+
+				if test.wantBodyContains != "" && !strings.Contains(string(bodyBytes), test.wantBodyContains) {
+					t.Errorf("testcase '%v': response body %q does not contain %q", test.testName, string(bodyBytes), test.wantBodyContains)
 				}
 			}
 		})


### PR DESCRIPTION
Fixes #770

## Problem

A `POST /v1/token` with `token_type=AWS_PRINCIPALTAGS` but no companion `aws_principal_tag_options` field is accepted at the launcher boundary and forwarded straight to the attestation path. Downstream the missing field surfaces as a closed Unix-domain-socket connection with no HTTP response, so `curl` reports `Empty reply from server` and `HTTP=000`. Every other malformed request to the same endpoint (empty body, unknown field, missing `token_type`) returns a clean `400 Bad Request`, so this one case makes a request-validation error look like a launcher or socket failure.

In `attest()` (the `/v1/token` POST path), the handler validates JSON parsing, non-empty `audience`, and non-empty `token_type`, then forwards the request via `AttestWithClient`. There is an explicit "Do not check that TokenTypeOptions matches TokenType in the launcher" comment, so `AWS_PRINCIPALTAGS` with a nil `PrincipalTagOptions` is passed through unchecked.

## Fix

Validate the one shape that cannot be served: when `token_type=AWS_PRINCIPALTAGS` and `aws_principal_tag_options` is absent, reject the request at the launcher boundary with `400 Bad Request` and a clear message, using the same `logAndWriteHTTPError` path the handler already uses for other malformed bodies. The valid path (options present) is unchanged, as are all other token types.

```go
if tokenOptions.TokenType == "AWS_PRINCIPALTAGS" && tokenOptions.PrincipalTagOptions == nil {
    err := fmt.Errorf("aws_principal_tag_options is required when token_type=AWS_PRINCIPALTAGS")
    a.logAndWriteHTTPError(w, http.StatusBadRequest, err)
    return
}
```

## Before / after

Request body:

```json
{"audience":"https://x","token_type":"AWS_PRINCIPALTAGS"}
```

- Before: launcher forwards the request downstream; the connection is closed with no HTTP response (empty reply, `HTTP=000`).
- After: `HTTP=400` with body `aws_principal_tag_options is required when token_type=AWS_PRINCIPALTAGS`. The same applies when a `nonces` array is also present.

## Tests

Added table cases to `TestCustomToken` in `launcher/teeserver/tee_server_test.go`:

- `TestAwsPrincipalTagsMissingOptions` and `TestAwsPrincipalTagsMissingOptionsWithNonces` assert `400` and the error-message body, and fail if the attestation path is invoked at all (so the request is rejected at the boundary, not forwarded).
- `TestAwsPrincipalTagsWithOptionsSucceeds` confirms a valid `AWS_PRINCIPALTAGS` request with options still returns `200`.

The test loop now also checks an optional `wantBodyContains` substring. `go test ./teeserver/...` passes; reverting the source change makes the two new cases fail (200 instead of 400, empty body), confirming the tests guard the fix.

## Scope

This is the launcher-boundary validation requested in the issue. The downstream REST conversion (`verifier/rest/rest.go` `setAwsPrincipalTagOptions`) already handles a nil `PrincipalTagOptions` gracefully, so this change is intentionally a narrow guard for the known-broken request shape and does not touch the shared token-conversion code.
