### PR TITLE
launcher: refactor NewRunner to use a RunnerConfig struct

### DIFF
--- a/launcher/container_runner.go
+++ b/launcher/container_runner.go
@@ -95,8 +95,31 @@ const (
 // Default OOM score for a CS container.
 const defaultOOMScore = 1000
 
+// RunnerConfig contains the configuration for creating a ContainerRunner.
+type RunnerConfig struct {
+	ContainerdClient *containerd.Client
+	Token            oauth2.Token
+	LaunchSpec       spec.LaunchSpec
+	MetadataClient   *metadata.Client
+	TPM              io.ReadWriteCloser
+	Logger           logging.Logger
+	SerialConsole    *os.File
+	GoogleClient     *http.Client
+	ClientOpts       []option.ClientOption
+}
+
 // NewRunner returns a runner.
-func NewRunner(ctx context.Context, cdClient *containerd.Client, token oauth2.Token, launchSpec spec.LaunchSpec, mdsClient *metadata.Client, tpm io.ReadWriteCloser, logger logging.Logger, serialConsole *os.File, googleClient *http.Client, opts ...option.ClientOption) (*ContainerRunner, error) {
+func NewRunner(ctx context.Context, cfg *RunnerConfig) (*ContainerRunner, error) {
+	cdClient := cfg.ContainerdClient
+	token := cfg.Token
+	launchSpec := cfg.LaunchSpec
+	mdsClient := cfg.MetadataClient
+	tpm := cfg.TPM
+	logger := cfg.Logger
+	serialConsole := cfg.SerialConsole
+	googleClient := cfg.GoogleClient
+	opts := cfg.ClientOpts
+
 	image, err := initImage(ctx, cdClient, launchSpec, token, googleClient)
 	if err != nil {
 		return nil, err

--- a/launcher/launcher/main.go
+++ b/launcher/launcher/main.go
@@ -246,7 +246,17 @@ func startLauncher(launchSpec spec.LaunchSpec, serialConsole *os.File, googleCli
 	logger.Info("Launch started", "duration_sec", time.Since(start).Seconds())
 
 	// tpm is nil when running in BC mode.
-	r, err := launcher.NewRunner(ctx, containerdClient, token, launchSpec, mdsClient, tpm, logger, serialConsole, googleClient, clientOpts...)
+	r, err := launcher.NewRunner(ctx, &launcher.RunnerConfig{
+		ContainerdClient: containerdClient,
+		Token:            token,
+		LaunchSpec:       launchSpec,
+		MetadataClient:   mdsClient,
+		TPM:              tpm,
+		Logger:           logger,
+		SerialConsole:    serialConsole,
+		GoogleClient:     googleClient,
+		ClientOpts:       clientOpts,
+	})
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Simplify the `NewRunner` constructor by grouping its 10 parameters into a `RunnerConfig` struct. This resolves the "fat constructor" code smell and makes it easier to pass optional configuration parameters in the future.

The fields of `RunnerConfig` are mapped to local variables at the beginning of `NewRunner` to keep the diff minimal and avoid churning the rest of the function body.