### PR TITLE
bc-guest: apply security hardening

### DIFF
--- a/launcher/image/bc-guest/bcentrypoint.sh
+++ b/launcher/image/bc-guest/bcentrypoint.sh
@@ -1,6 +1,11 @@
 #!/bin/bash
 
 main() {
+  # Set IMA policy
+  if [[ -f /usr/share/oem/ima-policy ]]; then
+    cp /usr/share/oem/ima-policy /sys/kernel/security/ima/policy
+  fi
+
   # Configure sysctls.
   sysctl -w kernel.kexec_load_disabled=1
 

--- a/launcher/image/bc-guest/wsd/wsd_runner.sh
+++ b/launcher/image/bc-guest/wsd/wsd_runner.sh
@@ -10,18 +10,18 @@ fi
 
 echo "=== Launching Workload Service Daemon Container ==="
 
-echo "Importing image from ${IMAGE_PATH}..."
-if [ -f "$IMAGE_PATH" ]; then
-    ctr images import "$IMAGE_PATH"
-else
-    echo "Error: Image file not found at $IMAGE_PATH"
-    exit 1
-fi
-
 echo "Checking for existing container..."
 if ctr container info "$CONTAINER_NAME" >/dev/null 2>&1; then
     echo "Removing existing container..."
     ctr container rm "$CONTAINER_NAME"
 fi
 
-ctr run --rm --net-host --mount "type=bind,src=/tmp/container_launcher/,dst=/run/container_launcher/,options=rbind:rw" --env SERVICE_ROLE="SERVICE_ROLE_WSD" --env KEY_PROTECTION_MECHANISM="KEY_PROTECTION_VM" --env KPS_IP="${KPS_VM_IP}"  "$IMAGE_REF" "$CONTAINER_NAME" agent --kps-vm-ip="${KPS_VM_IP}" --socket="/run/container_launcher/kmaserver.sock"
+ctr run --rm --net-host \
+  --mount "type=bind,src=/tmp/container_launcher/,dst=/run/container_launcher/,options=rbind:rw" \
+  --mount "type=tmpfs,dst=/tmp" \
+  --env SERVICE_ROLE="SERVICE_ROLE_WSD" \
+  --env KEY_PROTECTION_MECHANISM="KEY_PROTECTION_VM" \
+  --env KPS_IP="${KPS_VM_IP}" \
+  --rootfs /usr/share/oem/wsd/rootfs \
+  "$CONTAINER_NAME" \
+  /usr/local/bin/agent --kps-vm-ip="${KPS_VM_IP}" --socket="/run/container_launcher/kmaserver.sock"

--- a/launcher/image/bc_cloudbuild.yaml
+++ b/launcher/image/bc_cloudbuild.yaml
@@ -33,8 +33,9 @@ steps:
       - |
         set -e
         docker pull ${_WSD_CONTAINER_IMAGE_REF}
-        mkdir -p /workspace/wsd_image
-        docker save ${_WSD_CONTAINER_IMAGE_REF} -o /workspace/wsd_image/image.tar
+        container_id=$$(docker create ${_WSD_CONTAINER_IMAGE_REF})
+        docker export "$${container_id}" -o /workspace/wsd_rootfs.tar
+        docker rm "$${container_id}"
   - name: 'alpine'
     id: 'ExtractRawImage'
     args: ['tar', '-xf', './src_image.tar.gz']
@@ -65,12 +66,30 @@ steps:
            /workspace/oem-install/confidential_space/
         cp ./launcher/image/nodeproblemdetector/* /workspace/oem-install/confidential_space/nodeproblemdetector/
         cp ./launcher/image/bc-guest/wsd/* /workspace/oem-install/wsd/
-        if [ -f /workspace/wsd_image/image.tar ]; then
-            cp /workspace/wsd_image/image.tar /workspace/oem-install/wsd/image.tar
+
+        # Extract WSD rootfs
+        if [ -f /workspace/wsd_rootfs.tar ]; then
+          mkdir -p /workspace/oem-install/wsd/rootfs
+          tar -C /workspace/oem-install/wsd/rootfs -xf /workspace/wsd_rootfs.tar
+          mkdir -p /workspace/oem-install/wsd/rootfs/run/container_launcher
+          # Mountpoint needed by containerd
+          mkdir -p /workspace/oem-install/wsd/rootfs/dev/mqueue
         fi
 
+        # Create IMA policy
+        # 0bcd161c-b7c7-40fd-aa70-41f629c63d86 is a static UUID for the stateful
+        # partition
+        cat << 'EOF' > /workspace/oem-install/ima-policy
+        dont_appraise fsname=overlay
+        dont_appraise fsuuid=0bcd161c-b7c7-40fd-aa70-41f629c63d86
+        appraise func=BPRM_CHECK
+        appraise func=FILE_MMAP mask=MAY_EXEC
+        audit func=BPRM_CHECK
+        audit func=FILE_MMAP mask=MAY_EXEC
+        EOF
+
         cat << EOF > /workspace/oem-install/wsd/image.env
-        IMAGE_PATH="/usr/share/oem/wsd/image.tar"
+        IMAGE_PATH="/usr/share/oem/wsd/rootfs"
         IMAGE_REF="${_WSD_CONTAINER_IMAGE_REF}"
         CONTAINER_NAME="workload-service-daemon"
         KPS_VM_IP="192.168.100.3"
@@ -128,6 +147,7 @@ steps:
           "s|cros_efi|cros_efi cos.protected_stateful_partition=m|g"
           "s|cros_efi|cros_efi systemd.default_timeout_start_sec=900s|g"
           "s|cros_efi|cros_efi swiotlb=16777216,force,any|g"
+          "s|cros_efi|cros_efi systemd.mask=cloud-audit-setup.service|g"
           "s|systemd.mask=usr-share-oem.mount||g"
           "s|dm-m2d|dm-mod|g"
           "s|,oemroot|;oemroot|g"
@@ -165,6 +185,7 @@ steps:
 
         CMD=(
           "/oem-preloader"
+          "--ima-mode=hash"
           "--vmlinux=./vmlinux"
           "--src-image=./disk.raw"
           "--out-image=output.bin"


### PR DESCRIPTION
- Run the WSD container from the OEM partition
- Apply IMA labels to the OEM partition
- Set an IMA policy

Tested with build+boot+ssh and checking WSD logs and container-runner logs. WSD appeared healthy and workload ran.