### PR TITLE
logging: add missing io import in tests

### DIFF
--- a/launcher/internal/logging/logging_test.go
+++ b/launcher/internal/logging/logging_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
+	"io"
 	"log/slog"
 	"reflect"
 	"strings"


### PR DESCRIPTION
I submitted a commit missing an import breaking tests. This fixes it.