### PR TITLE
launcher: refactor logging interface and use explicit dependency inje…

### DIFF
--- a/launcher/container_runner.go
+++ b/launcher/container_runner.go
@@ -56,14 +56,15 @@ import (
 
 // ContainerRunner contains information about the container settings
 type ContainerRunner struct {
-	container     containerd.Container
-	launchSpec    spec.LaunchSpec
-	attestAgent   agent.AttestationAgent
-	logger        logging.Logger
-	gpuAttester   gpu.Attester
-	serialConsole *os.File
-	powerButton   *powerButtonListener // Populated only for a hardened image
-	clientOpts    []option.ClientOption
+	container      containerd.Container
+	launchSpec     spec.LaunchSpec
+	attestAgent    agent.AttestationAgent
+	logger         logging.Logger
+	workloadLogger logging.Logger
+	gpuAttester    gpu.Attester
+	serialConsole  *os.File
+	powerButton    *powerButtonListener // Populated only for a hardened image
+	clientOpts     []option.ClientOption
 }
 
 const tokenFileTmp = ".token.tmp"
@@ -103,6 +104,7 @@ type RunnerConfig struct {
 	MetadataClient   *metadata.Client
 	TPM              io.ReadWriteCloser
 	Logger           logging.Logger
+	WorkloadLogger   logging.Logger
 	SerialConsole    *os.File
 	GoogleClient     *http.Client
 	ClientOpts       []option.ClientOption
@@ -116,10 +118,10 @@ func NewRunner(ctx context.Context, cfg *RunnerConfig) (*ContainerRunner, error)
 	mdsClient := cfg.MetadataClient
 	tpm := cfg.TPM
 	logger := cfg.Logger
+	workloadLogger := cfg.WorkloadLogger
 	serialConsole := cfg.SerialConsole
 	googleClient := cfg.GoogleClient
 	opts := cfg.ClientOpts
-
 	image, err := initImage(ctx, cdClient, launchSpec, token, googleClient)
 	if err != nil {
 		return nil, err
@@ -385,6 +387,7 @@ func NewRunner(ctx context.Context, cfg *RunnerConfig) (*ContainerRunner, error)
 		launchSpec,
 		attestAgent,
 		logger,
+		workloadLogger,
 		nvidiaAttester,
 		serialConsole,
 		powerButton,
@@ -827,8 +830,8 @@ func (r *ContainerRunner) Run(ctx context.Context) error {
 		streamOpt = cio.WithStreams(nil, w, w)
 		r.logger.Info("Container stdout/stderr will be redirected to serial and Cloud Logging. This may result in performance issues due to slow serial console writes.")
 	case spec.CloudLogging:
-		stdoutWriter := logging.NewInfoWriter(r.logger)
-		stderrWriter := logging.NewErrorWriter(r.logger)
+		stdoutWriter := logging.NewInfoWriter(r.workloadLogger)
+		stderrWriter := logging.NewErrorWriter(r.workloadLogger)
 		streamOpt = cio.WithStreams(nil, stdoutWriter, stderrWriter)
 		r.logger.Info("Container stdout/stderr will be redirected to Cloud Logging with INFO and ERROR severities respectively.")
 	case spec.Serial:

--- a/launcher/internal/logging/logging.go
+++ b/launcher/internal/logging/logging.go
@@ -36,7 +36,6 @@ type Logger interface {
 	Warn(msg string, args ...any)
 	Error(msg string, args ...any)
 
-	SerialConsoleFile() *os.File
 	// Close flushes buffered logs and closes underlying resources. Callers should defer Close().
 	Close()
 }
@@ -46,27 +45,28 @@ type cLogger interface {
 	Flush() error
 }
 
-type logger struct {
-	cloudLogger  cLogger
-	serialLogger *slog.Logger
-	resource     *mrpb.MonitoredResource
-
-	instanceName      string
-	cloudClient       *clogging.Client
-	serialConsoleFile *os.File
-}
-
 type cloudLogger struct {
-	cloudLogger  cLogger
-	resource     *mrpb.MonitoredResource
+	cloudLogger cLogger
+	resource    *mrpb.MonitoredResource
+
 	instanceName string
 	cloudClient  *clogging.Client
 }
 
+type serialLogger struct {
+	slg *slog.Logger
+}
+
+type dualLogger struct {
+	cloud  Logger
+	serial Logger
+}
+
 type payload map[string]any
 
-// NewLogger returns a Logger with Cloud and Serial Console logging configured.
-func NewLogger(ctx context.Context, pool *x509.CertPool) (Logger, error) {
+// NewCloudLogger returns a Logger that logs exclusively to Cloud Logging.
+// Callers should run `defer logger.Close()` after initialization to ensure logs are flushed and handles are closed.
+func NewCloudLogger(ctx context.Context, pool *x509.CertPool) (Logger, error) {
 	// Retrieve monitored resource information.
 	mdsClient := metadata.NewClient(nil)
 
@@ -104,69 +104,6 @@ func NewLogger(ctx context.Context, pool *x509.CertPool) (Logger, error) {
 		return nil, err
 	}
 
-	// Configure Serial Console logger.
-	serialConsole, err := os.OpenFile(serialConsoleFile, os.O_WRONLY, 0)
-	if err != nil {
-		return nil, fmt.Errorf("failed to open serial console for writing: %v", err)
-	}
-
-	slg := slog.New(slog.NewTextHandler(serialConsole, nil))
-	slg.Info("Serial Console logger initialized")
-
-	// This is necessary for DEBUG logs to propagate properly.
-	slog.SetDefault(slg)
-
-	return &logger{
-		cloudLogger:  cloggingClient.Logger(logName),
-		serialLogger: slg,
-		resource: &mrpb.MonitoredResource{
-			Type: "gce_instance",
-			Labels: map[string]string{
-				"project_id":  projectID,
-				"instance_id": instanceID,
-				"zone":        zone,
-			},
-		},
-		instanceName:      instanceName,
-		cloudClient:       cloggingClient,
-		serialConsoleFile: serialConsole,
-	}, err
-}
-
-// NewCloudLogger returns a Logger that logs exclusively to Cloud Logging.
-func NewCloudLogger(ctx context.Context, pool *x509.CertPool) (Logger, error) {
-	mdsClient := metadata.NewClient(nil)
-
-	projectID, err := mdsClient.ProjectIDWithContext(ctx)
-	if err != nil {
-		return nil, fmt.Errorf("failed to retrieve Project ID from metadata server: %v", err)
-	}
-	instanceID, err := mdsClient.InstanceIDWithContext(ctx)
-	if err != nil {
-		return nil, fmt.Errorf("failed to retrieve Instance ID from metadata server: %v", err)
-	}
-	zone, err := mdsClient.ZoneWithContext(ctx)
-	if err != nil {
-		return nil, fmt.Errorf("failed to retrieve Zone from metadata server: %v", err)
-	}
-	instanceName, err := mdsClient.InstanceNameWithContext(ctx)
-	if err != nil {
-		return nil, fmt.Errorf("failed to retrieve Instance Name from metadata server: %v", err)
-	}
-
-	var opts []option.ClientOption
-	if pool != nil {
-		creds := credentials.NewTLS(&tls.Config{
-			RootCAs: pool,
-		})
-		opts = append(opts, option.WithGRPCDialOption(grpc.WithTransportCredentials(creds)))
-	}
-
-	cloggingClient, err := clogging.NewClient(ctx, projectID, opts...)
-	if err != nil {
-		return nil, err
-	}
-
 	return &cloudLogger{
 		cloudLogger: cloggingClient.Logger(logName),
 		resource: &mrpb.MonitoredResource{
@@ -182,18 +119,27 @@ func NewCloudLogger(ctx context.Context, pool *x509.CertPool) (Logger, error) {
 	}, nil
 }
 
-func (l *logger) SerialConsoleFile() *os.File {
-	return l.serialConsoleFile
+// NewSerialLogger returns a Logger that logs exclusively to the provided serial console.
+// It assumes serialConsole is a valid, writable file. The caller retains ownership of
+// serialConsole and is responsible for closing it.
+func NewSerialLogger(serialConsole *os.File) Logger {
+	slg := slog.New(slog.NewTextHandler(serialConsole, nil))
+	slg.Info("Serial Console logger initialized")
+
+	// This is necessary for DEBUG logs to propagate properly.
+	slog.SetDefault(slg)
+
+	return &serialLogger{slg: slg}
 }
 
-func (l *logger) Close() {
-	if l.cloudClient != nil {
-		l.cloudClient.Close()
-	}
+// NullLogger returns a Logger that discards all logs.
+func NullLogger() Logger {
+	return &nullLogger{}
+}
 
-	if l.serialConsoleFile != nil {
-		l.serialConsoleFile.Close()
-	}
+// DualLogger returns a Logger that duplicates its logs to both the cloud and serial loggers.
+func DualLogger(cloud Logger, serial Logger) Logger {
+	return &dualLogger{cloud: cloud, serial: serial}
 }
 
 func (l *cloudLogger) Log(severity clogging.Severity, msg string, args ...any) {
@@ -213,6 +159,7 @@ func (l *cloudLogger) Log(severity clogging.Severity, msg string, args ...any) {
 	}
 
 	if len(l.instanceName) > 0 {
+		// Needed for backwards compatibility with Cloudbuild tests.
 		pl[payloadInstanceNameKey] = l.instanceName
 	}
 
@@ -227,8 +174,6 @@ func (l *cloudLogger) Log(severity clogging.Severity, msg string, args ...any) {
 func (l *cloudLogger) Info(msg string, args ...any)  { l.Log(clogging.Info, msg, args...) }
 func (l *cloudLogger) Warn(msg string, args ...any)  { l.Log(clogging.Warning, msg, args...) }
 func (l *cloudLogger) Error(msg string, args ...any) { l.Log(clogging.Error, msg, args...) }
-
-func (l *cloudLogger) SerialConsoleFile() *os.File { return nil }
 
 func (l *cloudLogger) Close() {
 	if l.cloudClient != nil {
@@ -264,70 +209,48 @@ func addArgs(pl payload, args []any) {
 	addArgs(pl, args[2:])
 }
 
-func (l *logger) writeCloudLog(severity clogging.Severity, msg string, args ...any) {
-	if l.cloudLogger == nil {
-		return
-	}
-	// Write cloud log.
-	logEntry := clogging.Entry{
-		Severity: severity,
-		Resource: l.resource,
-	}
-
-	pl := payload{}
-	addArgs(pl, args)
-
-	if len(msg) > 0 {
-		pl[payloadMessageKey] = msg
-	}
-
-	if len(l.instanceName) > 0 {
-		// Needed for backwards compatibility with Cloudbuild tests.
-		pl[payloadInstanceNameKey] = l.instanceName
-	}
-
-	logEntry.Payload = pl
-
-	l.cloudLogger.Log(logEntry)
-	if err := l.cloudLogger.Flush(); err != nil {
-		l.serialLogger.Error(fmt.Sprintf("cloud.Logger.Flush returned error: %v", err))
-	}
-}
-
-func (l *logger) writeLog(severity clogging.Severity, msg string, args ...any) {
-	l.writeCloudLog(severity, msg, args...)
-
-	// Write to serial console.
+func (l *serialLogger) Log(severity clogging.Severity, msg string, args ...any) {
 	switch severity {
 	case clogging.Info, clogging.Notice, clogging.Debug:
-		l.serialLogger.Info(msg, args...)
+		l.slg.Info(msg, args...)
 	case clogging.Warning:
-		l.serialLogger.Warn(msg, args...)
+		l.slg.Warn(msg, args...)
 	case clogging.Error, clogging.Critical, clogging.Alert, clogging.Emergency:
-		l.serialLogger.Error(msg, args...)
+		l.slg.Error(msg, args...)
 	default:
 		slog.Debug(msg, args...)
 	}
 }
 
-// Log logs msg and args with the provided severity.
-func (l *logger) Log(severity clogging.Severity, msg string, args ...any) {
-	l.writeLog(severity, msg, args...)
+func (l *serialLogger) Info(msg string, args ...any)  { l.Log(clogging.Info, msg, args...) }
+func (l *serialLogger) Warn(msg string, args ...any)  { l.Log(clogging.Warning, msg, args...) }
+func (l *serialLogger) Error(msg string, args ...any) { l.Log(clogging.Error, msg, args...) }
+
+func (l *serialLogger) Close() {}
+
+func (d *dualLogger) Log(severity clogging.Severity, msg string, args ...any) {
+	d.cloud.Log(severity, msg, args...)
+	d.serial.Log(severity, msg, args...)
 }
 
-// Info logs msg and args at 'Info' severity.
-func (l *logger) Info(msg string, args ...any) {
-	l.writeLog(clogging.Info, msg, args...)
+func (d *dualLogger) Info(msg string, args ...any) {
+	d.cloud.Info(msg, args...)
+	d.serial.Info(msg, args...)
 }
 
-// Warn logs msg and args at 'Warn' severity.
-func (l *logger) Warn(msg string, args ...any) {
-	l.writeLog(clogging.Warning, msg, args...)
+func (d *dualLogger) Warn(msg string, args ...any) {
+	d.cloud.Warn(msg, args...)
+	d.serial.Warn(msg, args...)
 }
 
-// Error logs msg and args at 'Error' severity.
-func (l *logger) Error(msg string, args ...any) {
-	l.writeLog(clogging.Error, msg, args...)
+func (d *dualLogger) Error(msg string, args ...any) {
+	d.cloud.Error(msg, args...)
+	d.serial.Error(msg, args...)
+}
+
+func (d *dualLogger) Close() {
+	d.cloud.Close()
+	d.serial.Close()
 }
 
 // SimpleLogger returns a lightweight implementation that wraps a slog.Default() logger.
@@ -369,13 +292,17 @@ func (l *slogger) Error(msg string, args ...any) {
 	l.slg.Error(msg, args...)
 }
 
-func (l *slogger) SerialConsoleFile() *os.File {
-	return nil
-}
-
 func (l *slogger) Close() {}
 
-// SeverityWriter wraps a Logger and implements io.Writer to write directly to Cloud Logging at a specific severity level.
+type nullLogger struct{}
+
+func (n *nullLogger) Log(_ clogging.Severity, _ string, _ ...any) {}
+func (n *nullLogger) Info(_ string, _ ...any)                     {}
+func (n *nullLogger) Warn(_ string, _ ...any)                     {}
+func (n *nullLogger) Error(_ string, _ ...any)                    {}
+func (n *nullLogger) Close()                                      {}
+
+// SeverityWriter wraps a Logger and implements io.Writer to write to the Logger at a specific severity level.
 type SeverityWriter struct {
 	l        Logger
 	severity clogging.Severity
@@ -396,7 +323,7 @@ func NewErrorWriter(l Logger) io.Writer {
 	return NewSeverityWriter(l, clogging.Error)
 }
 
-// Write implements the io.Writer interface, redirecting logs to Cloud Logging with the configured severity.
+// Write implements the io.Writer interface, redirecting logs to the Logger with the configured severity.
 func (w *SeverityWriter) Write(p []byte) (n int, err error) {
 	// Trim any trailing newline.
 	end := len(p)
@@ -405,11 +332,7 @@ func (w *SeverityWriter) Write(p []byte) (n int, err error) {
 	}
 	msg := string(p[:end])
 
-	if realLogger, ok := w.l.(*logger); ok {
-		realLogger.writeCloudLog(w.severity, msg)
-	} else {
-		w.l.Log(w.severity, msg)
-	}
+	w.l.Log(w.severity, msg)
 
 	return len(p), nil
 }

--- a/launcher/internal/logging/logging_test.go
+++ b/launcher/internal/logging/logging_test.go
@@ -149,7 +149,7 @@ func (s *testSLogWriter) checkLogLevel(level slog.Level) error {
 	return nil
 }
 
-func TestWriteLog(t *testing.T) {
+func TestCloudLogger(t *testing.T) {
 	testResource := &mrpb.MonitoredResource{
 		Type: "gce_instance",
 		Labels: map[string]string{
@@ -159,15 +159,10 @@ func TestWriteLog(t *testing.T) {
 		},
 	}
 
-	// Redirect loggers to buffers.
-	cloudLogger := &testCLogger{}
-	serialLogs := &testSLogWriter{}
-
-	testLogger := &logger{
-		cloudLogger:  cloudLogger,
-		serialLogger: slog.New(slog.NewTextHandler(serialLogs, nil)),
+	cloudC := &testCLogger{}
+	cl := &cloudLogger{
+		cloudLogger:  cloudC,
 		resource:     testResource,
-
 		instanceName: "test-instance",
 	}
 
@@ -178,7 +173,44 @@ func TestWriteLog(t *testing.T) {
 		"key3": false,
 	}
 
-	testLogger.writeLog(clogging.Info, testMsg, toArgs(testPayload)...)
+	cl.Log(clogging.Info, testMsg, toArgs(testPayload)...)
+
+	// Add message and hostnames values to expected payload.
+	testPayload[payloadMessageKey] = testMsg
+	testPayload[payloadInstanceNameKey] = cl.instanceName
+
+	if !cmp.Equal(cloudC.log.Payload, testPayload) {
+		t.Errorf("Did not get expected payload in cloud logs: got %v, want %v", cloudC.log.Payload, testPayload)
+	}
+
+	if cloudC.log.Severity != clogging.Info {
+		t.Errorf("Did not get expected severity in cloud logs: got %v, want %v", cloudC.log.Severity, clogging.Info)
+	}
+
+	// Compare monitored resource.
+	if cloudC.log.Resource.Type != testResource.Type {
+		t.Errorf("Did not get expected monitored resource tyoe: got %v, want %v", cloudC.log.Resource.Type, testResource.Type)
+	}
+
+	if !cmp.Equal(cloudC.log.Resource.Labels, testResource.Labels) {
+		t.Errorf("Did not get expected monitored resource labels in cloud logs: got %v, want %v", cloudC.log.Resource.Labels, testResource.Labels)
+	}
+}
+
+func TestSerialLogger(t *testing.T) {
+	serialLogs := &testSLogWriter{}
+	sl := &serialLogger{
+		slg: slog.New(slog.NewTextHandler(serialLogs, nil)),
+	}
+
+	testMsg := "test message"
+	testPayload := payload{
+		"key1": "value1",
+		"key2": 2,
+		"key3": false,
+	}
+
+	sl.Log(clogging.Info, testMsg, toArgs(testPayload)...)
 
 	if err := serialLogs.checkLogContains(testMsg, testPayload); err != nil {
 		t.Errorf("Error validating Serial Log contents: %v", err)
@@ -187,26 +219,31 @@ func TestWriteLog(t *testing.T) {
 	if err := serialLogs.checkLogLevel(slog.LevelInfo); err != nil {
 		t.Errorf("Error validating Serial Log level: %v", err)
 	}
+}
 
-	// Add message and hostnames values to expected payload.
-	testPayload[payloadMessageKey] = testMsg
-	testPayload[payloadInstanceNameKey] = testLogger.instanceName
-
-	if !cmp.Equal(cloudLogger.log.Payload, testPayload) {
-		t.Errorf("Did not get expected payload in cloud logs: got %v, want %v", cloudLogger.log.Payload, testPayload)
+func TestDualLogger(t *testing.T) {
+	cloudC := &testCLogger{}
+	cl := &cloudLogger{
+		cloudLogger:  cloudC,
+		resource:     &mrpb.MonitoredResource{},
+		instanceName: "test-instance",
 	}
 
-	if cloudLogger.log.Severity != clogging.Info {
-		t.Errorf("Did not get expected severity in cloud logs: got %v, want %v", cloudLogger.log.Severity, clogging.Info)
+	serialLogs := &testSLogWriter{}
+	sl := &serialLogger{
+		slg: slog.New(slog.NewTextHandler(serialLogs, nil)),
 	}
 
-	// Compare monitored resource.
-	if cloudLogger.log.Resource.Type != testResource.Type {
-		t.Errorf("Did not get expected monitored resource tyoe: got %v, want %v", cloudLogger.log.Resource.Type, testResource.Type)
-	}
+	dLogger := DualLogger(cl, sl)
 
-	if !cmp.Equal(cloudLogger.log.Resource.Labels, testResource.Labels) {
-		t.Errorf("Did not get expected monitored resource labels in cloud logs: got %v, want %v", cloudLogger.log.Resource.Labels, testResource.Labels)
+	testMsg := "test message"
+	dLogger.Log(clogging.Info, testMsg)
+
+	if cloudC.log.Severity != clogging.Info {
+		t.Errorf("DualLogger: cloud logger did not receive log")
+	}
+	if err := serialLogs.checkLogContains(testMsg, payload{}); err != nil {
+		t.Errorf("DualLogger: serial logger did not receive log: %v", err)
 	}
 }
 
@@ -215,13 +252,13 @@ func TestLogFunctions(t *testing.T) {
 		name          string
 		cloudSeverity clogging.Severity
 		serialLevel   slog.Level
-		logFunc       func(lgr *logger, msg string)
+		logFunc       func(lgr Logger, msg string)
 	}{
 		{
 			name:          "logger.Info",
 			cloudSeverity: clogging.Info,
 			serialLevel:   slog.LevelInfo,
-			logFunc: func(lgr *logger, msg string) {
+			logFunc: func(lgr Logger, msg string) {
 				lgr.Info(msg)
 			},
 		},
@@ -229,7 +266,7 @@ func TestLogFunctions(t *testing.T) {
 			name:          "logger.Warn",
 			cloudSeverity: clogging.Warning,
 			serialLevel:   slog.LevelWarn,
-			logFunc: func(lgr *logger, msg string) {
+			logFunc: func(lgr Logger, msg string) {
 				lgr.Warn(msg)
 			},
 		},
@@ -237,7 +274,7 @@ func TestLogFunctions(t *testing.T) {
 			name:          "logger.Error",
 			cloudSeverity: clogging.Error,
 			serialLevel:   slog.LevelError,
-			logFunc: func(lgr *logger, msg string) {
+			logFunc: func(lgr Logger, msg string) {
 				lgr.Error(msg)
 			},
 		},
@@ -246,22 +283,25 @@ func TestLogFunctions(t *testing.T) {
 	msg := "test message"
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
-
-			// Redirect loggers to buffers.
 			cloudLogs := &testCLogger{}
-			serialLogs := &testSLogWriter{}
-
-			testLogger := &logger{
+			cl := &cloudLogger{
 				cloudLogger:  cloudLogs,
-				serialLogger: slog.New(slog.NewTextHandler(serialLogs, nil)),
+				resource:     &mrpb.MonitoredResource{},
 				instanceName: "test-instance",
 			}
 
-			tc.logFunc(testLogger, msg)
+			serialLogs := &testSLogWriter{}
+			sl := &serialLogger{
+				slg: slog.New(slog.NewTextHandler(serialLogs, nil)),
+			}
+
+			mLogger := DualLogger(cl, sl)
+
+			tc.logFunc(mLogger, msg)
 
 			expectedPayload := payload{
 				payloadMessageKey:      msg,
-				payloadInstanceNameKey: testLogger.instanceName,
+				payloadInstanceNameKey: cl.instanceName,
 			}
 
 			if cloudLogs.log.Severity != tc.cloudSeverity {
@@ -284,32 +324,85 @@ func TestLogFunctions(t *testing.T) {
 }
 
 func TestSeverityWriter(t *testing.T) {
-	cloudLogger := &testCLogger{}
-	serialLogs := &testSLogWriter{}
-
-	testLogger := &logger{
-		cloudLogger:  cloudLogger,
-		serialLogger: slog.New(slog.NewTextHandler(serialLogs, nil)),
+	tests := []struct {
+		name         string
+		writerFunc   func(Logger) io.Writer
+		input        string
+		wantMsg      string
+		wantSeverity clogging.Severity
+	}{
+		{
+			name:         "InfoWriter without newline",
+			writerFunc:   NewInfoWriter,
+			input:        "test info log",
+			wantMsg:      "test info log",
+			wantSeverity: clogging.Info,
+		},
+		{
+			name:         "InfoWriter strips trailing newlines",
+			writerFunc:   NewInfoWriter,
+			input:        "test info log\n\n",
+			wantMsg:      "test info log",
+			wantSeverity: clogging.Info,
+		},
+		{
+			name:         "ErrorWriter with trailing newline",
+			writerFunc:   NewErrorWriter,
+			input:        "test error log\n",
+			wantMsg:      "test error log",
+			wantSeverity: clogging.Error,
+		},
+		{
+			name:         "Preserves internal newlines",
+			writerFunc:   NewInfoWriter,
+			input:        "line 1\nline 2\n\n",
+			wantMsg:      "line 1\nline 2",
+			wantSeverity: clogging.Info,
+		},
+		{
+			name:         "Empty input",
+			writerFunc:   NewInfoWriter,
+			input:        "",
+			wantMsg:      "",
+			wantSeverity: clogging.Info,
+		},
+		{
+			name:         "Only newlines",
+			writerFunc:   NewInfoWriter,
+			input:        "\n\n\n",
+			wantMsg:      "",
+			wantSeverity: clogging.Info,
+		},
 	}
 
-	infoWriter := NewInfoWriter(testLogger)
-	errorWriter := NewErrorWriter(testLogger)
-
-	_, err := infoWriter.Write([]byte("info message\n"))
-	if err != nil {
-		t.Fatalf("infoWriter.Write failed: %v", err)
-	}
-
-	if cloudLogger.log.Severity != clogging.Info {
-		t.Errorf("expected Info severity, got %v", cloudLogger.log.Severity)
-	}
-
-	_, err = errorWriter.Write([]byte("error message\n"))
-	if err != nil {
-		t.Fatalf("errorWriter.Write failed: %v", err)
-	}
-
-	if cloudLogger.log.Severity != clogging.Error {
-		t.Errorf("expected Error severity, got %v", cloudLogger.log.Severity)
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			mock := &mockLogger{}
+			writer := tc.writerFunc(mock)
+			n, err := writer.Write([]byte(tc.input))
+			if err != nil || n != len(tc.input) {
+				t.Fatalf("Write failed: got n=%v, err=%v", n, err)
+			}
+			if mock.severity != tc.wantSeverity {
+				t.Errorf("Severity: got %v, want %v", mock.severity, tc.wantSeverity)
+			}
+			if mock.msg != tc.wantMsg {
+				t.Errorf("Message: got %q, want %q", mock.msg, tc.wantMsg)
+			}
+		})
 	}
 }
+
+type mockLogger struct {
+	severity clogging.Severity
+	msg      string
+}
+
+func (m *mockLogger) Log(severity clogging.Severity, msg string, _ ...any) {
+	m.severity = severity
+	m.msg = msg
+}
+func (m *mockLogger) Info(_ string, _ ...any)  {}
+func (m *mockLogger) Warn(_ string, _ ...any)  {}
+func (m *mockLogger) Error(_ string, _ ...any) {}
+func (m *mockLogger) Close()                   {}

--- a/launcher/launcher/main.go
+++ b/launcher/launcher/main.go
@@ -55,7 +55,10 @@ var rcMessage = map[int]string{
 // BuildCommit shows the commit when building the binary, set by -ldflags when building
 var BuildCommit = "dev"
 
+const serialConsoleFile = "/dev/console"
+
 var logger logging.Logger
+var workloadLogger logging.Logger
 var mdsClient *metadata.Client
 var launchSpec spec.LaunchSpec
 
@@ -67,7 +70,8 @@ var start time.Time
 func main() {
 	uptime, err := getUptime()
 	if err != nil {
-		logger.Error(fmt.Sprintf("error reading VM uptime: %v", err))
+		// logger is not initialized yet.
+		log.Default().Printf("error reading VM uptime: %v", err)
 	}
 	// Note the current time to later calculate launch time.
 	start = time.Now()
@@ -96,14 +100,25 @@ func main() {
 		return
 	}
 
-	logger, err = logging.NewLogger(ctx, pool)
+	serialConsole, err := os.OpenFile(serialConsoleFile, os.O_WRONLY, 0)
 	if err != nil {
-		log.Default().Printf("failed to initialize logging: %v", err)
+		log.Default().Printf("Failed to open serial console: %v", err)
 		exitCode = failRC
 		log.Default().Printf("%s, exit code: %d (%s)\n", exitMessage, exitCode, rcMessage[exitCode])
 		return
 	}
-	defer logger.Close()
+	defer serialConsole.Close()
+
+	workloadLogger, err = logging.NewCloudLogger(ctx, pool)
+	if err != nil {
+		log.Default().Printf("failed to initialize cloud logging: %v", err)
+		exitCode = failRC
+		log.Default().Printf("%s, exit code: %d (%s)\n", exitMessage, exitCode, rcMessage[exitCode])
+		return
+	}
+	defer workloadLogger.Close()
+
+	logger = logging.DualLogger(workloadLogger, logging.NewSerialLogger(serialConsole))
 
 	logger.Info("Boot completed", "duration_sec", uptime)
 	logger.Info(welcomeMessage, "build_commit", BuildCommit)
@@ -143,7 +158,7 @@ func main() {
 			logger.Info(exitMessage, "exit_code", exitCode)
 		}
 	}()
-	if err = startLauncher(launchSpec, logger.SerialConsoleFile(), googleClient, clientOpts...); err != nil {
+	if err = startLauncher(launchSpec, serialConsole, googleClient, clientOpts...); err != nil {
 		logger.Error(err.Error())
 	}
 
@@ -253,6 +268,7 @@ func startLauncher(launchSpec spec.LaunchSpec, serialConsole *os.File, googleCli
 		MetadataClient:   mdsClient,
 		TPM:              tpm,
 		Logger:           logger,
+		WorkloadLogger:   workloadLogger,
 		SerialConsole:    serialConsole,
 		GoogleClient:     googleClient,
 		ClientOpts:       clientOpts,


### PR DESCRIPTION
[This change refactors the logging infrastructure to enforce clean composition and remove abstraction violations:
- Removes `SerialConsoleFile()` from `logging.Logger` interface.
- Splits the monolithic `logger` into `cloudLogger`, `serialLogger`, and a composite `dualLogger`.
- Injects the `cloudLogger` (as `workloadLogger`) explicitly into `NewRunner` to redirect container logs to Cloud Logging only, removing type-assertion hacks inside the runner.
- Exposes `NullLogger()` to explicitly discard logs, and removes the magic `nil` handling from `NewSerialLogger`.
- Updates unit tests to test these components in isolation.