### PR TITLE
launcher: enable unit testing for ContainerRunner creation

### DIFF
--- a/go.work.sum
+++ b/go.work.sum
@@ -1792,6 +1792,7 @@ github.com/golang/glog v1.2.0/go.mod h1:6AhwSGph0fcJtXVM/PEHPqZlFeoLxhs7/t5UDAwm
 github.com/golang/glog v1.2.2/go.mod h1:6AhwSGph0fcJtXVM/PEHPqZlFeoLxhs7/t5UDAwmO+w=
 github.com/golang/glog v1.2.5 h1:DrW6hGnjIhtvhOIiAKT6Psh/Kd/ldepEa81DKeiRJ5I=
 github.com/golang/glog v1.2.5/go.mod h1:6AhwSGph0fcJtXVM/PEHPqZlFeoLxhs7/t5UDAwmO+w=
+github.com/golang/groupcache v0.0.0-20241129210726-2c02b8208cf8 h1:f+oWsMOmNPc8JmEHVZIycC7hBoQxHH9pNKQORJNozsQ=
 github.com/golang/groupcache v0.0.0-20241129210726-2c02b8208cf8/go.mod h1:wcDNUvekVysuuOpQKo3191zZyTpiI6se1N1ULghS0sw=
 github.com/golang/mock v1.6.0 h1:ErTB+efbowRARo13NNdxyJji2egdxLGQhRaY+DUumQc=
 github.com/golang/mock v1.7.0-rc.1/go.mod h1:s42URUywIqd+OcERslBJvOjepvNymP31m3q8d/GkuRs=
@@ -2254,6 +2255,7 @@ github.com/prometheus/procfs v0.0.3/go.mod h1:4A/X28fw3Fc593LaREMrKMqOKvUAntwMDa
 github.com/prometheus/procfs v0.0.5/go.mod h1:4A/X28fw3Fc593LaREMrKMqOKvUAntwMDaekg4FpcdQ=
 github.com/prometheus/procfs v0.7.3/go.mod h1:cz+aTbrPOrUb4q7XlbU9ygM+/jj0fzG6c1xBZuNvfVA=
 github.com/prometheus/procfs v0.10.1/go.mod h1:nwNm2aOCAYw8uTR/9bWRREkZFxAUcWzPHWJq+XBB/FM=
+github.com/prometheus/procfs v0.16.0 h1:xh6oHhKwnOJKMYiYBDWmkHqQPyiY40sny36Cmx2bbsM=
 github.com/prometheus/procfs v0.16.0/go.mod h1:8veyXUu3nGP7oaCxhX6yeaM5u4stL2FeMXnCqhDthZg=
 github.com/prometheus/tsdb v0.7.1 h1:YZcsG11NqnK4czYLrWd9mpEuAJIHVQLwdrleYfszMAA=
 github.com/pseudomuto/protoc-gen-doc v1.5.0 h1:pHZp0MEiT68jrZV8js8BS7E9ZEnlSLegoQbbtXj5lfo=

--- a/launcher/container_runner.go
+++ b/launcher/container_runner.go
@@ -96,9 +96,17 @@ const (
 // Default OOM score for a CS container.
 const defaultOOMScore = 1000
 
+// ContainerdClient abstracts the subset of containerd.Client methods used by the
+// runner. This enables unit testing by allowing a mock client to be injected.
+type ContainerdClient interface {
+	LoadContainer(ctx context.Context, id string) (containerd.Container, error)
+	NewContainer(ctx context.Context, id string, opts ...containerd.NewContainerOpts) (containerd.Container, error)
+	Pull(ctx context.Context, ref string, opts ...containerd.RemoteOpt) (containerd.Image, error)
+}
+
 // RunnerConfig contains the configuration for creating a ContainerRunner.
 type RunnerConfig struct {
-	ContainerdClient *containerd.Client
+	ContainerdClient ContainerdClient
 	Token            oauth2.Token
 	LaunchSpec       spec.LaunchSpec
 	MetadataClient   *metadata.Client
@@ -108,6 +116,7 @@ type RunnerConfig struct {
 	SerialConsole    *os.File
 	GoogleClient     *http.Client
 	ClientOpts       []option.ClientOption
+	AKFetcher        util.TpmKeyFetcher
 }
 
 // NewRunner returns a runner.
@@ -369,7 +378,11 @@ func NewRunner(ctx context.Context, cfg *RunnerConfig) (*ContainerRunner, error)
 		EnableGpuGcaSupport:       launchSpec.Experiments.EnableGpuGcaSupport,
 		BcMode:                    launchSpec.Experiments.BcMode,
 	}
-	attestAgent, err := agent.CreateAttestationAgent(tpm, client.GceAttestationKeyECC, verifierClient, principalFetcherWithImpersonate, sdClient, exps, logger, deviceROTs, launchSpec.SignedImageRepos)
+	akFetcher := cfg.AKFetcher
+	if akFetcher == nil {
+		akFetcher = client.GceAttestationKeyECC
+	}
+	attestAgent, err := agent.CreateAttestationAgent(tpm, akFetcher, verifierClient, principalFetcherWithImpersonate, sdClient, exps, logger, deviceROTs, launchSpec.SignedImageRepos)
 	if err != nil {
 		return nil, err
 	}
@@ -420,7 +433,7 @@ func enableMonitoring(enabled spec.MonitoringType, logger logging.Logger) error 
 	return nil
 }
 
-func getSignatureDiscoveryClient(cdClient *containerd.Client, mdsClient *metadata.Client, imageDesc v1.Descriptor, googleHTTPClient *http.Client) signaturediscovery.Fetcher {
+func getSignatureDiscoveryClient(cdClient ContainerdClient, mdsClient *metadata.Client, imageDesc v1.Descriptor, googleHTTPClient *http.Client) signaturediscovery.Fetcher {
 	resolverFetcher := func(ctx context.Context) (remotes.Resolver, error) {
 		return registryauth.RefreshResolver(ctx, mdsClient, googleHTTPClient)
 	}
@@ -938,7 +951,7 @@ func pullImageWithRetries(f func() (containerd.Image, error), retry func() backo
 	return image, nil
 }
 
-func initImage(ctx context.Context, cdClient *containerd.Client, launchSpec spec.LaunchSpec, token oauth2.Token, googleClient *http.Client) (containerd.Image, error) {
+func initImage(ctx context.Context, cdClient ContainerdClient, launchSpec spec.LaunchSpec, token oauth2.Token, googleClient *http.Client) (containerd.Image, error) {
 	var accessToken string
 	if token.Valid() {
 		accessToken = token.AccessToken

--- a/launcher/container_runner_test.go
+++ b/launcher/container_runner_test.go
@@ -5,8 +5,10 @@ import (
 	"context"
 	"crypto/rand"
 	"crypto/rsa"
+	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"net/http"
 	"os"
 	"path"
@@ -16,8 +18,10 @@ import (
 	"testing"
 	"time"
 
+	clogging "cloud.google.com/go/logging"
 	"github.com/cenkalti/backoff/v4"
 	"github.com/containerd/containerd"
+	"github.com/containerd/containerd/content"
 	"github.com/containerd/containerd/defaults"
 	"github.com/containerd/containerd/namespaces"
 	"github.com/containerd/containerd/oci"
@@ -26,10 +30,12 @@ import (
 	gecel "github.com/google/go-eventlog/cel"
 	"github.com/google/go-tpm-tools/agent"
 	"github.com/google/go-tpm-tools/cel"
+	"github.com/google/go-tpm-tools/client"
 	"github.com/google/go-tpm-tools/launcher/internal/gpu"
 	"github.com/google/go-tpm-tools/launcher/internal/logging"
 	"github.com/google/go-tpm-tools/launcher/launcherfile"
 	"github.com/google/go-tpm-tools/launcher/spec"
+	"github.com/google/go-tpm-tools/simulator"
 	"github.com/google/go-tpm-tools/verifier"
 	"github.com/opencontainers/go-digest"
 	v1 "github.com/opencontainers/image-spec/specs-go/v1"
@@ -837,11 +843,20 @@ func (c *fakeContainer) Spec(context.Context) (*oci.Spec, error) {
 	return &oci.Spec{Process: &specs.Process{Args: c.args, Env: c.env}}, nil
 }
 
+func (c *fakeContainer) ID() string {
+	return "tee-container"
+}
+
+func (c *fakeContainer) Delete(context.Context, ...containerd.DeleteOpts) error {
+	return nil
+}
+
 type fakeImage struct {
 	containerd.Image
-	name   string
-	digest digest.Digest
-	id     digest.Digest
+	name         string
+	digest       digest.Digest
+	id           digest.Digest
+	contentStore content.Store
 }
 
 func (i *fakeImage) Name() string {
@@ -853,5 +868,202 @@ func (i *fakeImage) Target() v1.Descriptor {
 }
 
 func (i *fakeImage) Config(_ context.Context) (v1.Descriptor, error) {
-	return v1.Descriptor{Digest: i.id}, nil
+	return v1.Descriptor{
+		Digest:    i.id,
+		MediaType: v1.MediaTypeImageConfig,
+	}, nil
+}
+
+func (i *fakeImage) ContentStore() content.Store {
+	return i.contentStore
+}
+
+type fakeContainerdClient struct {
+	pullResult containerd.Image
+	loadResult containerd.Container
+	newResult  containerd.Container
+	pullErr    error
+	loadErr    error
+	newErr     error
+}
+
+func (f *fakeContainerdClient) Pull(context.Context, string, ...containerd.RemoteOpt) (containerd.Image, error) {
+	return f.pullResult, f.pullErr
+}
+func (f *fakeContainerdClient) LoadContainer(context.Context, string) (containerd.Container, error) {
+	return f.loadResult, f.loadErr
+}
+func (f *fakeContainerdClient) NewContainer(context.Context, string, ...containerd.NewContainerOpts) (containerd.Container, error) {
+	return f.newResult, f.newErr
+}
+
+type fakeContentStore struct {
+	content.Store
+	blob []byte
+}
+
+func (f *fakeContentStore) ReaderAt(context.Context, v1.Descriptor) (content.ReaderAt, error) {
+	return &fakeReaderAt{blob: f.blob}, nil
+}
+
+type fakeReaderAt struct {
+	blob []byte
+}
+
+func (f *fakeReaderAt) ReadAt(p []byte, off int64) (int, error) {
+	if off >= int64(len(f.blob)) {
+		return 0, io.EOF
+	}
+	n := copy(p, f.blob[off:])
+	return n, nil
+}
+func (f *fakeReaderAt) Close() error { return nil }
+func (f *fakeReaderAt) Size() int64  { return int64(len(f.blob)) }
+
+type fakeLogger struct {
+	logs []string
+}
+
+func (f *fakeLogger) Log(clogging.Severity, string, ...any) {}
+func (f *fakeLogger) Info(msg string, args ...any) {
+	f.logs = append(f.logs, formatLog(msg, args...))
+}
+func (f *fakeLogger) Warn(string, ...any)  {}
+func (f *fakeLogger) Error(string, ...any) {}
+func (f *fakeLogger) Close()               {}
+
+func formatLog(msg string, args ...any) string {
+	if len(args) == 0 {
+		return msg
+	}
+	return msg + " " + strings.Trim(strings.Join(strings.Fields(strings.Trim(strings.Join(strings.Fields(strings.Trim(jsonMarshal(args), "[]")), " "), " ")), " "), " ")
+}
+
+func jsonMarshal(v any) string {
+	b, _ := json.Marshal(v)
+	return string(b)
+}
+
+func TestNewRunner(t *testing.T) {
+	// Helper to generate image configuration JSON.
+	imageConfigJSON := func(labels map[string]string) []byte {
+		ic := v1.Image{
+			Config: v1.ImageConfig{
+				ExposedPorts: map[string]struct{}{},
+				Labels:       labels,
+			},
+		}
+		b, _ := json.Marshal(ic)
+		return b
+	}
+
+	testCases := []struct {
+		name          string
+		imageLabels   map[string]string
+		envs          []spec.EnvVar
+		cmd           []string
+		wantErr       bool
+		wantErrSubstr string
+		verifyLogs    func(t *testing.T, logs []string)
+	}{
+		{
+			name: "Success_RedactEnvs",
+			imageLabels: map[string]string{
+				"tee.launch_policy.allow_env_override": "SECRET_VAR,PUBLIC_VAR",
+			},
+			envs: []spec.EnvVar{
+				{Name: "SECRET_VAR", Value: "mysecret"},
+				{Name: "PUBLIC_VAR", Value: "public"},
+			},
+			wantErr: false,
+			verifyLogs: func(t *testing.T, logs []string) {
+				foundSecret := false
+				foundPublic := false
+				for _, l := range logs {
+					if strings.Contains(l, "SECRET_VAR=[REDACTED]") {
+						foundSecret = true
+					}
+					if strings.Contains(l, "PUBLIC_VAR=[REDACTED]") {
+						foundPublic = true
+					}
+					if strings.Contains(l, "mysecret") || strings.Contains(l, "=public") {
+						t.Errorf("found unredacted variable value in logs: %s", l)
+					}
+				}
+				if !foundSecret || !foundPublic {
+					t.Errorf("expected redacted env variables not found in logs: %v", logs)
+				}
+			},
+		},
+		{
+			name:        "Failure_LaunchPolicyEnvViolation",
+			imageLabels: map[string]string{}, // Empty labels = no overrides allowed
+			envs: []spec.EnvVar{
+				{Name: "SECRET_VAR", Value: "mysecret"},
+			},
+			wantErr:       true,
+			wantErrSubstr: "is not allowed to be overridden",
+		},
+		{
+			name: "Failure_LaunchPolicyCmdViolation",
+			imageLabels: map[string]string{
+				"tee.launch_policy.allow_cmd_override": "false",
+			},
+			cmd:           []string{"/override-cmd"},
+			wantErr:       true,
+			wantErrSubstr: "CMD is not allowed to be overridden",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			fakeImg := &fakeImage{
+				name:         "test-image",
+				digest:       "sha256:1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
+				id:           "sha256:1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
+				contentStore: &fakeContentStore{blob: imageConfigJSON(tc.imageLabels)},
+			}
+			fakeCont := &fakeContainer{
+				args: []string{"/entrypoint.sh", "arg1"},
+			}
+			fakeCli := &fakeContainerdClient{
+				pullResult: fakeImg,
+				loadResult: nil,
+				loadErr:    errors.New("container not found"),
+				newResult:  fakeCont,
+			}
+
+			logger := &fakeLogger{}
+			tpm, err := simulator.Get()
+			if err != nil {
+				t.Skipf("TPM simulator not available: %v", err)
+			}
+			defer tpm.Close()
+
+			cfg := &RunnerConfig{
+				ContainerdClient: fakeCli,
+				TPM:              tpm,
+				AKFetcher:        client.AttestationKeyECC,
+				LaunchSpec: spec.LaunchSpec{
+					ImageRef:            "test-image",
+					Envs:                tc.envs,
+					Cmd:                 tc.cmd,
+					FakeVerifierEnabled: true,
+				},
+				Logger:         logger,
+				WorkloadLogger: logger,
+			}
+
+			_, err = NewRunner(context.Background(), cfg)
+			if (err != nil) != tc.wantErr {
+				t.Fatalf("NewRunner() error = %v, wantErr = %v", err, tc.wantErr)
+			}
+			if tc.wantErr && err != nil && !strings.Contains(err.Error(), tc.wantErrSubstr) {
+				t.Fatalf("NewRunner() error = %q, want error containing %q", err, tc.wantErrSubstr)
+			}
+			if tc.verifyLogs != nil {
+				tc.verifyLogs(t, logger.logs)
+			}
+		})
+	}
 }


### PR DESCRIPTION
NewRunner was previously untestable because it directly depended on a live `containerd` daemon socket and hardware-specific GCE TPM NVRAM indices. Introduce a mockable `containerdClient` interface and make the Attestation Key fetcher configurable. This allows testing runner configuration logic (such as environment variable log redaction and launch policies) locally using a TPM  simulator.