### PR TITLE
[launcher/image/measure] Add support for measuring nested VM images in host images

### DIFF
--- a/go.work
+++ b/go.work
@@ -6,6 +6,7 @@ use (
 	./cmd
 	./keymanager
 	./launcher
+	./launcher/image/measure
 	./verifier
 )
 

--- a/launcher/image/measure/Dockerfile
+++ b/launcher/image/measure/Dockerfile
@@ -1,5 +1,13 @@
 # From current directory:
 # gcloud builds submit --tag us-docker.pkg.dev/confidential-space-images-dev/cs-tools/measure:latest --project confidential-space-images-dev
+
+FROM golang:1.24 AS builder
+WORKDIR /src
+COPY go.mod go.sum ./
+RUN go mod download
+COPY extract_image_ovmf.go ./
+RUN go build -o /usr/local/bin/extract_image_ovmf extract_image_ovmf.go
+
 FROM gcr.io/cloud-builders/gcloud
 
 # Prevent interactive prompts during package installation
@@ -31,6 +39,9 @@ RUN apt-get update && apt-get install -y \
 
 RUN pip install --no-cache-dir lief
 
+
+# Copy the compiled extract_image_ovmf binary from builder stage
+COPY --from=builder /usr/local/bin/extract_image_ovmf /usr/local/bin/extract_image_ovmf
 
 # Copy the measure.sh script into the container
 # Ensure you have the script file in the same directory as this Dockerfile

--- a/launcher/image/measure/extract_image_ovmf.go
+++ b/launcher/image/measure/extract_image_ovmf.go
@@ -1,0 +1,42 @@
+// Package main provides an offline utility to calculate the expected MRTD
+// (Measurement of Resources at Td Launch) from a TDX firmware file (OVMF).
+package main
+
+import (
+	"encoding/hex"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/google/gce-tcb-verifier/tdx"
+)
+
+// cleanTdx takes the raw firmware bytes, simulates the hardware launch,
+// and returns the expected 48-byte MRTD as a hex string.
+func cleanTdx(fw []byte) string {
+	meas, err := tdx.MRTD(tdx.LaunchOptionsDefault(""), fw)
+	if err != nil {
+		fmt.Printf("Failed to compute MRTD: %v\n", err)
+		os.Exit(1)
+	}
+	return hex.EncodeToString(meas[:])
+}
+
+func main() {
+	filePath := "OVMF.inteltdx.fd"
+	if len(os.Args) > 1 {
+		filePath = os.Args[1]
+	}
+
+	fmt.Printf("Reading file: %s\n", filepath.Base(filePath))
+
+	fw, err := os.ReadFile(filePath)
+	if err != nil {
+		fmt.Printf("Failed to read file %s: %v\n", filePath, err)
+		os.Exit(1)
+	}
+
+	mrtdHex := cleanTdx(fw)
+
+	fmt.Printf("MRTD: %s\n", mrtdHex)
+}

--- a/launcher/image/measure/go.mod
+++ b/launcher/image/measure/go.mod
@@ -1,0 +1,11 @@
+module github.com/google/go-tpm-tools/launcher/image/measure
+
+go 1.24.0
+
+require github.com/google/gce-tcb-verifier v0.3.1
+
+require (
+	github.com/google/uuid v1.6.0 // indirect
+	golang.org/x/exp v0.0.0-20240409090435-93d18d7e34b8 // indirect
+	google.golang.org/protobuf v1.33.0 // indirect
+)

--- a/launcher/image/measure/go.sum
+++ b/launcher/image/measure/go.sum
@@ -1,0 +1,10 @@
+github.com/google/gce-tcb-verifier v0.3.1 h1:4L9YgkOtqC2U7cj4FofCUufHFCCpdD4Y0yPKI8UhOhI=
+github.com/google/gce-tcb-verifier v0.3.1/go.mod h1:GZCDLQxmEOCqUTL2BMB/zjo+hgXdUrR0Wgwz1OrwRYg=
+github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
+github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
+github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
+github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+golang.org/x/exp v0.0.0-20240409090435-93d18d7e34b8 h1:ESSUROHIBHg7USnszlcdmjBEwdMj9VUvU+OPk4yl2mc=
+golang.org/x/exp v0.0.0-20240409090435-93d18d7e34b8/go.mod h1:/lliqkxwWAhPjf5oSOIJup2XcqJaw8RGS6k3TGEc7GI=
+google.golang.org/protobuf v1.33.0 h1:uNO2rsAINq/JlFpSdYEKIZ0uKD/R9cpdv0T+yoGwGmI=
+google.golang.org/protobuf v1.33.0/go.mod h1:c6P6GXX6sHbq/GpV6MGZEdwhWPcYBgnhAHhKbcUYpos=

--- a/launcher/image/measure/measure_composite.sh
+++ b/launcher/image/measure/measure_composite.sh
@@ -20,7 +20,7 @@ trap 'rm -rf "$TMP_DIR"' EXIT
 # Verify dependencies proactively
 check_dependencies() {
     local missing_cmds=0
-    local deps=(cgpt debugfs qemu-img dd)
+    local deps=(cgpt debugfs qemu-img dd tar find)
     if [[ -n "${NESTED_IMAGES:-}" ]]; then
         for cmd in "${deps[@]}"; do
             if ! command -v "$cmd" &>/dev/null; then
@@ -36,8 +36,53 @@ check_dependencies() {
 run_dual_measurements() {
     local target_image="$1"
     local output_base="$2"
-    /usr/local/bin/measure.sh "$target_image" "${output_base}_sha256.json" "$CHANNEL" "$ARCH" sha256
-    /usr/local/bin/measure.sh "$target_image" "${output_base}_sha384.json" "$CHANNEL" "$ARCH" sha384
+    local measure_cmd="/usr/local/bin/measure.sh"
+    if [[ ! -x "$measure_cmd" && -f "$(dirname "$0")/measure.sh" ]]; then
+        measure_cmd="$(dirname "$0")/measure.sh"
+    fi
+    "$measure_cmd" "$target_image" "${output_base}_sha256.json" "$CHANNEL" "$ARCH" sha256
+    "$measure_cmd" "$target_image" "${output_base}_sha384.json" "$CHANNEL" "$ARCH" sha384
+}
+
+# Helper to extract OVMF firmware from ext4 partition layers and compute offline MRTD
+extract_and_measure_ovmf() {
+    local part_ext4="$1"
+    local output_base="$2"
+
+    local ovmf_tmp="$TMP_DIR/ovmf"
+    mkdir -p "$ovmf_tmp"
+
+    local out_fd_file="$ovmf_tmp/OVMF.fd"
+
+    # 1. Attempt exact path extraction based on host-acos directory layout (/tdx-qemu-app/usr/share/ovmf/OVMF.inteltdx.fd)
+    debugfs -R "dump /tdx-qemu-app/usr/share/ovmf/OVMF.inteltdx.fd $out_fd_file" "$part_ext4" 2>/dev/null || true
+
+    # 2. If directory path not found, attempt extraction from legacy tarball layout (/tdx-qemu-app.tar)
+    if [[ ! -f "$out_fd_file" || ! -s "$out_fd_file" ]]; then
+        debugfs -R "dump /tdx-qemu-app.tar $ovmf_tmp/tdx-qemu-app.tar" "$part_ext4" 2>/dev/null || true
+        if [[ -f "$ovmf_tmp/tdx-qemu-app.tar" && -s "$ovmf_tmp/tdx-qemu-app.tar" ]]; then
+            tar -xf "$ovmf_tmp/tdx-qemu-app.tar" -O usr/share/ovmf/OVMF.inteltdx.fd > "$out_fd_file" 2>/dev/null || \
+            tar -xf "$ovmf_tmp/tdx-qemu-app.tar" -O /usr/share/ovmf/OVMF.inteltdx.fd > "$out_fd_file" 2>/dev/null || true
+        fi
+    fi
+
+    if [[ -f "$out_fd_file" && -s "$out_fd_file" ]]; then
+        echo "Calculating OVMF MRTD (using $out_fd_file)..."
+        local extract_cmd="/usr/local/bin/extract_image_ovmf"
+        if [[ ! -x "$extract_cmd" && -f "$(dirname "$0")/extract_image_ovmf" ]]; then
+            extract_cmd="$(dirname "$0")/extract_image_ovmf"
+        fi
+        local mrtd_hex
+        mrtd_hex=$("$extract_cmd" "$out_fd_file" | sed -n 's/^MRTD: //p')
+
+        if [[ -n "$mrtd_hex" ]]; then
+            jq -n --arg mrtd "$mrtd_hex" '{mrtd: $mrtd}' > "${output_base}_mrtd.json"
+        fi
+    else
+        echo "Error: Expected active OVMF firmware (/tdx-qemu-app/usr/share/ovmf/OVMF.inteltdx.fd) not found in partition." >&2
+        rm -f "$out_fd_file"
+        exit 1
+    fi
 }
 
 if ! check_dependencies; then
@@ -82,6 +127,11 @@ if [[ -n "${NESTED_IMAGES:-}" ]]; then
         # Extract just the partition
         dd if="$OS_IMAGE" of="$PART_EXT4" skip="$SKIP_BYTES" count="$COUNT_BYTES" iflag=skip_bytes,count_bytes bs=4M status=none 2>/dev/null || \
         dd if="$OS_IMAGE" of="$PART_EXT4" skip="$SKIP_SECTORS" count="$SIZE_SECTORS" bs=512 status=none
+
+        # Extract OVMF and measure MRTD once from partition layer if not already measured
+        if [[ ! -f "${BASE_OUT}_mrtd.json" ]]; then
+            extract_and_measure_ovmf "$PART_EXT4" "${BASE_OUT}"
+        fi
 
         # Extract the nested image from the ext4 partition, capture debugfs errors
         debugfs_err="$TMP_DIR/debugfs_${SUFFIX}.err"


### PR DESCRIPTION
# Add automated Guest VM OVMF extraction and offline MRTD calculation

## Description
Add support for extracting guest VM OVMF (`OVMF.inteltdx.fd`) firmware and calculating offline MRTD within `measure_composite.sh`. This is needed for verifying composite BC Host ACOS images with embedded TDX workload VMs.

Added a new Go helper (`extract_image_ovmf`) that simulates TDX hardware launch (`gce-tcb-verifier` v0.3.1) and extended `measure_composite.sh` to extract the firmware binary directly from partition 8.

## Testing
Verified on known released host image using:

```bash
docker run --rm \
  --privileged \
  -v "$(pwd):/work" \
  -e NESTED_IMAGES="8:/key_oracle_vm_image.qcow2:key_oracle 8:/workload_vm_image.qcow2:workload" \
  --entrypoint /usr/local/bin/measure_composite.sh \
  cs-tools/measure:local \
  /work/disk.raw /work/host_measure.json hardened x86_64
```

Output successfully produced the offline OVMF MRTD measurement JSON (`host_measure_workload_mrtd.json`).

## Expected Outputs
Executing the composite measurement command on a composite host image containing a `workload` guest VM now produces the following additional OVMF output:

| Filename | Component | Format |
| :--- | :--- | :--- |
| `<BASE_NAME>_workload_mrtd.json` | Workload Guest VM OVMF MRTD | JSON (`{"mrtd": "..."}`) |
