### PR TITLE
Allow fluentbit forwarding

### DIFF
--- a/launcher/image/bc-guest/bc-fluent-bit-cs.conf
+++ b/launcher/image/bc-guest/bc-fluent-bit-cs.conf
@@ -69,10 +69,21 @@
     Match         kernel-logs
     Regex         msg NVRM:\s*Xid
 
-# TODO: Add additional filtering logic
+# Collects network status logs
+[INPUT]
+    Name           systemd
+    Tag            network-logs
+    Systemd_Filter _SYSTEMD_UNIT=systemd-networkd.service
+    DB             /var/log/google-fluentbit/systemd-networkd.log.db
+    Read_From_Tail False
+
+# Filters network logs for selected events.
+[FILTER]
+    Name          grep
+    Match         network-logs
+    Regex         MESSAGE (?i)(Link (UP|DOWN)|lease lost|(Lost|Gained) carrier|found matching network|DHCPv[46] address|Interface name change detected)
 
 # Collects logs from remote fluent-bit forwarders
-# These logs are pre-filtered
 [INPUT]
     Name forward
     Listen 192.168.100.2

--- a/launcher/image/bc-guest/bc-fluent-bit-cs.conf
+++ b/launcher/image/bc-guest/bc-fluent-bit-cs.conf
@@ -63,7 +63,13 @@
     Name kmsg
     Tag kernel-logs
 
-# TODO: apply log filtering
+# Filters kernel logs to only NVRM GPU messages
+[FILTER]
+    Name          grep
+    Match         kernel-logs
+    Regex         msg NVRM:\s*Xid
+
+# TODO: Add additional filtering logic
 
 # Collects logs from remote fluent-bit forwarders
 # These logs are pre-filtered

--- a/launcher/image/bc-guest/bc-fluent-bit-cs.conf
+++ b/launcher/image/bc-guest/bc-fluent-bit-cs.conf
@@ -1,5 +1,5 @@
 #
-# Copyright 2022 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/launcher/image/bc-guest/bc-fluent-bit-cs.conf
+++ b/launcher/image/bc-guest/bc-fluent-bit-cs.conf
@@ -1,0 +1,74 @@
+#
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# Forked from https://cos.googlesource.com/cos/overlays/board-overlays/+/refs/heads/master/project-lakitu/app-admin/fluent-bit/files/fluent-bit.conf
+
+[SERVICE]
+    # Flush
+    # =====
+    # set an interval of seconds before to flush records to a destination
+    flush        1
+    # Daemon
+    # ======
+    # instruct Fluent Bit to run in foreground or background mode.
+    daemon       Off
+    # Log_Level
+    # =========
+    # Set the verbosity level of the service, values can be:
+    #
+    # - error
+    # - warning
+    # - info
+    # - debug
+    # - trace
+    #
+    # by default 'info' is set, that means it includes 'error' and 'warning'.
+    log_level    info
+    # Storage
+    # =======
+    # Fluent Bit can use memory and filesystem buffering based mechanisms
+    #
+    # - https://docs.fluentbit.io/manual/administration/buffering-and-storage
+    #
+    # storage metrics
+    # ---------------
+    # publish storage pipeline metrics in '/api/v1/storage'. The metrics are
+    # exported only if the 'http_server' option is enabled.
+    #
+    storage.metrics on
+
+# Collects CS launcher and workload logs.
+[INPUT]
+    Name systemd
+    Tag  confidential-space-launcher
+    Systemd_Filter _SYSTEMD_UNIT=container-runner.service
+    DB /var/log/google-fluentbit/container-runner.log.db
+    Read_From_Tail False
+
+# Collects logs from remote fluent-bit forwarders
+[INPUT]
+    Name forward
+    Listen 192.168.100.2
+    Port 24224
+
+[OUTPUT]
+    Name        stackdriver
+    Match       *
+    Resource    gce_instance
+    severity_key severity
+    tls         On
+    tls.ca_file /usr/share/oem/google_roots.pem
+

--- a/launcher/image/bc-guest/bc-fluent-bit-cs.conf
+++ b/launcher/image/bc-guest/bc-fluent-bit-cs.conf
@@ -58,7 +58,15 @@
     DB /var/log/google-fluentbit/container-runner.log.db
     Read_From_Tail False
 
+# Collects log from /dev/kmsg
+[INPUT]
+    Name kmsg
+    Tag kernel-logs
+
+# TODO: apply log filtering
+
 # Collects logs from remote fluent-bit forwarders
+# These logs are pre-filtered
 [INPUT]
     Name forward
     Listen 192.168.100.2

--- a/launcher/image/bc-guest/bc-fluent-bit-cs.conf
+++ b/launcher/image/bc-guest/bc-fluent-bit-cs.conf
@@ -58,16 +58,24 @@
     DB /var/log/google-fluentbit/container-runner.log.db
     Read_From_Tail False
 
+# Collects Workload Service Daemon (WSD) logs
+[INPUT]
+    Name           systemd
+    Tag            wsd-service
+    Systemd_Filter _SYSTEMD_UNIT=wsd.service
+    DB             /var/log/google-fluentbit/wsd.log.db
+    Read_From_Tail False
+
 # Collects log from /dev/kmsg
 [INPUT]
     Name kmsg
     Tag kernel-logs
 
-# Filters kernel logs to only NVRM GPU messages
+# Filters kernel logs to only NVRM GPU and OOM messages
 [FILTER]
     Name          grep
     Match         kernel-logs
-    Regex         msg NVRM:\s*Xid
+    Regex         msg (NVRM:\s*Xid|Out of memory)
 
 # Collects network status logs
 [INPUT]

--- a/launcher/image/bc-guest/bcentrypoint.sh
+++ b/launcher/image/bc-guest/bcentrypoint.sh
@@ -52,8 +52,10 @@ main() {
     /usr/share/oem/confidential_space/bc_gpu_setup.sh
   fi
 
-  # Allow incoming connections to fluent bit from KPS VM
-  iptables -A INPUT -p tcp -s 192.168.100.0/24 --dport 24224 -j ACCEPT
+  # Allow incoming Fluent Bit logs from host
+  iptables -A INPUT -p tcp -s 192.168.100.1 --dport 24224 -j ACCEPT
+  # Allow incoming Fluent Bit logs from KPS VM
+  iptables -A INPUT -p tcp -s 192.168.100.3 --dport 24224 -j ACCEPT
 
   systemctl enable container-runner.service
   systemctl enable wsd.service

--- a/launcher/image/bc-guest/bcentrypoint.sh
+++ b/launcher/image/bc-guest/bcentrypoint.sh
@@ -52,8 +52,6 @@ main() {
     /usr/share/oem/confidential_space/bc_gpu_setup.sh
   fi
 
-  # Allow incoming Fluent Bit logs from host
-  iptables -A INPUT -p tcp -s 192.168.100.1 --dport 24224 -j ACCEPT
   # Allow incoming Fluent Bit logs from KPS VM
   iptables -A INPUT -p tcp -s 192.168.100.3 --dport 24224 -j ACCEPT
 

--- a/launcher/image/bc-guest/bcentrypoint.sh
+++ b/launcher/image/bc-guest/bcentrypoint.sh
@@ -59,7 +59,7 @@ main() {
   systemctl enable wsd.service
   systemctl start container-runner.service
   systemctl start wsd.service
-  systemctl start fluent-bit.service
+  systemctl restart fluent-bit.service
 }
 
 main

--- a/launcher/image/bc-guest/bcentrypoint.sh
+++ b/launcher/image/bc-guest/bcentrypoint.sh
@@ -14,7 +14,7 @@ main() {
   cp /usr/share/oem/wsd/wsd.service /etc/systemd/system/wsd.service
   # Override default fluent-bit config.
   mkdir -p /etc/fluent-bit
-  cp /usr/share/oem/confidential_space/fluent-bit-cs.conf /etc/fluent-bit/fluent-bit.conf
+  cp /usr/share/oem/confidential_space/bc-fluent-bit-cs.conf /etc/fluent-bit/fluent-bit.conf
 
   mkdir /tmp/container_launcher
   chmod +rw /tmp/container_launcher
@@ -51,6 +51,9 @@ main() {
   if [[ -f /usr/share/oem/confidential_space/bc_gpu_setup.sh ]]; then
     /usr/share/oem/confidential_space/bc_gpu_setup.sh
   fi
+
+  # Allow incoming connections to fluent bit from KPS VM
+  iptables -A INPUT -p tcp -s 192.168.100.0/24 --dport 24224 -j ACCEPT
 
   systemctl enable container-runner.service
   systemctl enable wsd.service

--- a/launcher/image/bc_cloudbuild.yaml
+++ b/launcher/image/bc_cloudbuild.yaml
@@ -69,7 +69,7 @@ steps:
         cp ./launcher/image/bc-guest/bcexperiment.json \
            ./launcher/image/launcher \
            ./launcher/image/container-runner.service \
-           ./launcher/image/fluent-bit-cs.conf \
+           ./launcher/image/bc-guest/bc-fluent-bit-cs.conf \
            ./launcher/image/exit_script.sh \
            ./launcher/image/bc-guest/bc_network_setup.sh \
            ./launcher/image/bc-guest/bc_network_optimization.sh \


### PR DESCRIPTION
Create a dedicated fluent-bit config file to accept forwarded logs and enable additional collection and filtration.

Key changes:

- [new] bc-fluent-bit.config: 
Collect and filter kernel, network logs and WSD
Configure fluent-bit forward receiver

- bc-entrypoint.sh
Update `iptables` firewall rules to allow incoming TCP port 24224 traffic exclusively from the KPS vm.
Update to use newly created config file

Additional filtering logic is expected to be added.
See https://github.com/GoogleCloudPlatform/key-protection-module/pull/64 for corresponding KPS VM change.
