### PR TITLE
launcher: parallelize test_mounts.yaml execution

### DIFF
--- a/launcher/image/test/test_mounts.yaml
+++ b/launcher/image/test/test_mounts.yaml
@@ -19,6 +19,7 @@ steps:
           '-n', '${_VM_NAME_PREFIX}-${BUILD_ID}-default',
           '-z', '${_ZONE}',
         ]
+  waitFor: ['-']
 - name: 'gcr.io/cloud-builders/gcloud'
   id: CreateVMWithMountsAllowed
   entrypoint: 'bash'
@@ -32,6 +33,7 @@ steps:
           '-n', '${_VM_NAME_PREFIX}-${BUILD_ID}-allowed',
           '-z', '${_ZONE}',
         ]
+  waitFor: ['-']
 - name: 'gcr.io/cloud-builders/gcloud'
   id: CreateVMWithMountsDenied
   entrypoint: 'bash'
@@ -43,6 +45,7 @@ steps:
           '-n', '${_VM_NAME_PREFIX}-${BUILD_ID}-denied',
           '-z', '${_ZONE}',
         ]
+  waitFor: ['-']
 - name: 'gcr.io/cloud-builders/gcloud'
   id: CheckDevShmExists
   env:
@@ -64,6 +67,7 @@ steps:
         echo 'TEST FAILED' > /workspace/status.txt
         echo $SERIAL_OUTPUT
     fi
+  waitFor: ['CreateVMWithDefaultDevShmSize']
 - name: 'gcr.io/cloud-builders/gcloud'
   id: CheckMountsAllowed
   env:
@@ -95,6 +99,7 @@ steps:
         echo 'TEST FAILED' > /workspace/status.txt
         echo $SERIAL_OUTPUT
     fi
+  waitFor: ['CreateVMWithMountsAllowed']
 
 - name: 'gcr.io/cloud-builders/gcloud'
   id: CheckMountsDenied
@@ -148,3 +153,4 @@ steps:
   env:
   - 'BUILD_ID=$BUILD_ID'
   args: ['check_failure.sh']
+  waitFor: ['CleanUpVMWithDefault', 'CleanUpVMWithMountsAllowed', 'CleanUpVMWithMountsDenied']


### PR DESCRIPTION
Add explicit `waitFor` dependencies to parallelize VM creations, verifications, and cleanups in `test_mounts.yaml`.  Previously, steps in `test_mounts.yaml` ran sequentially by default because `waitFor` was omitted. When a third VM test (default shm test) was added in PR #493, the sequential execution delayed `CheckMountsAllowed` until ~340s after the allowed VM's creation. Because Confidential Space VMs schedule a self-shutdown 120s after completing their workload, this delay caused the verification step to run after the VM had already terminated, causing flaky `Could not fetch serial port output` failures. Parallelizing the steps ensures each verification step runs immediately after its respective VM is created, and reduces overall test execution time from ~200s to ~90s.

### Current Execution Flow (Sequential)
```mermaid
graph TD
    %% Define Steps
    Step0[Step 0: CreateVMWithDefaultDevShmSize]
    Step1[Step 1: CreateVMWithMountsAllowed]
    Step2[Step 2: CreateVMWithMountsDenied]
    Step3[Step 3: CheckDevShmExists]
    Step4[Step 4: CheckMountsAllowed]
    Step5[Step 5: CheckMountsDenied]
    Step6[Step 6: CleanUpVMWithDefault]
    Step7[Step 7: CleanUpVMWithMountsAllowed]
    Step8[Step 8: CleanUpVMWithMountsDenied]
    Step9[Step 9: CheckFailure]

    %% Implicit sequential dependencies (no waitFor)
    Step0 -->|implicit| Step1
    Step1 -->|implicit| Step2
    Step2 -->|implicit| Step3
    Step3 -->|implicit| Step4
    
    %% Explicit waitFor dependencies
    Step2 -->|waitFor| Step5
    Step3 -->|waitFor| Step6
    Step4 -->|waitFor| Step7
    Step5 -->|waitFor| Step8
    
    %% Step 9 waits for all prior steps (0 to 8) to complete
    Step6 --> Step9
    Step7 --> Step9
    Step8 --> Step9
```
    

### This PR

```mermaid
graph TD
    %% Define Steps
    Step0[CreateVMWithDefaultDevShmSize]
    Step1[CreateVMWithMountsAllowed]
    Step2[CreateVMWithMountsDenied]
    
    Step3[CheckDevShmExists]
    Step4[CheckMountsAllowed]
    Step5[CheckMountsDenied]
    
    Step6[CleanUpVMWithDefault]
    Step7[CleanUpVMWithMountsAllowed]
    Step8[CleanUpVMWithMountsDenied]
    
    Step9[CheckFailure]
    %% Parallel starts
    Start((Start)) --> Step0
    Start --> Step1
    Start --> Step2
    %% Verification waits only for its own VM creation
    Step0 -->|waitFor| Step3
    Step1 -->|waitFor| Step4
    Step2 -->|waitFor| Step5
    %% Cleanup waits only for its own Check
    Step3 -->|waitFor| Step6
    Step4 -->|waitFor| Step7
    Step5 -->|waitFor| Step8
    %% Finalize waits for all cleanups
    Step6 --> Step9
    Step7 --> Step9
    Step8 --> Step9
```