### PR TITLE
[Launcher] Abstract GPU driver setup into bc_gpu_setup.sh

### DIFF
--- a/launcher/image/bc-guest/bc_gpu_setup.sh
+++ b/launcher/image/bc-guest/bc_gpu_setup.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+set -euo pipefail
+
+# Install gpu drivers
+modprobe ib_umad
+modprobe nvidia
+modprobe nvidia-uvm
+modprobe nvidia-modeset
+
+echo "Running nvidia-persistenced" | tee /dev/console
+systemd-run -p Type=forking --unit=nvidia-persistenced-transient /opt/nvidia/595.58.03/bin/nvidia-persistenced
+
+echo "Waiting 1 minute for nvidia-persistenced to initialize..." | tee /dev/console
+sleep 60s
+
+if [ -f  /usr/share/oem/confidential_space/gpu_helper.tar ]; then
+    echo "Importing GPU helper image..." | tee /dev/console
+    sudo ctr images import /usr/share/oem/confidential_space/gpu_helper.tar
+fi
+
+echo "Running NVLSM and Fabric Manager..." | tee /dev/console
+
+sudo ctr containers create --privileged --net-host \
+    --mount type=bind,src=/dev,dst=/dev,options=rbind:rw \
+    --mount type=bind,src=/opt/nvidia,dst=/opt/nvidia-host,options=rbind:rw \
+    docker.io/library/guest-gpu-tools:latest \
+    guest-gpu-tools-task
+
+sudo ctr tasks start -d guest-gpu-tools-task
+echo "Waiting 2 min for NVLSM and Fabric Manager to initialize..." | tee /dev/console
+sleep 2m
+
+echo "GPU daemon ready" | tee /dev/console

--- a/launcher/image/bc-guest/bcentrypoint.sh
+++ b/launcher/image/bc-guest/bcentrypoint.sh
@@ -48,35 +48,9 @@ main() {
   systemctl daemon-reload
 
   # Install gpu drivers
-  modprobe ib_umad
-  modprobe nvidia
-  modprobe nvidia-uvm
-  modprobe nvidia-modeset
-
-  echo "Running nvidia-persistenced" | tee /dev/console
-  systemd-run -p Type=forking --unit=nvidia-persistenced-transient /opt/nvidia/595.58.03/bin/nvidia-persistenced
-
-  echo "Waiting 1 minute for nvidia-persistenced to initialize..." | tee /dev/console
-  sleep 60s
-
-  if [ -f  /usr/share/oem/confidential_space/gpu_helper.tar ]; then
-      echo "Importing GPU helper image..." | tee /dev/console
-      sudo ctr images import /usr/share/oem/confidential_space/gpu_helper.tar
+  if [[ -f /usr/share/oem/confidential_space/bc_gpu_setup.sh ]]; then
+    /usr/share/oem/confidential_space/bc_gpu_setup.sh
   fi
-
-  echo "Running NVLSM and Fabric Manager..." | tee /dev/console
-
-  sudo ctr containers create --privileged --net-host \
-      --mount type=bind,src=/dev,dst=/dev,options=rbind:rw \
-      --mount type=bind,src=/opt/nvidia,dst=/opt/nvidia-host,options=rbind:rw \
-      docker.io/library/guest-gpu-tools:latest \
-      guest-gpu-tools-task
-
-  sudo ctr tasks start -d guest-gpu-tools-task
-  echo "Waiting 2 min for NVLSM and Fabric Manager to initialize..." | tee /dev/console
-  sleep 2m
-
-  echo "GPU daemon ready" | tee /dev/console
 
   systemctl enable container-runner.service
   systemctl enable wsd.service

--- a/launcher/image/bc_cloudbuild.yaml
+++ b/launcher/image/bc_cloudbuild.yaml
@@ -74,6 +74,7 @@ steps:
            ./launcher/image/bc-guest/bc_network_monitor.sh \
            /workspace/gpu_helper.tar \
            ./launcher/image/bc-guest/bc_pin_pci_numa_nodes.sh \
+           ./launcher/image/bc-guest/bc_gpu_setup.sh \
            /workspace/oem-install/confidential_space/
         cp ./launcher/image/nodeproblemdetector/* /workspace/oem-install/confidential_space/nodeproblemdetector/
         cp ./launcher/image/bc-guest/wsd/* /workspace/oem-install/wsd/
@@ -117,6 +118,7 @@ steps:
         chmod +x /workspace/oem-install/confidential_space/bc_network_runtime_optimization.sh || true
         chmod +x /workspace/oem-install/confidential_space/bc_network_monitor.sh || true
         chmod +x /workspace/oem-install/confidential_space/bc_pin_pci_numa_nodes.sh || true
+        chmod +x /workspace/oem-install/confidential_space/bc_gpu_setup.sh || true
         chmod +x /workspace/oem-install/entrypoint.sh || true
         chmod +x /workspace/oem-install/wsd/wsd_runner.sh || true
         chmod +x /workspace/oem-install/wsd/exit_script.sh || true


### PR DESCRIPTION
Abstracted inline GPU driver and daemon setup from `bcentrypoint.sh` into a standalone script (`bc_gpu_setup.sh`).

* **Modular Script Abstraction**: Extracted NVIDIA driver loading, `nvidia-persistenced`, and Fabric Manager container startup into `bc_gpu_setup.sh`.
* **Entrypoint Simplification**: Replaced inline GPU commands in `bcentrypoint.sh` with a conditional call to `bc_gpu_setup.sh`.
* **Build Integration**: Updated `bc_cloudbuild.yaml` to copy `bc_gpu_setup.sh` and set executable permissions.
