### PR TITLE
Unpack guest-gpu-tools:latest onto OEM partition

### DIFF
--- a/launcher/image/bc-guest/bc_gpu_setup.sh
+++ b/launcher/image/bc-guest/bc_gpu_setup.sh
@@ -13,18 +13,19 @@ systemd-run -p Type=forking --unit=nvidia-persistenced-transient /opt/nvidia/595
 echo "Waiting 1 minute for nvidia-persistenced to initialize..." | tee /dev/console
 sleep 60s
 
-if [ -f  /usr/share/oem/confidential_space/gpu_helper.tar ]; then
-    echo "Importing GPU helper image..." | tee /dev/console
-    sudo ctr images import /usr/share/oem/confidential_space/gpu_helper.tar
+if [ ! -d /usr/share/oem/gpu_helper/rootfs ]; then
+    echo "Error: GPU rootfs not found at /usr/share/oem/gpu_helper/rootfs!" | tee /dev/console
+    exit 1
 fi
 
 echo "Running NVLSM and Fabric Manager..." | tee /dev/console
 
-sudo ctr containers create --privileged --net-host \
+sudo ctr containers create --rootfs --privileged --net-host \
     --mount type=bind,src=/dev,dst=/dev,options=rbind:rw \
     --mount type=bind,src=/opt/nvidia,dst=/opt/nvidia-host,options=rbind:rw \
-    docker.io/library/guest-gpu-tools:latest \
-    guest-gpu-tools-task
+    /usr/share/oem/gpu_helper/rootfs \
+    guest-gpu-tools-task \
+    /entrypoint.sh
 
 sudo ctr tasks start -d guest-gpu-tools-task
 echo "Waiting 2 min for NVLSM and Fabric Manager to initialize..." | tee /dev/console

--- a/launcher/image/bc_cloudbuild.yaml
+++ b/launcher/image/bc_cloudbuild.yaml
@@ -48,7 +48,9 @@ steps:
       - |
         set -e
         docker build -t guest-gpu-tools:latest ./launcher/internal/gpu/daemons/
-        docker save guest-gpu-tools:latest -o /workspace/gpu_helper.tar
+        container_id=$$(docker create guest-gpu-tools:latest)
+        docker export "$${container_id}" -o /workspace/gpu_helper_rootfs.tar
+        docker rm "$${container_id}"
 
   - name: 'alpine'
     id: 'PrepareOEMInstallDir'
@@ -61,6 +63,7 @@ steps:
         mkdir -p /workspace/oem-install/confidential_space
         mkdir -p /workspace/oem-install/confidential_space/nodeproblemdetector
         mkdir -p /workspace/oem-install/wsd
+        mkdir -p /workspace/oem-install/gpu_helper
 
         cp ./launcher/image/bc-guest/bcentrypoint.sh /workspace/oem-install/entrypoint.sh
         cp ./launcher/image/bc-guest/bcexperiment.json \
@@ -72,7 +75,6 @@ steps:
            ./launcher/image/bc-guest/bc_network_optimization.sh \
            ./launcher/image/bc-guest/bc_network_runtime_optimization.sh \
            ./launcher/image/bc-guest/bc_network_monitor.sh \
-           /workspace/gpu_helper.tar \
            ./launcher/image/bc-guest/bc_pin_pci_numa_nodes.sh \
            ./launcher/image/bc-guest/bc_gpu_setup.sh \
            /workspace/oem-install/confidential_space/
@@ -87,6 +89,15 @@ steps:
           mkdir -p /workspace/oem-install/wsd/rootfs/run/container_launcher
           # Mountpoint needed by containerd
           mkdir -p /workspace/oem-install/wsd/rootfs/dev/mqueue
+        fi
+
+        # Extract GPU rootfs
+        if [ -f /workspace/gpu_helper_rootfs.tar ]; then
+          mkdir -p /workspace/oem-install/gpu_helper/rootfs
+          tar -C /workspace/oem-install/gpu_helper/rootfs -xf /workspace/gpu_helper_rootfs.tar
+          mkdir -p /workspace/oem-install/gpu_helper/rootfs/opt/nvidia-host
+          # Mountpoint needed by containerd
+          mkdir -p /workspace/oem-install/gpu_helper/rootfs/dev/mqueue
         fi
 
         # Create IMA policy

--- a/launcher/internal/gpu/daemons/entrypoint.sh
+++ b/launcher/internal/gpu/daemons/entrypoint.sh
@@ -3,6 +3,24 @@
 # Exit on error
 set -e
 
+mount_overlay() {
+    local target="$1"
+    local upper
+    local work
+    if [[ -d "${target}" ]]; then
+        upper=$(mktemp -d)
+        work=$(mktemp -d)
+        mount -t overlay -o "rw,noexec,nosuid,nodev,lowerdir=${target},upperdir=${upper},workdir=${work}" none "${target}"
+    fi
+}
+
+mount -t tmpfs -o rw,noexec,nosuid,nodev none /tmp
+mount -t tmpfs -o rw,noexec,nosuid,nodev none /var/tmp
+mount -t tmpfs -o rw,noexec,nosuid,nodev none /var/log
+mount -t tmpfs -o rw,noexec,nosuid,nodev none /var/lib
+mount -t tmpfs -o rw,noexec,nosuid,nodev none /var/cache
+mount_overlay /usr/share/nvidia
+
 echo "Starting guest GPU daemon service [595.58.03]..." | tee /dev/console
 export LD_LIBRARY_PATH=/opt/nvidia-host/595.58.03/lib64:$LD_LIBRARY_PATH
 


### PR DESCRIPTION
Extends read-only security features to guest-gpu-tools container.

Test: after build and boot, saw
`[ WorkloadVM ] Fabric readiness completed for all GPUs.` in logs.