### PR TITLE
Fix wrong test dependency in the log redirection test

### DIFF
--- a/launcher/image/test/test_log_redirection.yaml
+++ b/launcher/image/test/test_log_redirection.yaml
@@ -68,7 +68,7 @@ steps:
   env:
   - 'CLEANUP=$_CLEANUP'
   args: ['cleanup.sh', '${_VM_NAME_PREFIX}-${BUILD_ID}-serial', '${_ZONE}']
-  waitFor: ['LogSerialCheckCloudLoggingTest', 'LogSerialCheckCloudLoggingTest']
+  waitFor: ['LogSerialCheckSerialTest', 'LogSerialCheckCloudLoggingTest']
 
 - name: 'gcr.io/cloud-builders/gcloud'
   id: CreateVMRedirectCloudLogging


### PR DESCRIPTION
Fixes a typo in the log redirection test configuration where a cleanup step waited for the same verification step twice instead of waiting for both parallel verification steps. This led to premature VM deletion before the serial log check could complete.