### PR TITLE
Best practices - prevent deadlock on runSystemCmd

### DIFF
--- a/launcher/internal/systemctl/systemctl.go
+++ b/launcher/internal/systemctl/systemctl.go
@@ -72,14 +72,14 @@ func runSystemdCmd(cmdFunc func(context.Context, string, string, chan<- string) 
 		return fmt.Errorf("failed to run systemctl [%s] for unit [%s]: %v", cmd, unit, err)
 	}
 
-  select {
-  case result := <-progress:
-	  if result != "done" {
-		  return fmt.Errorf("systemctl [%s] result was [%s], want done", cmd, result)
-	  }
-	  log.Printf("Finished up systemctl [%s] for unit [%s]", cmd, unit)
-	  return nil
-  case <-ctx.Done():
-	  return fmt.Errorf("DBus operation timed out or cancelled: %w", ctx.Err())
-  }
+	select {
+	case result := <-progress:
+		if result != "done" {
+			return fmt.Errorf("systemctl [%s] result was [%s], want done", cmd, result)
+		}
+		log.Printf("Finished up systemctl [%s] for unit [%s]", cmd, unit)
+		return nil
+	case <-ctx.Done():
+		return fmt.Errorf("DBus operation timed out or cancelled: %w", ctx.Err())
+	}
 }

--- a/launcher/internal/systemctl/systemctl.go
+++ b/launcher/internal/systemctl/systemctl.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"time"
 
 	"github.com/coreos/go-systemd/v22/dbus"
 )
@@ -60,6 +61,9 @@ func (s *Systemctl) IsActive(ctx context.Context, unit string) (string, error) {
 func (s *Systemctl) Close() { s.dbus.Close() }
 
 func runSystemdCmd(cmdFunc func(context.Context, string, string, chan<- string) (int, error), cmd string, unit string) error {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
 	progress := make(chan string, 1)
 
 	// Run systemd command in "replace" mode to start the unit and its dependencies,
@@ -68,10 +72,14 @@ func runSystemdCmd(cmdFunc func(context.Context, string, string, chan<- string) 
 		return fmt.Errorf("failed to run systemctl [%s] for unit [%s]: %v", cmd, unit, err)
 	}
 
-	if result := <-progress; result != "done" {
+select {
+case result := <-progress:
+	if result != "done" {
 		return fmt.Errorf("systemctl [%s] result was [%s], want done", cmd, result)
 	}
-
 	log.Printf("Finished up systemctl [%s] for unit [%s]", cmd, unit)
 	return nil
+case <-ctx.Done():
+	return fmt.Errorf("DBus operation timed out or cancelled: %w", ctx.Err())
+}
 }

--- a/launcher/internal/systemctl/systemctl.go
+++ b/launcher/internal/systemctl/systemctl.go
@@ -72,7 +72,7 @@ func runSystemdCmd(cmdFunc func(context.Context, string, string, chan<- string) 
 		return fmt.Errorf("failed to run systemctl [%s] for unit [%s]: %v", cmd, unit, err)
 	}
 
-select {
+  select {
   case result := <-progress:
 	  if result != "done" {
 		  return fmt.Errorf("systemctl [%s] result was [%s], want done", cmd, result)
@@ -81,5 +81,5 @@ select {
 	  return nil
   case <-ctx.Done():
 	  return fmt.Errorf("DBus operation timed out or cancelled: %w", ctx.Err())
-}
+  }
 }

--- a/launcher/internal/systemctl/systemctl.go
+++ b/launcher/internal/systemctl/systemctl.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"time"
 
 	"github.com/coreos/go-systemd/v22/dbus"
 )
@@ -60,6 +61,9 @@ func (s *Systemctl) IsActive(ctx context.Context, unit string) (string, error) {
 func (s *Systemctl) Close() { s.dbus.Close() }
 
 func runSystemdCmd(cmdFunc func(context.Context, string, string, chan<- string) (int, error), cmd string, unit string) error {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
 	progress := make(chan string, 1)
 
 	// Run systemd command in "replace" mode to start the unit and its dependencies,
@@ -68,10 +72,14 @@ func runSystemdCmd(cmdFunc func(context.Context, string, string, chan<- string) 
 		return fmt.Errorf("failed to run systemctl [%s] for unit [%s]: %v", cmd, unit, err)
 	}
 
-	if result := <-progress; result != "done" {
-		return fmt.Errorf("systemctl [%s] result was [%s], want done", cmd, result)
+	select {
+	case result := <-progress:
+		if result != "done" {
+			return fmt.Errorf("systemctl [%s] result was [%s], want done", cmd, result)
+		}
+		log.Printf("Finished up systemctl [%s] for unit [%s]", cmd, unit)
+		return nil
+	case <-ctx.Done():
+		return fmt.Errorf("DBus operation timed out or cancelled: %w", ctx.Err())
 	}
-
-	log.Printf("Finished up systemctl [%s] for unit [%s]", cmd, unit)
-	return nil
 }

--- a/launcher/internal/systemctl/systemctl_test.go
+++ b/launcher/internal/systemctl/systemctl_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"testing"
+	"time"
 )
 
 func TestRunSystmedCmd(t *testing.T) {
@@ -16,6 +17,10 @@ func TestRunSystmedCmd(t *testing.T) {
 	}
 	failedUnitFunc := func(_ context.Context, _, _ string, progress chan<- string) (int, error) {
 		progress <- "failed"
+		return 1, nil
+	}
+	timeoutUnitFunc := func(_ context.Context, _, _ string, _ chan<- string) (int, error) {
+		time.Sleep(35 * time.Second)
 		return 1, nil
 	}
 
@@ -37,6 +42,11 @@ func TestRunSystmedCmd(t *testing.T) {
 		{
 			name:          "failed unit run",
 			sytemdCmdFunc: failedUnitFunc,
+			wantErr:       true,
+		},
+		{
+			name:          "timeout",
+			sytemdCmdFunc: timeoutUnitFunc,
 			wantErr:       true,
 		},
 	}


### PR DESCRIPTION
Add 30 second timeout to launcher