### PR TITLE
remove invalid token from error message

### DIFF
--- a/launcher/registryauth/auth.go
+++ b/launcher/registryauth/auth.go
@@ -81,5 +81,5 @@ func RefreshResolver(ctx context.Context, client *metadata.Client, googleClient 
 		return Resolver(token.AccessToken, googleClient), nil
 	}
 
-	return nil, fmt.Errorf("invalid token from metadata server: %v", token)
+	return nil, fmt.Errorf("invalid token from metadata server")
 }


### PR DESCRIPTION
Even though the token is invalid, it should not be logged