### PR TITLE
launcher: dependency inject TPM and mount verifier

### DIFF
--- a/launcher/launcher/main.go
+++ b/launcher/launcher/main.go
@@ -131,11 +131,37 @@ func main() {
 		return
 	}
 
-	if err := verifyFsAndMount(launchSpec); err != nil {
-		logger.Error(fmt.Sprintf("failed to verify filesystem and mounts: %v\n", err))
+	verifier := osMountVerifier{}
+	if err := verifyDiskIntegrity(verifier); err != nil {
+		logger.Error(fmt.Sprintf("failed to verify disk integrity: %v\n", err))
 		exitCode = rebootRC
 		logger.Error(exitMessage, "exit_code", exitCode, "exit_msg", rcMessage[exitCode])
 		return
+	}
+	if err := verifyMounts(launchSpec, verifier); err != nil {
+		logger.Error(fmt.Sprintf("failed to verify mounts: %v\n", err))
+		exitCode = rebootRC
+		logger.Error(exitMessage, "exit_code", exitCode, "exit_msg", rcMessage[exitCode])
+		return
+	}
+
+	var tpm io.ReadWriteCloser
+	if !launchSpec.Experiments.BcMode {
+		tpm, err = tpm2.OpenTPM("/dev/tpmrm0")
+		if err != nil {
+			logger.Error(fmt.Sprintf("failed to open TPM device: %v", err))
+			exitCode = rebootRC
+			logger.Error(exitMessage, "exit_code", exitCode, "exit_msg", rcMessage[exitCode])
+			return
+		}
+		defer tpm.Close()
+
+		if err := initTPM(tpm, logger); err != nil {
+			logger.Error(fmt.Sprintf("failed to initialize TPM: %v", err))
+			exitCode = getExitCode(launchSpec.Hardened, launchSpec.RestartPolicy, err)
+			logger.Error(exitMessage, "exit_code", exitCode, "exit_msg", rcMessage[exitCode])
+			return
+		}
 	}
 
 	defer func() {
@@ -151,7 +177,7 @@ func main() {
 			logger.Info(exitMessage, "exit_code", exitCode)
 		}
 	}()
-	if err = startLauncher(launchSpec, logger, workloadLogger, mdsClient, start, serialConsole, googleClient, clientOpts...); err != nil {
+	if err = startLauncher(launchSpec, tpm, logger, workloadLogger, mdsClient, start, serialConsole, googleClient, clientOpts...); err != nil {
 		logger.Error(err.Error())
 	}
 
@@ -213,6 +239,7 @@ func getUptime() (string, error) {
 
 func startLauncher(
 	launchSpec spec.LaunchSpec,
+	tpm io.ReadWriteCloser,
 	logger logging.Logger,
 	workloadLogger logging.Logger,
 	mdsClient *metadata.Client,
@@ -227,14 +254,6 @@ func startLauncher(
 		return &launcher.RetryableError{Err: err}
 	}
 	defer containerdClient.Close()
-
-	tpm, err := initTPM(launchSpec, logger)
-	if err != nil {
-		return err
-	}
-	if tpm != nil {
-		defer tpm.Close()
-	}
 
 	token, err := registryauth.RetrieveAuthToken(context.Background(), mdsClient)
 	if err != nil {
@@ -283,17 +302,7 @@ func startLauncher(
 	return r.Run(ctx)
 }
 
-func initTPM(launchSpec spec.LaunchSpec, logger logging.Logger) (io.ReadWriteCloser, error) {
-	if launchSpec.Experiments.BcMode {
-		logger.Info("Running in BC mode, bypassing TPM initialization and checks.")
-		return nil, nil
-	}
-
-	tpm, err := tpm2.OpenTPM("/dev/tpmrm0")
-	if err != nil {
-		return nil, &launcher.RetryableError{Err: err}
-	}
-
+func initTPM(tpm io.ReadWriteCloser, logger logging.Logger) error {
 	// check DA info, don't crash if failed
 	daInfo, err := launcher.GetTPMDAInfo(tpm)
 	if err != nil {
@@ -318,28 +327,26 @@ func initTPM(launchSpec spec.LaunchSpec, logger logging.Logger) (io.ReadWriteClo
 	// check AK (EK signing) cert
 	gceAk, err := client.GceAttestationKeyECC(tpm)
 	if err != nil {
-		tpm.Close()
-		return nil, err
+		return err
 	}
 	defer gceAk.Close()
 
 	if gceAk.Cert() == nil {
-		tpm.Close()
-		return nil, errors.New("failed to find AKCert on this VM: try creating a new VM or contacting support")
+		return errors.New("failed to find AKCert on this VM: try creating a new VM or contacting support")
 	}
 
-	return tpm, nil
+	return nil
 }
 
 // verifyFsAndMount checks the partitions/mounts are as expected, based on the command output reported by OS.
 // These checks are not a security guarantee.
-func verifyFsAndMount(launchSpec spec.LaunchSpec) error {
-	dmLsOutput, err := exec.Command("dmsetup", "ls").Output()
+func verifyDiskIntegrity(verifier integrityVerifier) error {
+	dmLsOutput, err := verifier.DmsetupLs()
 	if err != nil {
-		return fmt.Errorf("failed to call `dmsetup ls`: %v %s", err, string(dmLsOutput))
+		return fmt.Errorf("failed to call `dmsetup ls`: %v %s", err, dmLsOutput)
 	}
 
-	dmDevs := strings.Split(string(dmLsOutput), "\n")
+	dmDevs := strings.Split(dmLsOutput, "\n")
 	devNameToDevNo := make(map[string]string)
 	for _, dmDev := range dmDevs {
 		if dmDev == "" {
@@ -355,89 +362,125 @@ func verifyFsAndMount(launchSpec spec.LaunchSpec) error {
 	var cryptNo, zeroNo string
 	var ok bool
 	if _, ok = devNameToDevNo["protected_stateful_partition"]; !ok {
-		return fmt.Errorf("failed to find /dev/mapper/protected_stateful_partition: %s", string(dmLsOutput))
+		return fmt.Errorf("failed to find /dev/mapper/protected_stateful_partition: %s", dmLsOutput)
 	}
 	if cryptNo, ok = devNameToDevNo["protected_stateful_partition_crypt"]; !ok {
-		return fmt.Errorf("failed to find /dev/mapper/protected_stateful_partition_crypt: %s", string(dmLsOutput))
+		return fmt.Errorf("failed to find /dev/mapper/protected_stateful_partition_crypt: %s", dmLsOutput)
 	}
 	if zeroNo, ok = devNameToDevNo["protected_stateful_partition_zero"]; !ok {
-		return fmt.Errorf("failed to find /dev/mapper/protected_stateful_partition_zero: %s", string(dmLsOutput))
+		return fmt.Errorf("failed to find /dev/mapper/protected_stateful_partition_zero: %s", dmLsOutput)
 	}
 
-	dmTableCloneOutput, err := exec.Command("dmsetup", "table", "/dev/mapper/protected_stateful_partition").Output()
+	dmTableCloneOutput, err := verifier.DmsetupTable("/dev/mapper/protected_stateful_partition")
 	if err != nil {
-		return fmt.Errorf("failed to check /dev/mapper/protected_stateful_partition status: %v %s", err, string(dmTableCloneOutput))
+		return fmt.Errorf("failed to check /dev/mapper/protected_stateful_partition status: %v %s", err, dmTableCloneOutput)
 	}
-	cloneTable := strings.Fields(string(dmTableCloneOutput))
+	cloneTable := strings.Fields(dmTableCloneOutput)
 	// https://docs.kernel.org/admin-guide/device-mapper/dm-clone.html
 	if len(cloneTable) < 7 {
-		return fmt.Errorf("clone table does not match expected format: %s", string(dmTableCloneOutput))
+		return fmt.Errorf("clone table does not match expected format: %s", dmTableCloneOutput)
 	}
 	if cloneTable[2] != "clone" {
-		return fmt.Errorf("protected_stateful_partition is not a dm-clone device: %s", string(dmTableCloneOutput))
+		return fmt.Errorf("protected_stateful_partition is not a dm-clone device: %s", dmTableCloneOutput)
 	}
 	if cloneTable[4] != cryptNo {
-		return fmt.Errorf("protected_stateful_partition does not have protected_stateful_partition_crypt as a destination device: %s", string(dmTableCloneOutput))
+		return fmt.Errorf("protected_stateful_partition does not have protected_stateful_partition_crypt as a destination device: %s", dmTableCloneOutput)
 	}
 	if cloneTable[5] != zeroNo {
-		return fmt.Errorf("protected_stateful_partition protected_stateful_partition_zero as a source device: %s", string(dmTableCloneOutput))
+		return fmt.Errorf("protected_stateful_partition protected_stateful_partition_zero as a source device: %s", dmTableCloneOutput)
 	}
 
 	// Check protected_stateful_partition_crypt is encrypted and is on integrity protection.
-	dmTableCryptOutput, err := exec.Command("dmsetup", "table", "/dev/mapper/protected_stateful_partition_crypt").Output()
+	dmTableCryptOutput, err := verifier.DmsetupTable("/dev/mapper/protected_stateful_partition_crypt")
 	if err != nil {
-		return fmt.Errorf("failed to check /dev/mapper/protected_stateful_partition_crypt status: %v %s", err, string(dmTableCryptOutput))
+		return fmt.Errorf("failed to check /dev/mapper/protected_stateful_partition_crypt status: %v %s", err, dmTableCryptOutput)
 	}
-	matched := regexp.MustCompile(`integrity:28:aead`).FindString(string(dmTableCryptOutput))
+	matched := regexp.MustCompile(`integrity:28:aead`).FindString(dmTableCryptOutput)
 	if len(matched) == 0 {
 		return fmt.Errorf("stateful partition is not integrity protected: \n%s", dmTableCryptOutput)
 	}
-	matched = regexp.MustCompile(`capi:gcm\(aes\)-random`).FindString(string(dmTableCryptOutput))
+	matched = regexp.MustCompile(`capi:gcm\(aes\)-random`).FindString(dmTableCryptOutput)
 	if len(matched) == 0 {
 		return fmt.Errorf("stateful partition is not using the aes-gcm-random cipher: \n%s", dmTableCryptOutput)
 	}
 
-	// Make sure /var/lib/containerd is on protected_stateful_partition.
-	findmountOutput, err := exec.Command("findmnt", "/dev/mapper/protected_stateful_partition").Output()
+	// Check verity status on vroot and oemroot.
+	cryptSetupOutput, err := verifier.CryptsetupStatus("vroot")
 	if err != nil {
-		return fmt.Errorf("failed to findmnt /dev/mapper/protected_stateful_partition: %v %s", err, string(findmountOutput))
+		return fmt.Errorf("failed to check vroot status: %v %s", err, cryptSetupOutput)
 	}
-	matched = regexp.MustCompile(`/var/lib/containerd\s+/dev/mapper/protected_stateful_partition\[/var/lib/containerd\]\s+ext4\s+rw,nosuid,nodev,relatime,commit=30`).FindString(string(findmountOutput))
+	if !strings.Contains(cryptSetupOutput, "/dev/mapper/vroot is active and is in use.") {
+		return fmt.Errorf("/dev/mapper/vroot was not mounted correctly: \n%s", cryptSetupOutput)
+	}
+	cryptSetupOutput, err = verifier.CryptsetupStatus("oemroot")
+	if err != nil {
+		return fmt.Errorf("failed to check oemroot status: %v %s", err, cryptSetupOutput)
+	}
+	if !strings.Contains(cryptSetupOutput, "/dev/mapper/oemroot is active and is in use.") {
+		return fmt.Errorf("/dev/mapper/oemroot was not mounted correctly: \n%s", cryptSetupOutput)
+	}
+
+	return nil
+}
+
+func verifyMounts(launchSpec spec.LaunchSpec, verifier mountVerifier) error {
+	// Make sure /var/lib/containerd is on protected_stateful_partition.
+	findmountOutput, err := verifier.Findmnt("/dev/mapper/protected_stateful_partition")
+	if err != nil {
+		return fmt.Errorf("failed to findmnt /dev/mapper/protected_stateful_partition: %v %s", err, findmountOutput)
+	}
+	matched := regexp.MustCompile(`/var/lib/containerd\s+/dev/mapper/protected_stateful_partition\[/var/lib/containerd\]\s+ext4\s+rw,nosuid,nodev,relatime,commit=30`).FindString(findmountOutput)
 	if len(matched) == 0 {
 		return fmt.Errorf("/var/lib/containerd was not mounted on the protected_stateful_partition: \n%s", findmountOutput)
 	}
 	if !launchSpec.Experiments.BcMode {
-		matched = regexp.MustCompile(`/var/lib/google\s+/dev/mapper/protected_stateful_partition\[/var/lib/google\]\s+ext4\s+rw,nosuid,nodev,relatime,commit=30`).FindString(string(findmountOutput))
+		matched = regexp.MustCompile(`/var/lib/google\s+/dev/mapper/protected_stateful_partition\[/var/lib/google\]\s+ext4\s+rw,nosuid,nodev,relatime,commit=30`).FindString(findmountOutput)
 		if len(matched) == 0 {
 			return fmt.Errorf("/var/lib/google was not mounted on the protected_stateful_partition: \n%s", findmountOutput)
 		}
 	}
 
 	// Check /tmp is on tmpfs.
-	findmntOutput, err := exec.Command("findmnt", "tmpfs").Output()
+	findmntOutput, err := verifier.Findmnt("tmpfs")
 	if err != nil {
-		return fmt.Errorf("failed to findmnt tmpfs: %v %s", err, string(findmntOutput))
+		return fmt.Errorf("failed to findmnt tmpfs: %v %s", err, findmntOutput)
 	}
-	matched = regexp.MustCompile(`/tmp\s+tmpfs\s+tmpfs`).FindString(string(findmntOutput))
+	matched = regexp.MustCompile(`/tmp\s+tmpfs\s+tmpfs`).FindString(findmntOutput)
 	if len(matched) == 0 {
 		return fmt.Errorf("/tmp was not mounted on the tmpfs: \n%s", findmntOutput)
 	}
 
-	// Check verity status on vroot and oemroot.
-	cryptSetupOutput, err := exec.Command("cryptsetup", "status", "vroot").Output()
-	if err != nil {
-		return fmt.Errorf("failed to check vroot status: %v %s", err, string(cryptSetupOutput))
-	}
-	if !strings.Contains(string(cryptSetupOutput), "/dev/mapper/vroot is active and is in use.") {
-		return fmt.Errorf("/dev/mapper/vroot was not mounted correctly: \n%s", cryptSetupOutput)
-	}
-	cryptSetupOutput, err = exec.Command("cryptsetup", "status", "oemroot").Output()
-	if err != nil {
-		return fmt.Errorf("failed to check oemroot status: %v %s", err, string(cryptSetupOutput))
-	}
-	if !strings.Contains(string(cryptSetupOutput), "/dev/mapper/oemroot is active and is in use.") {
-		return fmt.Errorf("/dev/mapper/oemroot was not mounted correctly: \n%s", cryptSetupOutput)
-	}
-
 	return nil
+}
+
+type integrityVerifier interface {
+	DmsetupLs() (string, error)
+	DmsetupTable(name string) (string, error)
+	CryptsetupStatus(name string) (string, error)
+}
+
+type mountVerifier interface {
+	Findmnt(target string) (string, error)
+}
+
+type osMountVerifier struct{}
+
+func (osMountVerifier) DmsetupLs() (string, error) {
+	out, err := exec.Command("dmsetup", "ls").Output()
+	return string(out), err
+}
+
+func (osMountVerifier) DmsetupTable(name string) (string, error) {
+	out, err := exec.Command("dmsetup", "table", name).Output()
+	return string(out), err
+}
+
+func (osMountVerifier) Findmnt(target string) (string, error) {
+	out, err := exec.Command("findmnt", target).Output()
+	return string(out), err
+}
+
+func (osMountVerifier) CryptsetupStatus(name string) (string, error) {
+	out, err := exec.Command("cryptsetup", "status", name).Output()
+	return string(out), err
 }

--- a/launcher/launcher/main.go
+++ b/launcher/launcher/main.go
@@ -57,15 +57,8 @@ var BuildCommit = "dev"
 
 const serialConsoleFile = "/dev/console"
 
-var logger logging.Logger
-var workloadLogger logging.Logger
-var mdsClient *metadata.Client
-var launchSpec spec.LaunchSpec
-
-var welcomeMessage = "TEE container launcher initiating"
-var exitMessage = "TEE container launcher exiting"
-
-var start time.Time
+const welcomeMessage = "TEE container launcher initiating"
+const exitMessage = "TEE container launcher exiting"
 
 func main() {
 	uptime, err := getUptime()
@@ -74,7 +67,7 @@ func main() {
 		log.Default().Printf("error reading VM uptime: %v", err)
 	}
 	// Note the current time to later calculate launch time.
-	start = time.Now()
+	start := time.Now()
 
 	var exitCode int // by default exit code is 0
 	ctx := context.Background()
@@ -109,7 +102,7 @@ func main() {
 	}
 	defer serialConsole.Close()
 
-	workloadLogger, err = logging.NewCloudLogger(ctx, pool)
+	workloadLogger, err := logging.NewCloudLogger(ctx, pool)
 	if err != nil {
 		log.Default().Printf("failed to initialize cloud logging: %v", err)
 		exitCode = failRC
@@ -118,7 +111,7 @@ func main() {
 	}
 	defer workloadLogger.Close()
 
-	logger = logging.DualLogger(workloadLogger, logging.NewSerialLogger(serialConsole))
+	logger := logging.DualLogger(workloadLogger, logging.NewSerialLogger(serialConsole))
 
 	logger.Info("Boot completed", "duration_sec", uptime)
 	logger.Info(welcomeMessage, "build_commit", BuildCommit)
@@ -128,8 +121,8 @@ func main() {
 	}
 
 	// Get RestartPolicy and IsHardened from spec
-	mdsClient = metadata.NewClient(nil)
-	launchSpec, err = spec.GetLaunchSpec(ctx, logger, mdsClient)
+	mdsClient := metadata.NewClient(nil)
+	launchSpec, err := spec.GetLaunchSpec(ctx, logger, mdsClient)
 	if err != nil {
 		logger.Error(fmt.Sprintf("failed to get launchspec, make sure you're running inside a GCE VM: %v", err))
 		// if cannot get launchSpec, exit directly
@@ -138,7 +131,7 @@ func main() {
 		return
 	}
 
-	if err := verifyFsAndMount(); err != nil {
+	if err := verifyFsAndMount(launchSpec); err != nil {
 		logger.Error(fmt.Sprintf("failed to verify filesystem and mounts: %v\n", err))
 		exitCode = rebootRC
 		logger.Error(exitMessage, "exit_code", exitCode, "exit_msg", rcMessage[exitCode])
@@ -158,7 +151,7 @@ func main() {
 			logger.Info(exitMessage, "exit_code", exitCode)
 		}
 	}()
-	if err = startLauncher(launchSpec, serialConsole, googleClient, clientOpts...); err != nil {
+	if err = startLauncher(launchSpec, logger, workloadLogger, mdsClient, start, serialConsole, googleClient, clientOpts...); err != nil {
 		logger.Error(err.Error())
 	}
 
@@ -218,7 +211,16 @@ func getUptime() (string, error) {
 	return string(split[0]), nil
 }
 
-func startLauncher(launchSpec spec.LaunchSpec, serialConsole *os.File, googleClient *http.Client, clientOpts ...option.ClientOption) error {
+func startLauncher(
+	launchSpec spec.LaunchSpec,
+	logger logging.Logger,
+	workloadLogger logging.Logger,
+	mdsClient *metadata.Client,
+	start time.Time,
+	serialConsole *os.File,
+	googleClient *http.Client,
+	clientOpts ...option.ClientOption,
+) error {
 	logger.Info(fmt.Sprintf("Launch Spec: %+v", launchSpec.LogFriendly()))
 	containerdClient, err := containerd.New(defaults.DefaultAddress)
 	if err != nil {
@@ -226,7 +228,7 @@ func startLauncher(launchSpec spec.LaunchSpec, serialConsole *os.File, googleCli
 	}
 	defer containerdClient.Close()
 
-	tpm, err := initTPM(launchSpec)
+	tpm, err := initTPM(launchSpec, logger)
 	if err != nil {
 		return err
 	}
@@ -281,7 +283,7 @@ func startLauncher(launchSpec spec.LaunchSpec, serialConsole *os.File, googleCli
 	return r.Run(ctx)
 }
 
-func initTPM(launchSpec spec.LaunchSpec) (io.ReadWriteCloser, error) {
+func initTPM(launchSpec spec.LaunchSpec, logger logging.Logger) (io.ReadWriteCloser, error) {
 	if launchSpec.Experiments.BcMode {
 		logger.Info("Running in BC mode, bypassing TPM initialization and checks.")
 		return nil, nil
@@ -331,7 +333,7 @@ func initTPM(launchSpec spec.LaunchSpec) (io.ReadWriteCloser, error) {
 
 // verifyFsAndMount checks the partitions/mounts are as expected, based on the command output reported by OS.
 // These checks are not a security guarantee.
-func verifyFsAndMount() error {
+func verifyFsAndMount(launchSpec spec.LaunchSpec) error {
 	dmLsOutput, err := exec.Command("dmsetup", "ls").Output()
 	if err != nil {
 		return fmt.Errorf("failed to call `dmsetup ls`: %v %s", err, string(dmLsOutput))

--- a/launcher/launcher/main_test.go
+++ b/launcher/launcher/main_test.go
@@ -2,9 +2,11 @@ package main
 
 import (
 	"errors"
+	"strings"
 	"testing"
 
 	"github.com/google/go-tpm-tools/launcher"
+	"github.com/google/go-tpm-tools/launcher/internal/experiments"
 	"github.com/google/go-tpm-tools/launcher/spec"
 )
 
@@ -126,6 +128,373 @@ func TestGetExitCode(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			if rc := getExitCode(tc.isHardened, tc.restartPolicy, tc.err); rc != tc.expectedReturnCode {
 				t.Errorf("got %d, wanted %d", rc, tc.expectedReturnCode)
+			}
+		})
+	}
+}
+
+type fakeIntegrityVerifier struct {
+	dmsetupLsOut    string
+	dmsetupLsErr    error
+	dmsetupTableOut map[string]string
+	dmsetupTableErr map[string]error
+	cryptsetupOut   map[string]string
+	cryptsetupErr   map[string]error
+}
+
+func (f fakeIntegrityVerifier) DmsetupLs() (string, error) {
+	return f.dmsetupLsOut, f.dmsetupLsErr
+}
+
+func (f fakeIntegrityVerifier) DmsetupTable(name string) (string, error) {
+	if f.dmsetupTableErr != nil {
+		if err := f.dmsetupTableErr[name]; err != nil {
+			return "", err
+		}
+	}
+	return f.dmsetupTableOut[name], nil
+}
+
+func (f fakeIntegrityVerifier) CryptsetupStatus(name string) (string, error) {
+	if f.cryptsetupErr != nil {
+		if err := f.cryptsetupErr[name]; err != nil {
+			return "", err
+		}
+	}
+	return f.cryptsetupOut[name], nil
+}
+
+type fakeMountVerifier struct {
+	findmntOut map[string]string
+	findmntErr map[string]error
+}
+
+func (f fakeMountVerifier) Findmnt(target string) (string, error) {
+	if f.findmntErr != nil {
+		if err := f.findmntErr[target]; err != nil {
+			return "", err
+		}
+	}
+	return f.findmntOut[target], nil
+}
+
+func TestVerifyDiskIntegrity(t *testing.T) {
+	tests := []struct {
+		name          string
+		verifier      fakeIntegrityVerifier
+		expectedError string
+	}{
+		{
+			name: "success path",
+			verifier: fakeIntegrityVerifier{
+				dmsetupLsOut: `protected_stateful_partition (254:0)
+protected_stateful_partition_crypt (254:1)
+protected_stateful_partition_zero (254:2)`,
+				dmsetupTableOut: map[string]string{
+					"/dev/mapper/protected_stateful_partition":       "0 20971520 clone 254:99 254:1 254:2 8",
+					"/dev/mapper/protected_stateful_partition_crypt": "0 20971520 integrity:28:aead capi:gcm(aes)-random",
+				},
+				cryptsetupOut: map[string]string{
+					"vroot":   "/dev/mapper/vroot is active and is in use.",
+					"oemroot": "/dev/mapper/oemroot is active and is in use.",
+				},
+			},
+			expectedError: "",
+		},
+		{
+			name: "dmsetup ls fails",
+			verifier: fakeIntegrityVerifier{
+				dmsetupLsErr: errors.New("command failed"),
+			},
+			expectedError: "failed to call `dmsetup ls`: command failed",
+		},
+		{
+			name: "missing protected_stateful_partition",
+			verifier: fakeIntegrityVerifier{
+				dmsetupLsOut: `protected_stateful_partition_crypt (254:1)
+protected_stateful_partition_zero (254:2)`,
+			},
+			expectedError: "failed to find /dev/mapper/protected_stateful_partition",
+		},
+		{
+			name: "missing crypt partition",
+			verifier: fakeIntegrityVerifier{
+				dmsetupLsOut: `protected_stateful_partition (254:0)
+protected_stateful_partition_zero (254:2)`,
+			},
+			expectedError: "failed to find /dev/mapper/protected_stateful_partition_crypt",
+		},
+		{
+			name: "missing zero partition",
+			verifier: fakeIntegrityVerifier{
+				dmsetupLsOut: `protected_stateful_partition (254:0)
+protected_stateful_partition_crypt (254:1)`,
+			},
+			expectedError: "failed to find /dev/mapper/protected_stateful_partition_zero",
+		},
+		{
+			name: "dmsetup table clone fails",
+			verifier: fakeIntegrityVerifier{
+				dmsetupLsOut: `protected_stateful_partition (254:0)
+protected_stateful_partition_crypt (254:1)
+protected_stateful_partition_zero (254:2)`,
+				dmsetupTableErr: map[string]error{
+					"/dev/mapper/protected_stateful_partition": errors.New("table error"),
+				},
+			},
+			expectedError: "failed to check /dev/mapper/protected_stateful_partition status: table error",
+		},
+		{
+			name: "clone table wrong format",
+			verifier: fakeIntegrityVerifier{
+				dmsetupLsOut: `protected_stateful_partition (254:0)
+protected_stateful_partition_crypt (254:1)
+protected_stateful_partition_zero (254:2)`,
+				dmsetupTableOut: map[string]string{
+					"/dev/mapper/protected_stateful_partition": "0 20971520 clone",
+				},
+			},
+			expectedError: "clone table does not match expected format",
+		},
+		{
+			name: "not a dm-clone device",
+			verifier: fakeIntegrityVerifier{
+				dmsetupLsOut: `protected_stateful_partition (254:0)
+protected_stateful_partition_crypt (254:1)
+protected_stateful_partition_zero (254:2)`,
+				dmsetupTableOut: map[string]string{
+					"/dev/mapper/protected_stateful_partition": "0 20971520 linear 254:99 254:1 254:2 8",
+				},
+			},
+			expectedError: "protected_stateful_partition is not a dm-clone device",
+		},
+		{
+			name: "wrong destination device",
+			verifier: fakeIntegrityVerifier{
+				dmsetupLsOut: `protected_stateful_partition (254:0)
+protected_stateful_partition_crypt (254:1)
+protected_stateful_partition_zero (254:2)`,
+				dmsetupTableOut: map[string]string{
+					"/dev/mapper/protected_stateful_partition": "0 20971520 clone 254:99 254:99 254:2 8",
+				},
+			},
+			expectedError: "does not have protected_stateful_partition_crypt as a destination device",
+		},
+		{
+			name: "wrong source device",
+			verifier: fakeIntegrityVerifier{
+				dmsetupLsOut: `protected_stateful_partition (254:0)
+protected_stateful_partition_crypt (254:1)
+protected_stateful_partition_zero (254:2)`,
+				dmsetupTableOut: map[string]string{
+					"/dev/mapper/protected_stateful_partition": "0 20971520 clone 254:99 254:1 254:99 8",
+				},
+			},
+			expectedError: "protected_stateful_partition protected_stateful_partition_zero as a source device",
+		},
+		{
+			name: "crypt partition missing integrity",
+			verifier: fakeIntegrityVerifier{
+				dmsetupLsOut: `protected_stateful_partition (254:0)
+protected_stateful_partition_crypt (254:1)
+protected_stateful_partition_zero (254:2)`,
+				dmsetupTableOut: map[string]string{
+					"/dev/mapper/protected_stateful_partition":       "0 20971520 clone 254:99 254:1 254:2 8",
+					"/dev/mapper/protected_stateful_partition_crypt": "0 20971520 crypt aes-gcm-random",
+				},
+			},
+			expectedError: "stateful partition is not integrity protected",
+		},
+		{
+			name: "crypt partition wrong cipher",
+			verifier: fakeIntegrityVerifier{
+				dmsetupLsOut: `protected_stateful_partition (254:0)
+protected_stateful_partition_crypt (254:1)
+protected_stateful_partition_zero (254:2)`,
+				dmsetupTableOut: map[string]string{
+					"/dev/mapper/protected_stateful_partition":       "0 20971520 clone 254:99 254:1 254:2 8",
+					"/dev/mapper/protected_stateful_partition_crypt": "0 20971520 integrity:28:aead aes-gcm-random",
+				},
+			},
+			expectedError: "stateful partition is not using the aes-gcm-random cipher",
+		},
+		{
+			name: "vroot status fails",
+			verifier: fakeIntegrityVerifier{
+				dmsetupLsOut: `protected_stateful_partition (254:0)
+protected_stateful_partition_crypt (254:1)
+protected_stateful_partition_zero (254:2)`,
+				dmsetupTableOut: map[string]string{
+					"/dev/mapper/protected_stateful_partition":       "0 20971520 clone 254:99 254:1 254:2 8",
+					"/dev/mapper/protected_stateful_partition_crypt": "0 20971520 integrity:28:aead capi:gcm(aes)-random",
+				},
+				cryptsetupErr: map[string]error{
+					"vroot": errors.New("cryptsetup error"),
+				},
+			},
+			expectedError: "failed to check vroot status: cryptsetup error",
+		},
+		{
+			name: "vroot not active",
+			verifier: fakeIntegrityVerifier{
+				dmsetupLsOut: `protected_stateful_partition (254:0)
+protected_stateful_partition_crypt (254:1)
+protected_stateful_partition_zero (254:2)`,
+				dmsetupTableOut: map[string]string{
+					"/dev/mapper/protected_stateful_partition":       "0 20971520 clone 254:99 254:1 254:2 8",
+					"/dev/mapper/protected_stateful_partition_crypt": "0 20971520 integrity:28:aead capi:gcm(aes)-random",
+				},
+				cryptsetupOut: map[string]string{
+					"vroot":   "Device vroot is not active.",
+					"oemroot": "/dev/mapper/oemroot is active and is in use.",
+				},
+			},
+			expectedError: "/dev/mapper/vroot was not mounted correctly",
+		},
+		{
+			name: "oemroot not active",
+			verifier: fakeIntegrityVerifier{
+				dmsetupLsOut: `protected_stateful_partition (254:0)
+protected_stateful_partition_crypt (254:1)
+protected_stateful_partition_zero (254:2)`,
+				dmsetupTableOut: map[string]string{
+					"/dev/mapper/protected_stateful_partition":       "0 20971520 clone 254:99 254:1 254:2 8",
+					"/dev/mapper/protected_stateful_partition_crypt": "0 20971520 integrity:28:aead capi:gcm(aes)-random",
+				},
+				cryptsetupOut: map[string]string{
+					"vroot":   "/dev/mapper/vroot is active and is in use.",
+					"oemroot": "Device oemroot is inactive.",
+				},
+			},
+			expectedError: "/dev/mapper/oemroot was not mounted correctly",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := verifyDiskIntegrity(tc.verifier)
+			if tc.expectedError == "" {
+				if err != nil {
+					t.Errorf("expected no error, got %v", err)
+				}
+			} else {
+				if err == nil {
+					t.Errorf("expected error containing %q, got nil", tc.expectedError)
+				} else if !strings.Contains(err.Error(), tc.expectedError) {
+					t.Errorf("expected error containing %q, got %v", tc.expectedError, err)
+				}
+			}
+		})
+	}
+}
+
+func TestVerifyMounts(t *testing.T) {
+	tests := []struct {
+		name          string
+		launchSpec    spec.LaunchSpec
+		verifier      fakeMountVerifier
+		expectedError string
+	}{
+		{
+			name:       "success path",
+			launchSpec: spec.LaunchSpec{},
+			verifier: fakeMountVerifier{
+				findmntOut: map[string]string{
+					"/dev/mapper/protected_stateful_partition": `/var/lib/containerd /dev/mapper/protected_stateful_partition[/var/lib/containerd] ext4 rw,nosuid,nodev,relatime,commit=30
+/var/lib/google     /dev/mapper/protected_stateful_partition[/var/lib/google]     ext4 rw,nosuid,nodev,relatime,commit=30`,
+					"tmpfs": "/tmp tmpfs tmpfs rw,nosuid,nodev",
+				},
+			},
+			expectedError: "",
+		},
+		{
+			name: "success path BC mode",
+			launchSpec: spec.LaunchSpec{
+				Experiments: experiments.Experiments{
+					BcMode: true,
+				},
+			},
+			verifier: fakeMountVerifier{
+				findmntOut: map[string]string{
+					"/dev/mapper/protected_stateful_partition": "/var/lib/containerd /dev/mapper/protected_stateful_partition[/var/lib/containerd] ext4 rw,nosuid,nodev,relatime,commit=30",
+					"tmpfs": "/tmp tmpfs tmpfs rw,nosuid,nodev",
+				},
+			},
+			expectedError: "",
+		},
+		{
+			name:       "findmnt stateful fails",
+			launchSpec: spec.LaunchSpec{},
+			verifier: fakeMountVerifier{
+				findmntErr: map[string]error{
+					"/dev/mapper/protected_stateful_partition": errors.New("findmnt error"),
+				},
+			},
+			expectedError: "failed to findmnt /dev/mapper/protected_stateful_partition: findmnt error",
+		},
+		{
+			name:       "containerd missing",
+			launchSpec: spec.LaunchSpec{},
+			verifier: fakeMountVerifier{
+				findmntOut: map[string]string{
+					"/dev/mapper/protected_stateful_partition": "/var/lib/google     /dev/mapper/protected_stateful_partition[/var/lib/google]     ext4 rw,nosuid,nodev,relatime,commit=30",
+					"tmpfs": "/tmp tmpfs tmpfs rw,nosuid,nodev",
+				},
+			},
+			expectedError: "/var/lib/containerd was not mounted on the protected_stateful_partition",
+		},
+		{
+			name:       "google missing (non-BC mode)",
+			launchSpec: spec.LaunchSpec{},
+			verifier: fakeMountVerifier{
+				findmntOut: map[string]string{
+					"/dev/mapper/protected_stateful_partition": "/var/lib/containerd /dev/mapper/protected_stateful_partition[/var/lib/containerd] ext4 rw,nosuid,nodev,relatime,commit=30",
+					"tmpfs": "/tmp tmpfs tmpfs rw,nosuid,nodev",
+				},
+			},
+			expectedError: "/var/lib/google was not mounted on the protected_stateful_partition",
+		},
+		{
+			name:       "findmnt tmpfs fails",
+			launchSpec: spec.LaunchSpec{},
+			verifier: fakeMountVerifier{
+				findmntOut: map[string]string{
+					"/dev/mapper/protected_stateful_partition": `/var/lib/containerd /dev/mapper/protected_stateful_partition[/var/lib/containerd] ext4 rw,nosuid,nodev,relatime,commit=30
+/var/lib/google     /dev/mapper/protected_stateful_partition[/var/lib/google]     ext4 rw,nosuid,nodev,relatime,commit=30`,
+				},
+				findmntErr: map[string]error{
+					"tmpfs": errors.New("tmpfs error"),
+				},
+			},
+			expectedError: "failed to findmnt tmpfs: tmpfs error",
+		},
+		{
+			name:       "tmp missing on tmpfs",
+			launchSpec: spec.LaunchSpec{},
+			verifier: fakeMountVerifier{
+				findmntOut: map[string]string{
+					"/dev/mapper/protected_stateful_partition": `/var/lib/containerd /dev/mapper/protected_stateful_partition[/var/lib/containerd] ext4 rw,nosuid,nodev,relatime,commit=30
+/var/lib/google     /dev/mapper/protected_stateful_partition[/var/lib/google]     ext4 rw,nosuid,nodev,relatime,commit=30`,
+					"tmpfs": "",
+				},
+			},
+			expectedError: "/tmp was not mounted on the tmpfs",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := verifyMounts(tc.launchSpec, tc.verifier)
+			if tc.expectedError == "" {
+				if err != nil {
+					t.Errorf("expected no error, got %v", err)
+				}
+			} else {
+				if err == nil {
+					t.Errorf("expected error containing %q, got nil", tc.expectedError)
+				} else if !strings.Contains(err.Error(), tc.expectedError) {
+					t.Errorf("expected error containing %q, got %v", tc.expectedError, err)
+				}
 			}
 		})
 	}


### PR DESCRIPTION
### Rationale
The launcher's boot pipeline (`launcher/launcher/main.go`) was previously untestable because it relied on hardcoded system calls—specifically, opening the physical TPM device (`/dev/tpmrm0`) and executing host CLI binaries (`dmsetup`, `findmnt`, `cryptsetup`) to verify partitions. 

By dependency injecting these resources as interfaces, we can now pass lightweight mock implementations in unit tests, allowing us to test the startup and verification logic in isolation.

### Changes
*   **TPM Handle Injection**: Moved the `tpm2.OpenTPM` call directly to `main()`. The opened `io.ReadWriteCloser` is now passed as a parameter to `initTPM` and `startLauncher`, allowing tests to easily inject a fake TPM.
*   **Mount Verifier Injection**: Defined a `mountVerifier` interface to abstract the device mapper and mount queries. Refactored `verifyFsAndMount` to accept this interface, using `osMountVerifier` in production and enabling mock verifiers in tests.