### PR TITLE
launcher: refactor monolithic NewRunner initialization into StartLauncher

### DIFF
--- a/launcher/container_runner.go
+++ b/launcher/container_runner.go
@@ -32,7 +32,6 @@ import (
 	"github.com/golang-jwt/jwt/v4"
 	"github.com/google/go-tpm-tools/agent"
 	"github.com/google/go-tpm-tools/cel"
-	"github.com/google/go-tpm-tools/client"
 	keymanager "github.com/google/go-tpm-tools/keymanager/km_common/proto"
 	workloadservice "github.com/google/go-tpm-tools/keymanager/workload_service"
 	"github.com/google/go-tpm-tools/launcher/internal/gpu"
@@ -43,13 +42,8 @@ import (
 	"github.com/google/go-tpm-tools/launcher/registryauth"
 	"github.com/google/go-tpm-tools/launcher/spec"
 	"github.com/google/go-tpm-tools/launcher/teeserver"
-	"github.com/google/go-tpm-tools/verifier"
-	"github.com/google/go-tpm-tools/verifier/fake"
-	"github.com/google/go-tpm-tools/verifier/ita"
-	"github.com/google/go-tpm-tools/verifier/util"
 	v1 "github.com/opencontainers/image-spec/specs-go/v1"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
-	"google.golang.org/api/option"
 	"google.golang.org/protobuf/proto"
 )
 
@@ -63,7 +57,7 @@ type ContainerRunner struct {
 	gpuAttester    gpu.Attester
 	serialConsole  *os.File
 	powerButton    *powerButtonListener // Populated only for a hardened image
-	clientOpts     []option.ClientOption
+	attestClients  teeserver.AttestClients
 }
 
 const tokenFileTmp = ".token.tmp"
@@ -107,30 +101,25 @@ type ContainerdClient interface {
 // RunnerConfig contains the configuration for creating a ContainerRunner.
 type RunnerConfig struct {
 	ContainerdClient ContainerdClient
+	Image            containerd.Image
+	AttestAgent      agent.AttestationAgent
+	GpuAttester      gpu.Attester
+	AttestClients    teeserver.AttestClients
 	LaunchSpec       spec.LaunchSpec
-	MetadataClient   *metadata.Client
-	TPM              io.ReadWriteCloser
 	Logger           logging.Logger
 	WorkloadLogger   logging.Logger
 	SerialConsole    *os.File
-	GoogleClient     *http.Client
-	ClientOpts       []option.ClientOption
-	AKFetcher        util.TpmKeyFetcher
-	Image            containerd.Image
 }
 
 // NewRunner returns a runner.
 func NewRunner(ctx context.Context, cfg *RunnerConfig) (*ContainerRunner, error) {
 	cdClient := cfg.ContainerdClient
 	launchSpec := cfg.LaunchSpec
-	mdsClient := cfg.MetadataClient
-	tpm := cfg.TPM
 	logger := cfg.Logger
 	workloadLogger := cfg.WorkloadLogger
 	serialConsole := cfg.SerialConsole
-	googleClient := cfg.GoogleClient
-	opts := cfg.ClientOpts
 	image := cfg.Image
+	attestAgent := cfg.AttestAgent
 
 	var mounts []specs.Mount
 	for _, lsMnt := range launchSpec.Mounts {
@@ -154,7 +143,8 @@ func NewRunner(ctx context.Context, cfg *RunnerConfig) (*ContainerRunner, error)
 	container, err := cdClient.LoadContainer(ctx, containerID)
 	if err == nil {
 		// container exists, delete it first
-		container.Delete(ctx, containerd.WithSnapshotCleanup)
+		// TODO: consider handling or logging cleanup error.
+		_ = container.Delete(ctx, containerd.WithSnapshotCleanup)
 	}
 
 	var loggedEnvs []string
@@ -245,8 +235,6 @@ func NewRunner(ctx context.Context, cfg *RunnerConfig) (*ContainerRunner, error)
 	}
 	specOpts = append(specOpts, cgroupOpts...)
 
-	var deviceROTs []agent.DeviceROT
-	nvidiaAttester := gpu.NewNvidiaAttester(launchSpec.InstallGpuDriver)
 	if launchSpec.InstallGpuDriver {
 		gpuMounts := []specs.Mount{
 			{
@@ -297,7 +285,6 @@ func NewRunner(ctx context.Context, cfg *RunnerConfig) (*ContainerRunner, error)
 			logger.Info(fmt.Sprintf("Detected nvidia device : %s", deviceFile))
 			specOpts = append(specOpts, oci.WithDevices(deviceFile, deviceFile, "crw-rw-rw-"))
 		}
-		deviceROTs = append(deviceROTs, nvidiaAttester)
 	}
 
 	container, err = cdClient.NewContainer(
@@ -309,7 +296,8 @@ func NewRunner(ctx context.Context, cfg *RunnerConfig) (*ContainerRunner, error)
 	)
 	if err != nil {
 		if container != nil {
-			container.Delete(ctx, containerd.WithSnapshotCleanup)
+			// TODO: consider handling or logging cleanup error.
+			_ = container.Delete(ctx, containerd.WithSnapshotCleanup)
 		}
 		return nil, &RetryableError{fmt.Errorf("failed to create a container: [%w]", err)}
 	}
@@ -329,60 +317,6 @@ func NewRunner(ctx context.Context, cfg *RunnerConfig) (*ContainerRunner, error)
 				len(containerSpec.Process.Args), len(launchSpec.Cmd))
 	}
 
-	principalFetcherWithImpersonate := func(audience string) ([][]byte, error) {
-		tokens, err := util.PrincipalFetcher(audience, mdsClient)
-		if err != nil {
-			return nil, err
-		}
-
-		// Fetch impersonated ID tokens.
-		for _, sa := range launchSpec.ImpersonateServiceAccounts {
-			idToken, err := FetchImpersonatedToken(ctx, sa, audience, opts...)
-			if err != nil {
-				return nil, fmt.Errorf("failed to get impersonated token for %v: %w", sa, err)
-			}
-
-			tokens = append(tokens, idToken)
-		}
-		return tokens, nil
-	}
-
-	asAddr := launchSpec.GcaAddress
-
-	var verifierClient verifier.Client
-	if launchSpec.FakeVerifierEnabled {
-		verifierClient = fake.NewClient(nil)
-	} else if launchSpec.ITAConfig.ITARegion == "" {
-		gcaClient, err := util.NewRESTClient(ctx, asAddr, launchSpec.ProjectID, launchSpec.Region, opts...)
-		if err != nil {
-			if !launchSpec.DisableGcaRefresh {
-				return nil, fmt.Errorf("failed to create REST verifier client: %v", err)
-			}
-			// If GCA refresh is disabled, swallow the error and continue.
-			logger.Info("Failed to create the GCA client for attestation agent, this is not necessarily blocking because GCA refresh is disabled so the launch will continue: %v", err)
-			gcaClient = nil
-		}
-
-		verifierClient = gcaClient
-	}
-
-	// Create a new signaturediscovery client to fetch signatures.
-	sdClient := getSignatureDiscoveryClient(cdClient, mdsClient, image.Target(), googleClient)
-
-	exps := agent.Experiments{
-		EnableAttestationEvidence: launchSpec.Experiments.EnableAttestationEvidence,
-		EnableGpuGcaSupport:       launchSpec.Experiments.EnableGpuGcaSupport,
-		BcMode:                    launchSpec.Experiments.BcMode,
-	}
-	akFetcher := cfg.AKFetcher
-	if akFetcher == nil {
-		akFetcher = client.GceAttestationKeyECC
-	}
-	attestAgent, err := agent.CreateAttestationAgent(tpm, akFetcher, verifierClient, principalFetcherWithImpersonate, sdClient, exps, logger, deviceROTs, launchSpec.SignedImageRepos)
-	if err != nil {
-		return nil, err
-	}
-
 	var powerButton *powerButtonListener
 	if launchSpec.Hardened {
 		powerButton, err = newPowerButtonListener(logger)
@@ -397,10 +331,10 @@ func NewRunner(ctx context.Context, cfg *RunnerConfig) (*ContainerRunner, error)
 		attestAgent,
 		logger,
 		workloadLogger,
-		nvidiaAttester,
+		cfg.GpuAttester,
 		serialConsole,
 		powerButton,
-		opts,
+		cfg.AttestClients,
 	}, nil
 }
 
@@ -773,32 +707,6 @@ func (r *ContainerRunner) Run(ctx context.Context) error {
 	// create and start the TEE server
 	r.logger.Info("EnableOnDemandAttestation is enabled: initializing TEE server.")
 
-	attestClients := teeserver.AttestClients{}
-
-	if r.launchSpec.FakeVerifierEnabled {
-		fakeClient := fake.NewClient(nil)
-		attestClients.GCA = fakeClient
-		attestClients.ITA = fakeClient
-	} else if r.launchSpec.ITAConfig.ITARegion != "" {
-		itaClient, err := ita.NewClient(r.launchSpec.ITAConfig)
-		if err != nil {
-			return fmt.Errorf("failed to create ITA client: %v", err)
-		}
-
-		attestClients.ITA = itaClient
-	} else {
-		gcaClient, err := util.NewRESTClient(ctx, r.launchSpec.GcaAddress, r.launchSpec.ProjectID, r.launchSpec.Region, r.clientOpts...)
-		if err != nil {
-			if !r.launchSpec.DisableGcaRefresh {
-				return fmt.Errorf("failed to create REST verifier client: %v", err)
-			}
-			// If GCA refresh is disabled, swallow the error and continue.
-			r.logger.Info("Failed to create the GCA client, but GCA refresh is disabled so the launch will continue: %v", err)
-			gcaClient = nil
-		}
-		attestClients.GCA = gcaClient
-	}
-
 	var workloadService *workloadservice.Server
 	// create and start the key manager server
 	if r.launchSpec.Experiments.EnableKeyManager {
@@ -813,12 +721,12 @@ func (r *ContainerRunner) Run(ctx context.Context) error {
 			return fmt.Errorf("failed to verify KeyManager socket permissions: %w", err)
 		}
 		workloadService = keyManagerServer
-		go keyManagerServer.Serve()
-		defer keyManagerServer.Shutdown(ctx)
+		go func() { _ = keyManagerServer.Serve() }()
+		defer func() { _ = keyManagerServer.Shutdown(ctx) }()
 	}
 
 	teeServerSocketPath := path.Join(launcherfile.HostTmpPath, teeServerSocket)
-	teeServer, err := teeserver.New(ctx, teeServerSocketPath, r.attestAgent, r.logger, r.launchSpec, attestClients, workloadService)
+	teeServer, err := teeserver.New(ctx, teeServerSocketPath, r.attestAgent, r.logger, r.launchSpec, r.attestClients, workloadService)
 	if err != nil {
 		return fmt.Errorf("failed to create the TEE server: %v", err)
 	}
@@ -826,8 +734,8 @@ func (r *ContainerRunner) Run(ctx context.Context) error {
 		return fmt.Errorf("failed to verify TEE server socket permissions: %w", err)
 	}
 
-	go teeServer.Serve()
-	defer teeServer.Shutdown(ctx)
+	go func() { _ = teeServer.Serve() }()
+	defer func() { _ = teeServer.Shutdown(ctx) }()
 
 	// Avoids breaking existing memory monitoring tests that depend on this log.
 	if r.launchSpec.MonitoringEnabled == spec.None {
@@ -1036,7 +944,8 @@ func (r *ContainerRunner) Close(ctx context.Context) {
 
 	// Exit gracefully:
 	// Delete container and close connection to attestation service.
-	r.container.Delete(ctx, containerd.WithSnapshotCleanup)
+	// TODO: consider handling or logging cleanup error.
+	_ = r.container.Delete(ctx, containerd.WithSnapshotCleanup)
 }
 
 // withRlimits sets the rlimit (like the max file descriptor) for the container process

--- a/launcher/container_runner_test.go
+++ b/launcher/container_runner_test.go
@@ -30,12 +30,10 @@ import (
 	gecel "github.com/google/go-eventlog/cel"
 	"github.com/google/go-tpm-tools/agent"
 	"github.com/google/go-tpm-tools/cel"
-	"github.com/google/go-tpm-tools/client"
 	"github.com/google/go-tpm-tools/launcher/internal/gpu"
 	"github.com/google/go-tpm-tools/launcher/internal/logging"
 	"github.com/google/go-tpm-tools/launcher/launcherfile"
 	"github.com/google/go-tpm-tools/launcher/spec"
-	"github.com/google/go-tpm-tools/simulator"
 	"github.com/google/go-tpm-tools/verifier"
 	"github.com/opencontainers/go-digest"
 	v1 "github.com/opencontainers/image-spec/specs-go/v1"
@@ -983,17 +981,10 @@ func TestNewRunner(t *testing.T) {
 			}
 
 			logger := &fakeLogger{}
-			tpm, err := simulator.Get()
-			if err != nil {
-				t.Skipf("TPM simulator not available: %v", err)
-			}
-			defer tpm.Close()
-
 			cfg := &RunnerConfig{
 				ContainerdClient: fakeCli,
 				Image:            fakeImg,
-				TPM:              tpm,
-				AKFetcher:        client.AttestationKeyECC,
+				AttestAgent:      &fakeAttestationAgent{},
 				LaunchSpec: spec.LaunchSpec{
 					ImageRef:            "test-image",
 					Envs:                tc.envs,
@@ -1004,7 +995,7 @@ func TestNewRunner(t *testing.T) {
 				WorkloadLogger: logger,
 			}
 
-			_, err = NewRunner(context.Background(), cfg)
+			_, err := NewRunner(context.Background(), cfg)
 			if (err != nil) != tc.wantErr {
 				t.Fatalf("NewRunner() error = %v, wantErr = %v", err, tc.wantErr)
 			}

--- a/launcher/errors.go
+++ b/launcher/errors.go
@@ -19,3 +19,29 @@ func (e *RetryableError) Error() string {
 func (e *WorkloadError) Error() string {
 	return "workload finished with a non-zero return code"
 }
+
+// TPMOpenError represents a failure to open the TPM device.
+type TPMOpenError struct {
+	Err error
+}
+
+func (e *TPMOpenError) Error() string {
+	return fmt.Sprintf("failed to open TPM device: %v", e.Err)
+}
+
+func (e *TPMOpenError) Unwrap() error {
+	return e.Err
+}
+
+// TPMInitError represents a failure to initialize/validate the TPM.
+type TPMInitError struct {
+	Err error
+}
+
+func (e *TPMInitError) Error() string {
+	return fmt.Sprintf("failed to initialize TPM: %v", e.Err)
+}
+
+func (e *TPMInitError) Unwrap() error {
+	return e.Err
+}

--- a/launcher/launcher/main.go
+++ b/launcher/launcher/main.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io"
 	"log"
 	"os"
 	"os/exec"
@@ -15,12 +14,10 @@ import (
 	"time"
 
 	"cloud.google.com/go/compute/metadata"
-	"github.com/google/go-tpm-tools/client"
 	"github.com/google/go-tpm-tools/launcher"
 	"github.com/google/go-tpm-tools/launcher/internal/logging"
 	"github.com/google/go-tpm-tools/launcher/launcherfile"
 	"github.com/google/go-tpm-tools/launcher/spec"
-	"github.com/google/go-tpm/legacy/tpm2"
 	"google.golang.org/api/option"
 )
 
@@ -31,12 +28,6 @@ const (
 	rebootRC = 3 // reboot
 	holdRC   = 4 // hold
 )
-
-var expectedTPMDAParams = launcher.TPMDAParams{
-	MaxTries:        0x20,    // 32 tries
-	RecoveryTime:    0x1C20,  // 120 mins
-	LockoutRecovery: 0x15180, // 24 hrs
-}
 
 var rcMessage = map[int]string{
 	successRC: "workload finished successfully, shutting down the VM",
@@ -138,25 +129,6 @@ func main() {
 		return
 	}
 
-	var tpm io.ReadWriteCloser
-	if !launchSpec.Experiments.BcMode {
-		tpm, err = tpm2.OpenTPM("/dev/tpmrm0")
-		if err != nil {
-			logger.Error(fmt.Sprintf("failed to open TPM device: %v", err))
-			exitCode = rebootRC
-			logger.Error(exitMessage, "exit_code", exitCode, "exit_msg", rcMessage[exitCode])
-			return
-		}
-		defer tpm.Close()
-
-		if err := initTPM(tpm, logger); err != nil {
-			logger.Error(fmt.Sprintf("failed to initialize TPM: %v", err))
-			exitCode = getExitCode(launchSpec.Hardened, launchSpec.RestartPolicy, err)
-			logger.Error(exitMessage, "exit_code", exitCode, "exit_msg", rcMessage[exitCode])
-			return
-		}
-	}
-
 	defer func() {
 		// Catch panic to attempt to output to Cloud Logging.
 		if r := recover(); r != nil {
@@ -170,8 +142,18 @@ func main() {
 			logger.Info(exitMessage, "exit_code", exitCode)
 		}
 	}()
-	if err = launcher.StartLauncher(ctx, launchSpec, tpm, logger, workloadLogger, mdsClient, start, serialConsole, googleClient, clientOpts...); err != nil {
+	if err = launcher.StartLauncher(ctx, launchSpec, logger, workloadLogger, serialConsole, clientOpts...); err != nil {
 		logger.Error(err.Error())
+		var tpmOpenErr *launcher.TPMOpenError
+		if errors.As(err, &tpmOpenErr) {
+			exitCode = rebootRC
+			return
+		}
+		var tpmInitErr *launcher.TPMInitError
+		if errors.As(err, &tpmInitErr) {
+			exitCode = getExitCode(launchSpec.Hardened, launchSpec.RestartPolicy, err)
+			return
+		}
 	}
 
 	workloadDuration := time.Since(start)
@@ -228,42 +210,6 @@ func getUptime() (string, error) {
 	}
 
 	return string(split[0]), nil
-}
-
-func initTPM(tpm io.ReadWriteCloser, logger logging.Logger) error {
-	// check DA info, don't crash if failed
-	daInfo, err := launcher.GetTPMDAInfo(tpm)
-	if err != nil {
-		logger.Error(fmt.Sprintf("Failed to get DA Info: %v", err))
-	} else {
-		if !daInfo.StartupClearOrderly {
-			logger.Warn(fmt.Sprintf("Failed orderly startup. Avoid using instance reset. Instead, use instance stop/start. DA lockout counter incremented: LockoutCounter: %d / MaxAuthFail: %d", daInfo.LockoutCounter, daInfo.MaxTries))
-		}
-
-		if err := launcher.SetTPMDAParams(tpm, expectedTPMDAParams); err != nil {
-			logger.Error(fmt.Sprintf("Failed to set DA params: %v", err))
-		}
-
-		daInfo, err := launcher.GetTPMDAInfo(tpm)
-		if err != nil {
-			logger.Error(fmt.Sprintf("Failed to get DA Info: %v", err))
-		} else {
-			logger.Info(fmt.Sprintf("Updated TPM DA params: %+v", daInfo))
-		}
-	}
-
-	// check AK (EK signing) cert
-	gceAk, err := client.GceAttestationKeyECC(tpm)
-	if err != nil {
-		return err
-	}
-	defer gceAk.Close()
-
-	if gceAk.Cert() == nil {
-		return errors.New("failed to find AKCert on this VM: try creating a new VM or contacting support")
-	}
-
-	return nil
 }
 
 // verifyFsAndMount checks the partitions/mounts are as expected, based on the command output reported by OS.

--- a/launcher/start.go
+++ b/launcher/start.go
@@ -2,44 +2,55 @@ package launcher
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
-	"net/http"
 	"os"
-	"time"
 
 	"cloud.google.com/go/compute/metadata"
 	"cos.googlesource.com/cos/tools.git/src/cmd/cos_gpu_installer/deviceinfo"
 	"github.com/containerd/containerd"
 	"github.com/containerd/containerd/defaults"
 	"github.com/containerd/containerd/namespaces"
+	"github.com/google/go-tpm-tools/agent"
+	"github.com/google/go-tpm-tools/client"
 	"github.com/google/go-tpm-tools/launcher/internal/gpu"
 	"github.com/google/go-tpm-tools/launcher/internal/logging"
 	"github.com/google/go-tpm-tools/launcher/registryauth"
 	"github.com/google/go-tpm-tools/launcher/spec"
+	"github.com/google/go-tpm-tools/launcher/teeserver"
+	"github.com/google/go-tpm-tools/verifier"
+	"github.com/google/go-tpm-tools/verifier/fake"
+	"github.com/google/go-tpm-tools/verifier/ita"
+	"github.com/google/go-tpm-tools/verifier/util"
+	"github.com/google/go-tpm/legacy/tpm2"
 	"google.golang.org/api/option"
 )
 
-// StartLauncher orchestrates the container creation and runs the ContainerRunner.
-func StartLauncher(
-	ctx context.Context,
-	launchSpec spec.LaunchSpec,
-	tpm io.ReadWriteCloser,
-	logger logging.Logger,
-	workloadLogger logging.Logger,
-	mdsClient *metadata.Client,
-	start time.Time,
-	serialConsole *os.File,
-	googleClient *http.Client,
-	clientOpts ...option.ClientOption,
-) error {
-	logger.Info(fmt.Sprintf("Launch Spec: %+v", launchSpec.LogFriendly()))
+var expectedTPMDAParams = TPMDAParams{
+	MaxTries:        0x20,    // 32 tries
+	RecoveryTime:    0x1C20,  // 120 mins
+	LockoutRecovery: 0x15180, // 24 hrs
+}
+
+// StartLauncher orchestrates the client creation, image pulling, attestation agent setup,
+// and runs the ContainerRunner.
+func StartLauncher(ctx context.Context, launchSpec spec.LaunchSpec, logger logging.Logger, workloadLogger logging.Logger, serialConsole *os.File, clientOpts ...option.ClientOption) error {
 	containerdClient, err := containerd.New(defaults.DefaultAddress)
 	if err != nil {
 		return &RetryableError{Err: err}
 	}
 	defer containerdClient.Close()
 
+	tpm, err := initTPM(launchSpec, logger)
+	if err != nil {
+		return err
+	}
+	if tpm != nil {
+		defer tpm.Close()
+	}
+
+	mdsClient := metadata.NewClient(nil)
 	token, err := registryauth.RetrieveAuthToken(ctx, mdsClient)
 	if err != nil {
 		logger.Info(fmt.Sprintf("failed to retrieve auth token: %v, using empty auth for image pulling", err))
@@ -64,24 +75,74 @@ func StartLauncher(
 		}
 	}
 
-	logger.Info("Launch started", "duration_sec", time.Since(start).Seconds())
+	googleClient, err := GoogleHTTPClient()
+	if err != nil {
+		return fmt.Errorf("failed to initialize Google root HTTP client: %v", err)
+	}
 
 	image, err := initImage(ctx, containerdClient, launchSpec, token, googleClient)
+	if err != nil {
+		return err
+	}
+	// Initialize verifier client and attest clients.
+	attestClients, err := createAttestClients(ctx, launchSpec, logger, clientOpts...)
+	if err != nil {
+		return err
+	}
+	var verifierClient verifier.Client
+	if launchSpec.ITAConfig.ITARegion != "" && !launchSpec.FakeVerifierEnabled {
+		verifierClient = attestClients.ITA
+	} else {
+		verifierClient = attestClients.GCA
+	}
+
+	// Create principal fetcher.
+	principalFetcherWithImpersonate := func(audience string) ([][]byte, error) {
+		tokens, err := util.PrincipalFetcher(audience, mdsClient)
+		if err != nil {
+			return nil, err
+		}
+		for _, sa := range launchSpec.ImpersonateServiceAccounts {
+			idToken, err := FetchImpersonatedToken(ctx, sa, audience, clientOpts...)
+			if err != nil {
+				return nil, fmt.Errorf("failed to get impersonated token for %v: %w", sa, err)
+			}
+			tokens = append(tokens, idToken)
+		}
+		return tokens, nil
+	}
+
+	// Create signature discovery client.
+	sdClient := getSignatureDiscoveryClient(containerdClient, mdsClient, image.Target(), googleClient)
+
+	// Create device ROTs and GpuAttester.
+	var deviceROTs []agent.DeviceROT
+	gpuAttester := gpu.NewNvidiaAttester(launchSpec.InstallGpuDriver)
+	if launchSpec.InstallGpuDriver {
+		deviceROTs = append(deviceROTs, gpuAttester)
+	}
+
+	// Create AttestationAgent.
+	exps := agent.Experiments{
+		EnableAttestationEvidence: launchSpec.Experiments.EnableAttestationEvidence,
+		EnableGpuGcaSupport:       launchSpec.Experiments.EnableGpuGcaSupport,
+		BcMode:                    launchSpec.Experiments.BcMode,
+	}
+	attestAgent, err := agent.CreateAttestationAgent(tpm, client.GceAttestationKeyECC, verifierClient, principalFetcherWithImpersonate, sdClient, exps, logger, deviceROTs, launchSpec.SignedImageRepos)
 	if err != nil {
 		return err
 	}
 
 	r, err := NewRunner(ctx, &RunnerConfig{
 		ContainerdClient: containerdClient,
+		Image:            image,
+		AttestAgent:      attestAgent,
+		GpuAttester:      gpuAttester,
+		AttestClients:    attestClients,
 		LaunchSpec:       launchSpec,
-		MetadataClient:   mdsClient,
-		TPM:              tpm,
 		Logger:           logger,
 		WorkloadLogger:   workloadLogger,
 		SerialConsole:    serialConsole,
-		GoogleClient:     googleClient,
-		ClientOpts:       clientOpts,
-		Image:            image,
 	})
 	if err != nil {
 		return err
@@ -89,4 +150,80 @@ func StartLauncher(
 	defer r.Close(ctx)
 
 	return r.Run(ctx)
+}
+
+func initTPM(launchSpec spec.LaunchSpec, logger logging.Logger) (io.ReadWriteCloser, error) {
+	if launchSpec.Experiments.BcMode {
+		logger.Info("Running in BC mode, bypassing TPM initialization and checks.")
+		return nil, nil
+	}
+
+	tpm, err := tpm2.OpenTPM("/dev/tpmrm0")
+	if err != nil {
+		return nil, &TPMOpenError{Err: err}
+	}
+
+	// check DA info, don't crash if failed
+	daInfo, err := GetTPMDAInfo(tpm)
+	if err != nil {
+		logger.Error(fmt.Sprintf("Failed to get DA Info: %v", err))
+	} else {
+		if !daInfo.StartupClearOrderly {
+			logger.Warn(fmt.Sprintf("Failed orderly startup. Avoid using instance reset. Instead, use instance stop/start. DA lockout counter incremented: LockoutCounter: %d / MaxAuthFail: %d", daInfo.LockoutCounter, daInfo.MaxTries))
+		}
+
+		if err := SetTPMDAParams(tpm, expectedTPMDAParams); err != nil {
+			logger.Error(fmt.Sprintf("Failed to set DA params: %v", err))
+		}
+
+		daInfo, err := GetTPMDAInfo(tpm)
+		if err != nil {
+			logger.Error(fmt.Sprintf("Failed to get DA Info: %v", err))
+		} else {
+			logger.Info(fmt.Sprintf("Updated TPM DA params: %+v", daInfo))
+		}
+	}
+
+	// check AK (EK signing) cert
+	gceAk, err := client.GceAttestationKeyECC(tpm)
+	if err != nil {
+		tpm.Close()
+		return nil, &TPMInitError{Err: err}
+	}
+	defer gceAk.Close()
+
+	if gceAk.Cert() == nil {
+		tpm.Close()
+		return nil, &TPMInitError{Err: errors.New("failed to find AKCert on this VM: try creating a new VM or contacting support")}
+	}
+
+	return tpm, nil
+}
+
+func createAttestClients(ctx context.Context, launchSpec spec.LaunchSpec, logger logging.Logger, clientOpts ...option.ClientOption) (teeserver.AttestClients, error) {
+	attestClients := teeserver.AttestClients{}
+
+	if launchSpec.FakeVerifierEnabled {
+		fakeClient := fake.NewClient(nil)
+		attestClients.GCA = fakeClient
+		attestClients.ITA = fakeClient
+	} else if launchSpec.ITAConfig.ITARegion != "" {
+		itaClient, err := ita.NewClient(launchSpec.ITAConfig)
+		if err != nil {
+			return attestClients, fmt.Errorf("failed to create ITA client: %v", err)
+		}
+		attestClients.ITA = itaClient
+	} else {
+		gcaClient, err := util.NewRESTClient(ctx, launchSpec.GcaAddress, launchSpec.ProjectID, launchSpec.Region, clientOpts...)
+		if err != nil {
+			if !launchSpec.DisableGcaRefresh {
+				return attestClients, fmt.Errorf("failed to create REST verifier client: %v", err)
+			}
+			logger.Info("Failed to create the GCA client, but GCA refresh is disabled so the launch will continue: %v", err)
+			gcaClient = nil
+		}
+		attestClients.GCA = gcaClient
+	}
+
+	return attestClients, nil
 }


### PR DESCRIPTION
To make the runner testable in isolation, this change moves resource acquisition (TPM handles, registry authentication, containerd client connections, and verifier clients) out of the library code (NewRunner) and into the orchestration layer (StartLauncher). This allows us to inject mock or fake resources in unit tests instead of requiring real hardware and network resources during construction.
