### PR TITLE
[launcher] remove ttys0 from hardened bc image

### DIFF
--- a/launcher/image/bc_cloudbuild.yaml
+++ b/launcher/image/bc_cloudbuild.yaml
@@ -192,6 +192,7 @@ steps:
           "s|cros_efi|cros_efi systemd.mask=var-lib-toolbox.mount|g"
           "s|cros_efi|cros_efi systemd.mask=update-engine.service|g"
           "s|cros_efi|cros_efi confidential-space.hardened=true|g"
+          "s|console=ttyS0,115200||g"
         )
 
         CMD=(


### PR DESCRIPTION
remove ttys0 from cmdline for bc hardened image, as there is no serial device, having this causes certain workload to crash.