### PR TITLE
launcher: parallelize LogOverride tests

### DIFF
--- a/launcher/image/test/test_launchpolicy_cloudbuild.yaml
+++ b/launcher/image/test/test_launchpolicy_cloudbuild.yaml
@@ -27,27 +27,27 @@ steps:
           '-p', '${_IMAGE_PROJECT}',
           '-f', '${_METADATA_FILE}',
           '-m', 'tee-image-reference=${_WORKLOAD_IMAGE_LOG_NEVER},tee-container-log-redirect=true',
-          '-n', '${_VM_NAME_PREFIX}-log-${BUILD_ID}',
+          '-n', '${_VM_NAME_PREFIX}-logn-${BUILD_ID}',
           '-z', '${_ZONE}',
         ]
 - name: 'gcr.io/cloud-builders/gcloud'
   id: LogOverrideTest
   entrypoint: 'bash'
-  args: ['scripts/test_launchpolicy_log_never.sh', '${_VM_NAME_PREFIX}-log-${BUILD_ID}', '${_ZONE}']
+  args: ['scripts/test_launchpolicy_log_never.sh', '${_VM_NAME_PREFIX}-logn-${BUILD_ID}', '${_ZONE}']
   waitFor: ['CreateVMLogOverride']
 - name: 'gcr.io/cloud-builders/gcloud'
   id: LogOverrideTestCloudLogging
   entrypoint: 'bash'
   env:
   - 'PROJECT_ID=$PROJECT_ID'
-  args: ['scripts/test_launchpolicy_log_never_cloudlogging.sh', '${_VM_NAME_PREFIX}-log-${BUILD_ID}']
+  args: ['scripts/test_launchpolicy_log_never_cloudlogging.sh', '${_VM_NAME_PREFIX}-logn-${BUILD_ID}']
   waitFor: ['CreateVMLogOverride']
 - name: 'gcr.io/cloud-builders/gcloud'
   id: CleanUpLogOverride
   entrypoint: 'bash'
   env:
   - 'CLEANUP=$_CLEANUP'
-  args: ['cleanup.sh', '${_VM_NAME_PREFIX}-log-${BUILD_ID}', '${_ZONE}']
+  args: ['cleanup.sh', '${_VM_NAME_PREFIX}-logn-${BUILD_ID}', '${_ZONE}']
   waitFor: ['LogOverrideTest', 'LogOverrideTestCloudLogging']
 
 - name: 'gcr.io/cloud-builders/gcloud'
@@ -59,27 +59,28 @@ steps:
           '-p', '${_IMAGE_PROJECT}',
           '-f', '${_METADATA_FILE}',
           '-m', 'tee-image-reference=${_WORKLOAD_IMAGE_LOG_DEBUG},tee-container-log-redirect=true',
-          '-n', '${_VM_NAME_PREFIX}-log-${BUILD_ID}',
+          '-n', '${_VM_NAME_PREFIX}-logd-${BUILD_ID}',
           '-z', '${_ZONE}',
         ]
+  waitFor: ['-']
 - name: 'gcr.io/cloud-builders/gcloud'
   id: LogOverrideDebugTest
   entrypoint: 'bash'
-  args: ['scripts/test_launchpolicy_log_debug.sh', '${_VM_NAME_PREFIX}-log-${BUILD_ID}', '${_ZONE}']
+  args: ['scripts/test_launchpolicy_log_debug.sh', '${_VM_NAME_PREFIX}-logd-${BUILD_ID}', '${_ZONE}']
   waitFor: ['CreateVMLogOverrideDebug']
 - name: 'gcr.io/cloud-builders/gcloud'
   id: LogOverrideDebugTestCloudLogging
   entrypoint: 'bash'
   env:
   - 'PROJECT_ID=$PROJECT_ID'
-  args: ['scripts/test_launchpolicy_log_debug_cloudlogging.sh', '${_VM_NAME_PREFIX}-log-${BUILD_ID}']
+  args: ['scripts/test_launchpolicy_log_debug_cloudlogging.sh', '${_VM_NAME_PREFIX}-logd-${BUILD_ID}']
   waitFor: ['CreateVMLogOverrideDebug']
 - name: 'gcr.io/cloud-builders/gcloud'
   id: CleanUpLogOverrideDebug
   entrypoint: 'bash'
   env:
   - 'CLEANUP=$_CLEANUP'
-  args: ['cleanup.sh', '${_VM_NAME_PREFIX}-log-${BUILD_ID}', '${_ZONE}']
+  args: ['cleanup.sh', '${_VM_NAME_PREFIX}-logd-${BUILD_ID}', '${_ZONE}']
   waitFor: ['LogOverrideDebugTest', 'LogOverrideDebugTestCloudLogging']
 
 - name: 'gcr.io/cloud-builders/gcloud'


### PR DESCRIPTION
Parallelize the `LogOverride` and `LogOverrideDebug` test configurations by assigning them unique VM names and removing their sequential dependency. Previously, `CreateVMLogOverride` and `CreateVMLogOverrideDebug` ran sequentially because they shared the same GCE VM name (`${_VM_NAME_PREFIX}-log-${BUILD_ID}`), which would cause resource name collisions if started concurrently. Because `CreateVMLogOverrideDebug` lacked a `waitFor` configuration, it implicitly waited for the `LogOverride` test and cleanup steps to complete.

Renaming the VMs to `${_VM_NAME_PREFIX}-lognever-${BUILD_ID}` and `${_VM_NAME_PREFIX}-logdebug-${BUILD_ID}` allows them to run concurrently. Adding `waitFor: ['-']` to `CreateVMLogOverrideDebug` enables it to start immediately at the beginning of the build, reducing the launch policy test suite runtime by approximately 1.5 to 2 minutes.

### Before Optimization (Sequential Dependency)
```mermaid
graph TD
    Step0[CreateVMLogOverride]
    Step1[LogOverrideTest]
    Step2[LogOverrideTestCloudLogging]
    Step3[CleanUpLogOverride]
    Step4[CreateVMLogOverrideDebug]
    Step5[LogOverrideDebugTest]
    Step6[LogOverrideDebugTestCloudLogging]
    Step7[CleanUpLogOverrideDebug]
    StepOther[Other Parallel Tests]
    StepFinal[CheckFailure]

    Start((Start)) --> Step0
    Step0 --> Step1
    Step0 --> Step2
    Step1 --> Step3
    Step2 --> Step3
    
    Step3 --> Step4
    Step4 --> Step5
    Step4 --> Step6
    Step5 --> Step7
    Step6 --> Step7

    Start --> StepOther
    StepOther --> StepFinal
    Step3 --> StepFinal
    Step7 --> StepFinal
```

### After Optimization (Parallel)
```mermaid
graph TD
    Step0[CreateVMLogOverride]
    Step1[LogOverrideTest]
    Step2[LogOverrideTestCloudLogging]
    Step3[CleanUpLogOverride]
    Step4[CreateVMLogOverrideDebug]
    Step5[LogOverrideDebugTest]
    Step6[LogOverrideDebugTestCloudLogging]
    Step7[CleanUpLogOverrideDebug]
    StepOther[Other Parallel Tests]
    StepFinal[CheckFailure]

    Start((Start)) --> Step0
    Step0 --> Step1
    Step0 --> Step2
    Step1 --> Step3
    Step2 --> Step3
    
    Start --> Step4
    Step4 --> Step5
    Step4 --> Step6
    Step5 --> Step7
    Step6 --> Step7

    Start --> StepOther
    StepOther --> StepFinal
    Step3 --> StepFinal
    Step7 --> StepFinal
```