### PR TITLE
launcher: dependency inject container image into ContainerRunner

### DIFF
--- a/launcher/container_runner.go
+++ b/launcher/container_runner.go
@@ -49,7 +49,6 @@ import (
 	"github.com/google/go-tpm-tools/verifier/util"
 	v1 "github.com/opencontainers/image-spec/specs-go/v1"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
-	"golang.org/x/oauth2"
 	"google.golang.org/api/option"
 	"google.golang.org/protobuf/proto"
 )
@@ -108,7 +107,6 @@ type ContainerdClient interface {
 // RunnerConfig contains the configuration for creating a ContainerRunner.
 type RunnerConfig struct {
 	ContainerdClient ContainerdClient
-	Token            oauth2.Token
 	LaunchSpec       spec.LaunchSpec
 	MetadataClient   *metadata.Client
 	TPM              io.ReadWriteCloser
@@ -118,12 +116,12 @@ type RunnerConfig struct {
 	GoogleClient     *http.Client
 	ClientOpts       []option.ClientOption
 	AKFetcher        util.TpmKeyFetcher
+	Image            containerd.Image
 }
 
 // NewRunner returns a runner.
 func NewRunner(ctx context.Context, cfg *RunnerConfig) (*ContainerRunner, error) {
 	cdClient := cfg.ContainerdClient
-	token := cfg.Token
 	launchSpec := cfg.LaunchSpec
 	mdsClient := cfg.MetadataClient
 	tpm := cfg.TPM
@@ -132,10 +130,7 @@ func NewRunner(ctx context.Context, cfg *RunnerConfig) (*ContainerRunner, error)
 	serialConsole := cfg.SerialConsole
 	googleClient := cfg.GoogleClient
 	opts := cfg.ClientOpts
-	image, err := initImage(ctx, cdClient, launchSpec, token, googleClient)
-	if err != nil {
-		return nil, err
-	}
+	image := cfg.Image
 
 	var mounts []specs.Mount
 	for _, lsMnt := range launchSpec.Mounts {
@@ -754,11 +749,6 @@ func defaultRetryPolicy() *backoff.ExponentialBackOff {
 	return expBack
 }
 
-func pullImageBackoffPolicy() backoff.BackOff {
-	b := backoff.NewConstantBackOff(time.Millisecond * 500)
-	return backoff.WithMaxRetries(b, 3)
-}
-
 // Run the container
 // Container output will always be redirected to logger writer for now
 func (r *ContainerRunner) Run(ctx context.Context) error {
@@ -970,41 +960,6 @@ func (r *ContainerRunner) enableGracefulShutdown(ctx context.Context, task conta
 			}
 		}
 	}()
-}
-
-func pullImageWithRetries(f func() (containerd.Image, error), retry func() backoff.BackOff) (containerd.Image, error) {
-	var err error
-	var image containerd.Image
-	err = backoff.Retry(func() error {
-		image, err = f()
-		return err
-	}, retry())
-	if err != nil {
-		return nil, fmt.Errorf("failed to pull image with retries, the last error is: %w", err)
-	}
-	return image, nil
-}
-
-func initImage(ctx context.Context, cdClient ContainerdClient, launchSpec spec.LaunchSpec, token oauth2.Token, googleClient *http.Client) (containerd.Image, error) {
-	var accessToken string
-	if token.Valid() {
-		accessToken = token.AccessToken
-	}
-
-	remoteOpt := containerd.WithResolver(registryauth.Resolver(accessToken, googleClient))
-	image, err := pullImageWithRetries(
-		func() (containerd.Image, error) {
-			return cdClient.Pull(ctx, launchSpec.ImageRef, containerd.WithPullUnpack, remoteOpt)
-		},
-		pullImageBackoffPolicy,
-	)
-	if err != nil {
-		if accessToken != "" {
-			return nil, fmt.Errorf("cannot pull the image: %w", err)
-		}
-		return nil, fmt.Errorf("cannot pull the image (no token, only works for a public image): %w", err)
-	}
-	return image, nil
 }
 
 // openPorts writes firewall rules to accept all traffic into that port and protocol using iptables.

--- a/launcher/container_runner_test.go
+++ b/launcher/container_runner_test.go
@@ -771,57 +771,6 @@ func TestMeasureCELEvents(t *testing.T) {
 	}
 }
 
-func TestPullImageWithRetries(t *testing.T) {
-	testCases := []struct {
-		name        string
-		imagePuller func(int) (containerd.Image, error)
-		wantPass    bool
-	}{
-		{
-			name:        "success with single attempt",
-			imagePuller: func(int) (containerd.Image, error) { return &fakeImage{}, nil },
-			wantPass:    true,
-		},
-		{
-			name: "failure then success",
-			imagePuller: func(attempts int) (containerd.Image, error) {
-				if attempts%2 == 1 {
-					return nil, errors.New("fake error")
-				}
-				return &fakeImage{}, nil
-			},
-			wantPass: true,
-		},
-		{
-			name: "failure with attempts exceeded",
-			imagePuller: func(int) (containerd.Image, error) {
-				return nil, errors.New("fake error")
-			},
-			wantPass: false,
-		},
-	}
-
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			retryPolicy := func() backoff.BackOff {
-				b := backoff.NewExponentialBackOff()
-				return backoff.WithMaxRetries(b, 2)
-			}
-
-			attempts := 0
-			_, err := pullImageWithRetries(
-				func() (containerd.Image, error) {
-					attempts++
-					return tc.imagePuller(attempts)
-				},
-				retryPolicy)
-			if gotPass := (err == nil); gotPass != tc.wantPass {
-				t.Errorf("pullImageWithRetries failed, got %v, but want %v", gotPass, tc.wantPass)
-			}
-		})
-	}
-}
-
 // This ensures fakeContainer implements containerd.Container interface.
 var _ containerd.Container = &fakeContainer{}
 
@@ -1042,6 +991,7 @@ func TestNewRunner(t *testing.T) {
 
 			cfg := &RunnerConfig{
 				ContainerdClient: fakeCli,
+				Image:            fakeImg,
 				TPM:              tpm,
 				AKFetcher:        client.AttestationKeyECC,
 				LaunchSpec: spec.LaunchSpec{

--- a/launcher/image.go
+++ b/launcher/image.go
@@ -1,0 +1,54 @@
+package launcher
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/cenkalti/backoff/v4"
+	"github.com/containerd/containerd"
+	"github.com/google/go-tpm-tools/launcher/registryauth"
+	"github.com/google/go-tpm-tools/launcher/spec"
+	"golang.org/x/oauth2"
+)
+
+func pullImageWithRetries(f func() (containerd.Image, error), retry func() backoff.BackOff) (containerd.Image, error) {
+	var err error
+	var image containerd.Image
+	err = backoff.Retry(func() error {
+		image, err = f()
+		return err
+	}, retry())
+	if err != nil {
+		return nil, fmt.Errorf("failed to pull image with retries, the last error is: %w", err)
+	}
+	return image, nil
+}
+
+func initImage(ctx context.Context, cdClient ContainerdClient, launchSpec spec.LaunchSpec, token oauth2.Token, googleClient *http.Client) (containerd.Image, error) {
+	var accessToken string
+	if token.Valid() {
+		accessToken = token.AccessToken
+	}
+
+	remoteOpt := containerd.WithResolver(registryauth.Resolver(accessToken, googleClient))
+	image, err := pullImageWithRetries(
+		func() (containerd.Image, error) {
+			return cdClient.Pull(ctx, launchSpec.ImageRef, containerd.WithPullUnpack, remoteOpt)
+		},
+		pullImageBackoffPolicy,
+	)
+	if err != nil {
+		if accessToken != "" {
+			return nil, fmt.Errorf("cannot pull the image: %w", err)
+		}
+		return nil, fmt.Errorf("cannot pull the image (no token, only works for a public image): %w", err)
+	}
+	return image, nil
+}
+
+func pullImageBackoffPolicy() backoff.BackOff {
+	b := backoff.NewConstantBackOff(time.Millisecond * 500)
+	return backoff.WithMaxRetries(b, 3)
+}

--- a/launcher/image_test.go
+++ b/launcher/image_test.go
@@ -1,0 +1,60 @@
+package launcher
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/cenkalti/backoff/v4"
+	"github.com/containerd/containerd"
+)
+
+func TestPullImageWithRetries(t *testing.T) {
+	testCases := []struct {
+		name        string
+		imagePuller func(int) (containerd.Image, error)
+		wantPass    bool
+	}{
+		{
+			name:        "success with single attempt",
+			imagePuller: func(int) (containerd.Image, error) { return &fakeImage{}, nil },
+			wantPass:    true,
+		},
+		{
+			name: "failure then success",
+			imagePuller: func(attempts int) (containerd.Image, error) {
+				if attempts%2 == 1 {
+					return nil, errors.New("fake error")
+				}
+				return &fakeImage{}, nil
+			},
+			wantPass: true,
+		},
+		{
+			name: "failure with attempts exceeded",
+			imagePuller: func(int) (containerd.Image, error) {
+				return nil, errors.New("fake error")
+			},
+			wantPass: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			retryPolicy := func() backoff.BackOff {
+				b := backoff.NewExponentialBackOff()
+				return backoff.WithMaxRetries(b, 2)
+			}
+
+			attempts := 0
+			_, err := pullImageWithRetries(
+				func() (containerd.Image, error) {
+					attempts++
+					return tc.imagePuller(attempts)
+				},
+				retryPolicy)
+			if gotPass := (err == nil); gotPass != tc.wantPass {
+				t.Errorf("pullImageWithRetries failed, got %v, but want %v", gotPass, tc.wantPass)
+			}
+		})
+	}
+}

--- a/launcher/start.go
+++ b/launcher/start.go
@@ -66,9 +66,13 @@ func StartLauncher(
 
 	logger.Info("Launch started", "duration_sec", time.Since(start).Seconds())
 
+	image, err := initImage(ctx, containerdClient, launchSpec, token, googleClient)
+	if err != nil {
+		return err
+	}
+
 	r, err := NewRunner(ctx, &RunnerConfig{
 		ContainerdClient: containerdClient,
-		Token:            token,
 		LaunchSpec:       launchSpec,
 		MetadataClient:   mdsClient,
 		TPM:              tpm,
@@ -77,6 +81,7 @@ func StartLauncher(
 		SerialConsole:    serialConsole,
 		GoogleClient:     googleClient,
 		ClientOpts:       clientOpts,
+		Image:            image,
 	})
 	if err != nil {
 		return err


### PR DESCRIPTION
Adding dependency injection to ContainerRunner will allow it to be tested using mocks/fakes when real resources are unavailable in a test environment.

Previously, the runner pulled the container image internally during initialization. This change moves the image-pulling responsibility up to the launcher orchestration layer.

Before: 
<img width="664" height="365" alt="image" src="https://github.com/user-attachments/assets/2894d39d-a577-487c-8f3d-82083ee73880" />

After:
<img width="664" height="380" alt="image" src="https://github.com/user-attachments/assets/6c897a3e-51ad-418f-adb4-f3fa54131a5b" />

