### PR TITLE
launcher: extract OCI spec options construction for unit testing

### DIFF
--- a/launcher/container_runner.go
+++ b/launcher/container_runner.go
@@ -24,10 +24,8 @@ import (
 	"github.com/cenkalti/backoff/v4"
 	"github.com/containerd/containerd"
 	"github.com/containerd/containerd/cio"
-	"github.com/containerd/containerd/containers"
 	"github.com/containerd/containerd/content"
 	"github.com/containerd/containerd/images"
-	"github.com/containerd/containerd/oci"
 	"github.com/containerd/containerd/remotes"
 	"github.com/golang-jwt/jwt/v4"
 	"github.com/google/go-tpm-tools/agent"
@@ -43,7 +41,6 @@ import (
 	"github.com/google/go-tpm-tools/launcher/spec"
 	"github.com/google/go-tpm-tools/launcher/teeserver"
 	v1 "github.com/opencontainers/image-spec/specs-go/v1"
-	specs "github.com/opencontainers/runtime-spec/specs-go"
 	"google.golang.org/protobuf/proto"
 )
 
@@ -121,20 +118,6 @@ func NewRunner(ctx context.Context, cfg *RunnerConfig) (*ContainerRunner, error)
 	image := cfg.Image
 	attestAgent := cfg.AttestAgent
 
-	var mounts []specs.Mount
-	for _, lsMnt := range launchSpec.Mounts {
-		mounts = append(mounts, lsMnt.SpecsMount())
-	}
-	mounts = appendTokenMounts(mounts)
-	var cgroupOpts []oci.SpecOpts
-	if launchSpec.CgroupNamespace {
-		mounts = appendCgroupRw(mounts)
-		cgroupOpts = []oci.SpecOpts{
-			oci.WithNamespacedCgroup(),
-			oci.WithLinuxNamespace(specs.LinuxNamespace{Type: specs.CgroupNamespace}),
-		}
-	}
-
 	envs, err := formatEnvVars(launchSpec.Envs)
 	if err != nil {
 		return nil, err
@@ -205,86 +188,15 @@ func NewRunner(ctx context.Context, cfg *RunnerConfig) (*ContainerRunner, error)
 		)
 	}
 
-	hostname, err := os.Hostname()
-	if err != nil {
-		return nil, &RetryableError{fmt.Errorf("cannot get hostname: [%w]", err)}
-	}
-
-	rlimits := []specs.POSIXRlimit{{
-		Type: "RLIMIT_NOFILE",
-		Hard: nofile,
-		Soft: nofile,
-	}}
-
-	specOpts := []oci.SpecOpts{
-		oci.WithImageConfigArgs(image, launchSpec.Cmd),
-		oci.WithEnv(envs),
-		oci.WithMounts(mounts),
-		// following 4 options are here to allow the container to have
-		// the host network (same effect as --net-host in ctr command)
-		oci.WithHostHostsFile,
-		oci.WithHostResolvconf,
-		oci.WithHostNamespace(specs.NetworkNamespace),
-		oci.WithEnv([]string{fmt.Sprintf("HOSTNAME=%s", hostname)}),
-		oci.WithAddedCapabilities(launchSpec.AddedCapabilities),
-		withRlimits(rlimits),
-		withOOMScoreAdj(defaultOOMScore),
-	}
-	if launchSpec.DevShmSize != 0 {
-		specOpts = append(specOpts, oci.WithDevShmSize(launchSpec.DevShmSize))
-	}
-	specOpts = append(specOpts, cgroupOpts...)
-
+	var deviceROTs []agent.DeviceROT
+	nvidiaAttester := gpu.NewNvidiaAttester(launchSpec.InstallGpuDriver)
 	if launchSpec.InstallGpuDriver {
-		gpuMounts := []specs.Mount{
-			{
-				Type:        "volume",
-				Source:      fmt.Sprintf("%s/lib64", gpu.InstallationHostDir),
-				Destination: fmt.Sprintf("%s/lib64", gpu.InstallationContainerDir),
-				Options:     []string{"rbind", "rw"},
-			}, {
-				Type:        "volume",
-				Source:      fmt.Sprintf("%s/bin", gpu.InstallationHostDir),
-				Destination: fmt.Sprintf("%s/bin", gpu.InstallationContainerDir),
-				Options:     []string{"rbind", "rw"},
-			},
-		}
-		if launchSpec.Experiments.BcMode {
-			gpuMounts = []specs.Mount{
-				{
-					Type:        "volume",
-					Source:      fmt.Sprintf("%s/lib64", gpu.BuiltInInstallation595_58_03HostDir),
-					Destination: fmt.Sprintf("%s/lib64", gpu.InstallationContainerDir),
-					Options:     []string{"rbind", "rw"},
-				}, {
-					Type:        "volume",
-					Source:      fmt.Sprintf("%s/bin", gpu.BuiltInInstallation595_58_03HostDir),
-					Destination: fmt.Sprintf("%s/bin", gpu.InstallationContainerDir),
-					Options:     []string{"rbind", "rw"},
-				},
-			}
-		}
+		deviceROTs = append(deviceROTs, nvidiaAttester)
+	}
 
-		specOpts = append(specOpts, oci.WithMounts(gpuMounts))
-
-		// /dev/nvidia-caps/* will not be listed here and will not be passed to
-		// the container workload
-		//
-		// following devices should be listed:
-		// /dev/nvidiactl
-		// /dev/nvidia-uvm
-		// /dev/nvidia-uvm-tools
-		// /dev/nvidia{0,1,2,...}
-		// /dev/nvidia-modeset
-		gpuDeviceFiles, err := listFilesWithPrefix("/dev", "nvidia")
-		if err != nil {
-			return nil, fmt.Errorf("failed to list nvidia devices: [%w]", err)
-		}
-
-		for _, deviceFile := range gpuDeviceFiles {
-			logger.Info(fmt.Sprintf("Detected nvidia device : %s", deviceFile))
-			specOpts = append(specOpts, oci.WithDevices(deviceFile, deviceFile, "crw-rw-rw-"))
-		}
+	specOpts, err := createOCISpecOpts(image, launchSpec, envs, listFilesWithPrefix, logger)
+	if err != nil {
+		return nil, err
 	}
 
 	container, err = cdClient.NewContainer(
@@ -380,30 +292,6 @@ func getSignatureDiscoveryClient(cdClient ContainerdClient, mdsClient *metadata.
 		return image, nil
 	}
 	return signaturediscovery.New(imageDesc, resolverFetcher, imageFetcher)
-}
-
-// formatEnvVars formats the environment variables to the oci format
-func formatEnvVars(envVars []spec.EnvVar) ([]string, error) {
-	var result []string
-	for _, envVar := range envVars {
-		ociFormat, err := cel.FormatEnvVar(envVar.Name, envVar.Value)
-		if err != nil {
-			return nil, fmt.Errorf("failed to format env var: %v", err)
-		}
-		result = append(result, ociFormat)
-	}
-	return result, nil
-}
-
-// appendTokenMounts appends the default mount specs for the OIDC token
-func appendTokenMounts(mounts []specs.Mount) []specs.Mount {
-	m := specs.Mount{}
-	m.Destination = launcherfile.ContainerRuntimeMountPath
-	m.Type = "bind"
-	m.Source = launcherfile.HostTmpPath
-	m.Options = []string{"rbind", "ro"}
-
-	return append(mounts, m)
 }
 
 func (r *ContainerRunner) measureCELEvents(ctx context.Context) error {
@@ -946,34 +834,6 @@ func (r *ContainerRunner) Close(ctx context.Context) {
 	// Delete container and close connection to attestation service.
 	// TODO: consider handling or logging cleanup error.
 	_ = r.container.Delete(ctx, containerd.WithSnapshotCleanup)
-}
-
-// withRlimits sets the rlimit (like the max file descriptor) for the container process
-func withRlimits(rlimits []specs.POSIXRlimit) oci.SpecOpts {
-	return func(_ context.Context, _ oci.Client, _ *containers.Container, s *oci.Spec) error {
-		s.Process.Rlimits = rlimits
-		return nil
-	}
-}
-
-// Set the container process's OOM score.
-func withOOMScoreAdj(oomScore int) oci.SpecOpts {
-	return func(_ context.Context, _ oci.Client, _ *containers.Container, s *oci.Spec) error {
-		s.Process.OOMScoreAdj = &oomScore
-		return nil
-	}
-}
-
-// appendCgroupRw mount maps a cgroup as read-write.
-func appendCgroupRw(mounts []specs.Mount) []specs.Mount {
-	m := specs.Mount{
-		Destination: "/sys/fs/cgroup",
-		Type:        "cgroup",
-		Source:      "cgroup",
-		Options:     []string{"rw", "nosuid", "noexec", "nodev"},
-	}
-
-	return append(mounts, m)
 }
 
 func verifySocketPermissions(socketPath string) error {

--- a/launcher/container_spec.go
+++ b/launcher/container_spec.go
@@ -1,0 +1,171 @@
+package launcher
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/containerd/containerd"
+	"github.com/containerd/containerd/containers"
+	"github.com/containerd/containerd/oci"
+	"github.com/google/go-tpm-tools/cel"
+	"github.com/google/go-tpm-tools/launcher/internal/gpu"
+	"github.com/google/go-tpm-tools/launcher/internal/logging"
+	"github.com/google/go-tpm-tools/launcher/launcherfile"
+	"github.com/google/go-tpm-tools/launcher/spec"
+	specs "github.com/opencontainers/runtime-spec/specs-go"
+)
+
+func createOCISpecOpts(image containerd.Image, launchSpec spec.LaunchSpec, envs []string, listFiles func(string, string) ([]string, error), logger logging.Logger) ([]oci.SpecOpts, error) {
+	var mounts []specs.Mount
+	for _, lsMnt := range launchSpec.Mounts {
+		mounts = append(mounts, lsMnt.SpecsMount())
+	}
+	mounts = appendTokenMounts(mounts)
+	if launchSpec.CgroupNamespace {
+		mounts = appendCgroupRw(mounts)
+	}
+	hostname, err := os.Hostname()
+	if err != nil {
+		return nil, &RetryableError{fmt.Errorf("cannot get hostname: [%w]", err)}
+	}
+
+	rlimits := []specs.POSIXRlimit{{
+		Type: "RLIMIT_NOFILE",
+		Hard: nofile,
+		Soft: nofile,
+	}}
+
+	specOpts := []oci.SpecOpts{
+		oci.WithImageConfigArgs(image, launchSpec.Cmd),
+		oci.WithEnv(envs),
+		oci.WithMounts(mounts),
+		// following 4 options are here to allow the container to have
+		// the host network (same effect as --net-host in ctr command)
+		oci.WithHostHostsFile,
+		oci.WithHostResolvconf,
+		oci.WithHostNamespace(specs.NetworkNamespace),
+		oci.WithEnv([]string{fmt.Sprintf("HOSTNAME=%s", hostname)}),
+		oci.WithAddedCapabilities(launchSpec.AddedCapabilities),
+		withRlimits(rlimits),
+		withOOMScoreAdj(defaultOOMScore),
+	}
+	if launchSpec.DevShmSize != 0 {
+		specOpts = append(specOpts, oci.WithDevShmSize(launchSpec.DevShmSize))
+	}
+
+	var cgroupOpts []oci.SpecOpts
+	if launchSpec.CgroupNamespace {
+		cgroupOpts = []oci.SpecOpts{
+			oci.WithNamespacedCgroup(),
+			oci.WithLinuxNamespace(specs.LinuxNamespace{Type: specs.CgroupNamespace}),
+		}
+	}
+	specOpts = append(specOpts, cgroupOpts...)
+
+	if launchSpec.InstallGpuDriver {
+		gpuMounts := []specs.Mount{
+			{
+				Type:        "volume",
+				Source:      fmt.Sprintf("%s/lib64", gpu.InstallationHostDir),
+				Destination: fmt.Sprintf("%s/lib64", gpu.InstallationContainerDir),
+				Options:     []string{"rbind", "rw"},
+			}, {
+				Type:        "volume",
+				Source:      fmt.Sprintf("%s/bin", gpu.InstallationHostDir),
+				Destination: fmt.Sprintf("%s/bin", gpu.InstallationContainerDir),
+				Options:     []string{"rbind", "rw"},
+			},
+		}
+		if launchSpec.Experiments.BcMode {
+			gpuMounts = []specs.Mount{
+				{
+					Type:        "volume",
+					Source:      fmt.Sprintf("%s/lib64", gpu.BuiltInInstallation595_58_03HostDir),
+					Destination: fmt.Sprintf("%s/lib64", gpu.InstallationContainerDir),
+					Options:     []string{"rbind", "rw"},
+				}, {
+					Type:        "volume",
+					Source:      fmt.Sprintf("%s/bin", gpu.BuiltInInstallation595_58_03HostDir),
+					Destination: fmt.Sprintf("%s/bin", gpu.InstallationContainerDir),
+					Options:     []string{"rbind", "rw"},
+				},
+			}
+		}
+
+		specOpts = append(specOpts, oci.WithMounts(gpuMounts))
+
+		// /dev/nvidia-caps/* will not be listed here and will not be passed to
+		// the container workload
+		//
+		// following devices should be listed:
+		// /dev/nvidiactl
+		// /dev/nvidia-uvm
+		// /dev/nvidia-uvm-tools
+		// /dev/nvidia{0,1,2,...}
+		// /dev/nvidia-modeset
+		gpuDeviceFiles, err := listFiles("/dev", "nvidia")
+		if err != nil {
+			return nil, fmt.Errorf("failed to list nvidia devices: [%w]", err)
+		}
+
+		for _, deviceFile := range gpuDeviceFiles {
+			logger.Info(fmt.Sprintf("Detected nvidia device : %s", deviceFile))
+			specOpts = append(specOpts, oci.WithDevices(deviceFile, deviceFile, "crw-rw-rw-"))
+		}
+	}
+
+	return specOpts, nil
+}
+
+// formatEnvVars formats the environment variables to the oci format
+func formatEnvVars(envVars []spec.EnvVar) ([]string, error) {
+	var result []string
+	for _, envVar := range envVars {
+		ociFormat, err := cel.FormatEnvVar(envVar.Name, envVar.Value)
+		if err != nil {
+			return nil, fmt.Errorf("failed to format env var: %v", err)
+		}
+		result = append(result, ociFormat)
+	}
+	return result, nil
+}
+
+// appendTokenMounts appends the default mount specs for the OIDC token
+func appendTokenMounts(mounts []specs.Mount) []specs.Mount {
+	m := specs.Mount{}
+	m.Destination = launcherfile.ContainerRuntimeMountPath
+	m.Type = "bind"
+	m.Source = launcherfile.HostTmpPath
+	m.Options = []string{"rbind", "ro"}
+
+	return append(mounts, m)
+}
+
+// withRlimits sets the rlimit (like the max file descriptor) for the container process
+func withRlimits(rlimits []specs.POSIXRlimit) oci.SpecOpts {
+	return func(_ context.Context, _ oci.Client, _ *containers.Container, s *oci.Spec) error {
+		s.Process.Rlimits = rlimits
+		return nil
+	}
+}
+
+// Set the container process's OOM score.
+func withOOMScoreAdj(oomScore int) oci.SpecOpts {
+	return func(_ context.Context, _ oci.Client, _ *containers.Container, s *oci.Spec) error {
+		s.Process.OOMScoreAdj = &oomScore
+		return nil
+	}
+}
+
+// appendCgroupRw mount maps a cgroup as read-write.
+func appendCgroupRw(mounts []specs.Mount) []specs.Mount {
+	m := specs.Mount{
+		Destination: "/sys/fs/cgroup",
+		Type:        "cgroup",
+		Source:      "cgroup",
+		Options:     []string{"rw", "nosuid", "noexec", "nodev"},
+	}
+
+	return append(mounts, m)
+}

--- a/launcher/container_spec_test.go
+++ b/launcher/container_spec_test.go
@@ -1,0 +1,495 @@
+package launcher
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"reflect"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/containerd/containerd/containers"
+	"github.com/containerd/containerd/namespaces"
+	"github.com/containerd/containerd/oci"
+	"github.com/google/go-tpm-tools/launcher/internal/experiments"
+	"github.com/google/go-tpm-tools/launcher/internal/launchermount"
+	"github.com/google/go-tpm-tools/launcher/spec"
+	v1 "github.com/opencontainers/image-spec/specs-go/v1"
+	specs "github.com/opencontainers/runtime-spec/specs-go"
+)
+
+type mockMount struct {
+	specsMount specs.Mount
+}
+
+func (m mockMount) SpecsMount() specs.Mount {
+	return m.specsMount
+}
+
+func (m mockMount) Mountpoint() string {
+	return m.specsMount.Destination
+}
+
+func createFakeImage(labels map[string]string, entrypoint, cmd []string) *fakeImage {
+	ic := v1.Image{
+		Config: v1.ImageConfig{
+			Labels:     labels,
+			Entrypoint: entrypoint,
+			Cmd:        cmd,
+		},
+	}
+	b, _ := json.Marshal(ic)
+	return &fakeImage{
+		name:         "test-image",
+		id:           "test-id",
+		digest:       "sha256:12345",
+		contentStore: &fakeContentStore{blob: b},
+	}
+}
+
+func dummyListFiles(_, _ string) ([]string, error) {
+	return nil, nil
+}
+
+func getFuncName(i any) string {
+	return runtime.FuncForPC(reflect.ValueOf(i).Pointer()).Name()
+}
+
+// createDefaultLinuxNamespaces returns a default set of namespaces similar to containerd's default template.
+func createDefaultLinuxNamespaces() []specs.LinuxNamespace {
+	return []specs.LinuxNamespace{
+		{Type: specs.PIDNamespace, Path: "/proc/1/ns/pid"},
+		{Type: specs.NetworkNamespace, Path: "/proc/1/ns/net"},
+		{Type: specs.IPCNamespace, Path: "/proc/1/ns/ipc"},
+		{Type: specs.UTSNamespace, Path: "/proc/1/ns/uts"},
+		{Type: specs.MountNamespace, Path: "/proc/1/ns/mnt"},
+	}
+}
+
+func applySpecOptsToSpec(ctx context.Context, specOpts []oci.SpecOpts) (specs.Spec, error) {
+	gotSpec := oci.Spec{
+		Mounts: []specs.Mount{
+			{Destination: "/dev/shm", Type: "tmpfs", Source: "shm"},
+		},
+		Linux: &specs.Linux{
+			Namespaces: createDefaultLinuxNamespaces(),
+		},
+		Process: &specs.Process{},
+	}
+	dummyContainer := containers.Container{ID: "dummy"}
+	for _, opt := range specOpts[1:] { // Skip WithImageConfigArgs
+		if err := opt(ctx, nil, &dummyContainer, &gotSpec); err != nil {
+			return gotSpec, err
+		}
+	}
+	return gotSpec, nil
+}
+
+func TestCreateOCISpecOpts_ProcessEnv(t *testing.T) {
+	ctx := namespaces.WithNamespace(context.Background(), "default")
+	logger := &fakeLogger{}
+	img := createFakeImage(map[string]string{"foo": "bar"}, []string{"/bin/entrypoint"}, []string{"default", "args"})
+	envs := []string{"ENV_VAR_1=value1", "ENV_VAR_2=value2"}
+
+	specOpts, err := createOCISpecOpts(img, spec.LaunchSpec{}, envs, dummyListFiles, logger)
+	if err != nil {
+		t.Fatalf("createOCISpecOpts failed: %v", err)
+	}
+
+	gotSpec, err := applySpecOptsToSpec(ctx, specOpts)
+	if err != nil {
+		t.Fatalf("failed to apply spec option: %v", err)
+	}
+
+	hasEnv1, hasEnv2, hasHostname := false, false, false
+	for _, env := range gotSpec.Process.Env {
+		if env == "ENV_VAR_1=value1" {
+			hasEnv1 = true
+		}
+		if env == "ENV_VAR_2=value2" {
+			hasEnv2 = true
+		}
+		if strings.HasPrefix(env, "HOSTNAME=") {
+			hasHostname = true
+		}
+	}
+	if !hasEnv1 || !hasEnv2 || !hasHostname {
+		t.Errorf("Env variables not set correctly: envs=%v", gotSpec.Process.Env)
+	}
+}
+
+func TestCreateOCISpecOpts_Mounts(t *testing.T) {
+	ctx := namespaces.WithNamespace(context.Background(), "default")
+	logger := &fakeLogger{}
+	img := createFakeImage(nil, nil, nil)
+
+	ls := spec.LaunchSpec{
+		Mounts: []launchermount.Mount{
+			mockMount{
+				specsMount: specs.Mount{
+					Source:      "/host/path",
+					Destination: "/container/path",
+					Type:        "bind",
+				},
+			},
+		},
+	}
+
+	specOpts, err := createOCISpecOpts(img, ls, nil, dummyListFiles, logger)
+	if err != nil {
+		t.Fatalf("createOCISpecOpts failed: %v", err)
+	}
+
+	gotSpec, err := applySpecOptsToSpec(ctx, specOpts)
+	if err != nil {
+		t.Fatalf("failed to apply spec option: %v", err)
+	}
+
+	foundOperatorMount, foundTokenMount := false, false
+	for _, mnt := range gotSpec.Mounts {
+		if mnt.Source == "/host/path" && mnt.Destination == "/container/path" {
+			foundOperatorMount = true
+		}
+		if strings.Contains(mnt.Destination, "container_launcher") {
+			for _, opt := range mnt.Options {
+				if opt == "ro" {
+					foundTokenMount = true
+				}
+			}
+		}
+	}
+	if !foundOperatorMount {
+		t.Errorf("Operator mount not found in spec: mounts=%v", gotSpec.Mounts)
+	}
+	if !foundTokenMount {
+		t.Errorf("Default OIDC token mount (container_launcher, ro) not found in spec: mounts=%v", gotSpec.Mounts)
+	}
+}
+
+func TestCreateOCISpecOpts_Rlimits(t *testing.T) {
+	ctx := namespaces.WithNamespace(context.Background(), "default")
+	logger := &fakeLogger{}
+	img := createFakeImage(nil, nil, nil)
+
+	specOpts, err := createOCISpecOpts(img, spec.LaunchSpec{}, nil, dummyListFiles, logger)
+	if err != nil {
+		t.Fatalf("createOCISpecOpts failed: %v", err)
+	}
+
+	gotSpec, err := applySpecOptsToSpec(ctx, specOpts)
+	if err != nil {
+		t.Fatalf("failed to apply spec option: %v", err)
+	}
+
+	foundLimit := false
+	for _, limit := range gotSpec.Process.Rlimits {
+		if limit.Type == "RLIMIT_NOFILE" && limit.Hard == nofile && limit.Soft == nofile {
+			foundLimit = true
+		}
+	}
+	if !foundLimit {
+		t.Errorf("File descriptor limits not applied correctly: %v", gotSpec.Process.Rlimits)
+	}
+}
+
+func TestCreateOCISpecOpts_Namespaces(t *testing.T) {
+	ctx := namespaces.WithNamespace(context.Background(), "default")
+	logger := &fakeLogger{}
+	img := createFakeImage(nil, nil, nil)
+
+	specOpts, err := createOCISpecOpts(img, spec.LaunchSpec{}, nil, dummyListFiles, logger)
+	if err != nil {
+		t.Fatalf("createOCISpecOpts failed: %v", err)
+	}
+
+	gotSpec, err := applySpecOptsToSpec(ctx, specOpts)
+	if err != nil {
+		t.Fatalf("failed to apply spec option: %v", err)
+	}
+
+	foundNetNS, foundPIDNS, foundIPCNS, foundUTSNS, foundMountNS := false, false, false, false, false
+	for _, ns := range gotSpec.Linux.Namespaces {
+		switch ns.Type {
+		case specs.NetworkNamespace:
+			foundNetNS = true
+		case specs.PIDNamespace:
+			foundPIDNS = true
+		case specs.IPCNamespace:
+			foundIPCNS = true
+		case specs.UTSNamespace:
+			foundUTSNS = true
+		case specs.MountNamespace:
+			foundMountNS = true
+		}
+	}
+	if foundNetNS {
+		t.Errorf("Host network namespace sharing failed: NetworkNamespace was not removed from the spec. Namespaces: %v", gotSpec.Linux.Namespaces)
+	}
+	if !foundPIDNS || !foundIPCNS || !foundUTSNS || !foundMountNS {
+		t.Errorf("Only NetworkNamespace should be removed for host sharing. Namespaces: %v", gotSpec.Linux.Namespaces)
+	}
+}
+
+func TestCreateOCISpecOpts_Cgroups(t *testing.T) {
+	ctx := namespaces.WithNamespace(context.Background(), "default")
+	logger := &fakeLogger{}
+	img := createFakeImage(nil, nil, nil)
+
+	testCases := []struct {
+		name            string
+		cgroupNamespace bool
+		wantCgroupNS    bool
+	}{
+		{
+			name:            "cgroup namespace enabled",
+			cgroupNamespace: true,
+			wantCgroupNS:    true,
+		},
+		{
+			name:            "cgroup namespace disabled (host namespace)",
+			cgroupNamespace: false,
+			wantCgroupNS:    false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ls := spec.LaunchSpec{
+				CgroupNamespace: tc.cgroupNamespace,
+			}
+			specOpts, err := createOCISpecOpts(img, ls, nil, dummyListFiles, logger)
+			if err != nil {
+				t.Fatalf("createOCISpecOpts failed: %v", err)
+			}
+
+			// Verify the first option is indeed WithImageConfigArgs
+			if len(specOpts) == 0 {
+				t.Fatalf("specOpts is empty")
+			}
+			firstOptName := getFuncName(specOpts[0])
+			if !strings.Contains(firstOptName, "WithImageConfigArgs") {
+				t.Errorf("expected first option to be WithImageConfigArgs, got %s", firstOptName)
+			}
+
+			gotSpec := oci.Spec{
+				Linux: &specs.Linux{
+					Namespaces: createDefaultLinuxNamespaces(),
+				},
+				Process: &specs.Process{},
+			}
+			dummyContainer := containers.Container{ID: "dummy"}
+			for _, opt := range specOpts[1:] { // Skip WithImageConfigArgs
+				if err := opt(ctx, nil, &dummyContainer, &gotSpec); err != nil {
+					t.Fatalf("failed to apply spec option: %v", err)
+				}
+			}
+
+			foundCgroupNS := false
+			if gotSpec.Linux != nil {
+				for _, ns := range gotSpec.Linux.Namespaces {
+					if ns.Type == specs.CgroupNamespace {
+						foundCgroupNS = true
+					}
+				}
+			}
+			if foundCgroupNS != tc.wantCgroupNS {
+				t.Errorf("Cgroup namespace presence mismatch: got %v, want %v", foundCgroupNS, tc.wantCgroupNS)
+			}
+		})
+	}
+}
+
+func TestCreateOCISpecOpts_GPU(t *testing.T) {
+	ctx := namespaces.WithNamespace(context.Background(), "default")
+	logger := &fakeLogger{}
+	img := createFakeImage(nil, nil, nil)
+
+	// Injected mock filesystem scanner
+	mockListFiles := func(dir, prefix string) ([]string, error) {
+		if dir == "/dev" && prefix == "nvidia" {
+			return []string{"/dev/nvidia0", "/dev/nvidiactl"}, nil
+		}
+		return nil, nil
+	}
+
+	ls := spec.LaunchSpec{
+		InstallGpuDriver: true,
+	}
+
+	specOpts, err := createOCISpecOpts(img, ls, nil, mockListFiles, logger)
+	if err != nil {
+		t.Fatalf("createOCISpecOpts failed: %v", err)
+	}
+
+	// Verify the first option is indeed WithImageConfigArgs
+	if len(specOpts) == 0 {
+		t.Fatalf("specOpts is empty")
+	}
+	firstOptName := getFuncName(specOpts[0])
+	if !strings.Contains(firstOptName, "WithImageConfigArgs") {
+		t.Errorf("expected first option to be WithImageConfigArgs, got %s", firstOptName)
+	}
+
+	gotSpec := oci.Spec{
+		Linux: &specs.Linux{
+			Namespaces: createDefaultLinuxNamespaces(),
+		},
+		Process: &specs.Process{},
+	}
+
+	// We also skip WithDevices options in tests since they run os.Stat on host paths that don't exist.
+	var hasGPUDeviceOpt bool
+	dummyContainer := containers.Container{ID: "dummy"}
+	for _, opt := range specOpts[1:] { // Skip WithImageConfigArgs
+		optName := getFuncName(opt)
+		if strings.Contains(optName, "WithDevices") {
+			hasGPUDeviceOpt = true
+			continue // Skip executing the device stat option
+		}
+
+		if err := opt(ctx, nil, &dummyContainer, &gotSpec); err != nil {
+			t.Fatalf("failed to apply spec option: %v", err)
+		}
+	}
+
+	if !hasGPUDeviceOpt {
+		t.Errorf("expected to find WithDevices option for GPU device mapping")
+	}
+
+	// Verify GPU library bind mounts
+	foundGpuMount := false
+	for _, mnt := range gotSpec.Mounts {
+		if mnt.Destination == "/usr/local/nvidia/lib64" {
+			foundGpuMount = true
+		}
+	}
+	if !foundGpuMount {
+		t.Errorf("GPU library mount not found in spec: %v", gotSpec.Mounts)
+	}
+}
+
+func TestCreateOCISpecOpts_GPU_BCMode(t *testing.T) {
+	ctx := namespaces.WithNamespace(context.Background(), "default")
+	logger := &fakeLogger{}
+	img := createFakeImage(nil, nil, nil)
+
+	mockListFiles := func(dir, prefix string) ([]string, error) {
+		if dir == "/dev" && prefix == "nvidia" {
+			return []string{"/dev/nvidia0"}, nil
+		}
+		return nil, nil
+	}
+
+	ls := spec.LaunchSpec{
+		InstallGpuDriver: true,
+		Experiments: experiments.Experiments{
+			BcMode: true,
+		},
+	}
+
+	specOpts, err := createOCISpecOpts(img, ls, nil, mockListFiles, logger)
+	if err != nil {
+		t.Fatalf("createOCISpecOpts failed: %v", err)
+	}
+
+	gotSpec := oci.Spec{
+		Linux: &specs.Linux{
+			Namespaces: createDefaultLinuxNamespaces(),
+		},
+		Process: &specs.Process{},
+	}
+
+	dummyContainer := containers.Container{ID: "dummy"}
+	for _, opt := range specOpts[1:] { // Skip WithImageConfigArgs
+		optName := getFuncName(opt)
+		if strings.Contains(optName, "WithDevices") {
+			continue // Skip executing the device stat option
+		}
+		if err := opt(ctx, nil, &dummyContainer, &gotSpec); err != nil {
+			t.Fatalf("failed to apply spec option: %v", err)
+		}
+	}
+
+	// Verify GPU library bind mounts use the pre-baked 595.58.03 BC mode path
+	foundBcMount := false
+	for _, mnt := range gotSpec.Mounts {
+		if mnt.Source == "/opt/nvidia/595.58.03/lib64" && mnt.Destination == "/usr/local/nvidia/lib64" {
+			foundBcMount = true
+		}
+	}
+	if !foundBcMount {
+		t.Errorf("Expected BC Mode GPU mount (/opt/nvidia/595.58.03/lib64 -> /usr/local/nvidia/lib64) not found in spec: %v", gotSpec.Mounts)
+	}
+}
+
+func TestCreateOCISpecOpts_GPU_Error(t *testing.T) {
+	logger := &fakeLogger{}
+	img := createFakeImage(nil, nil, nil)
+
+	// Inject a scanner that fails
+	mockListFilesError := func(_, _ string) ([]string, error) {
+		return nil, fmt.Errorf("device filesystem scan failed")
+	}
+
+	ls := spec.LaunchSpec{
+		InstallGpuDriver: true,
+	}
+
+	_, err := createOCISpecOpts(img, ls, nil, mockListFilesError, logger)
+	if err == nil {
+		t.Fatalf("expected createOCISpecOpts to fail when listFiles fails, but got no error")
+	}
+	if !strings.Contains(err.Error(), "device filesystem scan failed") {
+		t.Errorf("expected error to wrap 'device filesystem scan failed', got: %v", err)
+	}
+}
+
+func TestCreateOCISpecOpts_DevShmSize(t *testing.T) {
+	ctx := namespaces.WithNamespace(context.Background(), "default")
+	logger := &fakeLogger{}
+	img := createFakeImage(nil, nil, nil)
+
+	ls := spec.LaunchSpec{
+		DevShmSize: 1048576, // 1MB
+	}
+
+	specOpts, err := createOCISpecOpts(img, ls, nil, dummyListFiles, logger)
+	if err != nil {
+		t.Fatalf("createOCISpecOpts failed: %v", err)
+	}
+
+	gotSpec, err := applySpecOptsToSpec(ctx, specOpts)
+	if err != nil {
+		t.Fatalf("failed to apply spec option: %v", err)
+	}
+
+	// Verify that /dev/shm mount exists with the custom size option
+	foundShmMount := false
+	for _, mnt := range gotSpec.Mounts {
+		if mnt.Destination == "/dev/shm" && mnt.Type == "tmpfs" {
+			for _, opt := range mnt.Options {
+				if strings.HasPrefix(opt, "size=1048576") {
+					foundShmMount = true
+				}
+			}
+		}
+	}
+	if !foundShmMount {
+		t.Errorf("Expected custom size /dev/shm mount not found in spec: %v", gotSpec.Mounts)
+	}
+}
+
+func TestFormatEnvVars_Error(t *testing.T) {
+	invalidEnvs := []spec.EnvVar{
+		{Name: "1INVALID", Value: "value"}, // starts with a digit
+	}
+
+	_, err := formatEnvVars(invalidEnvs)
+	if err == nil {
+		t.Fatalf("expected formatEnvVars to fail on invalid env name, but got no error")
+	}
+	if !strings.Contains(err.Error(), "malformed env name") {
+		t.Errorf("expected error to contain 'malformed env name', got: %v", err)
+	}
+}


### PR DESCRIPTION
Extracts the OCI container specification options builder from NewRunner into a standalone, testable function `createOCISpecOpts` in container_spec.go. This allows us to verify container options (envs, mounts, limits, cgroups, GPUs) in unit tests by applying them in-memory to a blank spec.