### PR TITLE
launcher: parallelize GCE image export steps in cloudbuild.yaml

### DIFF
--- a/launcher/cloudbuild.yaml
+++ b/launcher/cloudbuild.yaml
@@ -590,7 +590,7 @@ steps:
 
 - name: 'gcr.io/cloud-builders/gcloud'
   id: ExportDebugImage
-  waitFor: ['ExportHardenedImage', 'DebugImageTests']
+  waitFor: ['DebugImageTests']
   entrypoint: 'gcloud'
   args: ['compute', 'images', 'export',
           '--destination-uri=gs://${PROJECT_ID}_raw-images/${_OUTPUT_IMAGE_PREFIX}-debug-${_OUTPUT_IMAGE_SUFFIX}.tar.gz',
@@ -631,7 +631,7 @@ steps:
 
 - name: 'gcr.io/cloud-builders/gcloud'
   id: ExportVgHardenedImage
-  waitFor: ['ExportDebugImage', 'HardenedVgImageBuild']
+  waitFor: ['HardenedVgImageBuild', 'KeymanagerTests']
   entrypoint: 'gcloud'
   args: ['compute', 'images', 'export',
          '--destination-uri=gs://${PROJECT_ID}_raw-images/${_OUTPUT_IMAGE_PREFIX}-vg-hardened-${_OUTPUT_IMAGE_SUFFIX}.tar.gz',
@@ -640,7 +640,7 @@ steps:
 
 - name: 'gcr.io/cloud-builders/gcloud'
   id: ExportVgDebugImage
-  waitFor: ['ExportVgHardenedImage', 'DebugVgImageBuild']
+  waitFor: ['DebugVgImageBuild', 'KeymanagerTests']
   entrypoint: 'gcloud'
   args: ['compute', 'images', 'export',
           '--destination-uri=gs://${PROJECT_ID}_raw-images/${_OUTPUT_IMAGE_PREFIX}-vg-debug-${_OUTPUT_IMAGE_SUFFIX}.tar.gz',


### PR DESCRIPTION
Parallelize the GCE image export and measurement steps in the main GCB build pipeline to optimize total build time. Previously, `ExportHardenedImage`, `ExportDebugImage`, `ExportVgHardenedImage`, and `ExportVgDebugImage` were chained to run sequentially. Since each GCE image export task takes between 3 to 5 minutes, this sequential chain added 9 to 15 minutes of overhead to the pipeline. Because each export step uses unique source images, unique GCS destination URIs, and isolated Daisy scratch folders, they can run concurrently. We have:
1. Removed the sequential dependencies by making `ExportDebugImage` wait only on `DebugImageTests`.
2. Restructured `ExportVgHardenedImage` and `ExportVgDebugImage` to run concurrently, waiting only on their respective builds and `KeymanagerTests`. As a result, all 4 image exports and their subsequent measurement steps will execute concurrently as soon as their respective test suites finish, reducing overall build time by 9 to 15 minutes.

### Before Optimization (Sequential Exports)
```mermaid
graph TD
    subgraph Setup & Compilation
        Roots[DownloadGoogleRoots]
        BaseIdent[BaseImageIdent]
        KMCompile[KeyManagerCompile]
        LCompile[LauncherCompile]
        ExpBinary[DownloadExpBinary]
        GpuDrivers[DownloadGpuDrivers]
    end

    subgraph Image Builds
        DebugVgBuild[DebugVgImageBuild]
        HardenedVgBuild[HardenedVgImageBuild]
        DebugBuild[DebugImageBuild]
        HardenedBuild[HardenedImageBuild]
        DebugBcBuild[DebugBcImageBuild/Export]
        HardenedBcBuild[HardenedBcImageBuild/Export]
    end

    subgraph Integration Tests
        KeymanagerTests[KeymanagerTests]
        DebugImageTests[DebugImageTests]
        HardenedImageTests[HardenedImageTests]
        OtherDebug[Other Parallel Debug Tests]
        OtherHardened[Other Parallel Hardened Tests]
    end

    subgraph GCE Image Exports
        ExportHardened[ExportHardenedImage]
        ExportDebug[ExportDebugImage]
        ExportVgHardened[ExportVgHardenedImage]
        ExportVgDebug[ExportVgDebugImage]
    end

    subgraph Image Measurements
        MeasureHardened[MeasureHardenedImage]
        MeasureDebug[MeasureDebugImage]
        MeasureVgHardened[MeasureVgHardenedImage]
        MeasureVgDebug[MeasureVgDebugImage]
    end

    %% Setup -> Compilation
    KMCompile --> LCompile
    BaseIdent --> GpuDrivers

    %% Compilation -> Builds
    LCompile --> DebugVgBuild
    LCompile --> HardenedVgBuild
    LCompile --> DebugBuild
    LCompile --> HardenedBuild
    LCompile --> DebugBcBuild
    LCompile --> HardenedBcBuild
    Roots & BaseIdent & ExpBinary & GpuDrivers --> DebugVgBuild & HardenedVgBuild & DebugBuild & HardenedBuild & DebugBcBuild & HardenedBcBuild

    %% Builds -> Tests
    DebugVgBuild --> KeymanagerTests
    DebugBuild --> DebugImageTests & OtherDebug
    HardenedBuild --> HardenedImageTests & OtherHardened

    %% Tests -> Sequential Exports
    HardenedImageTests --> ExportHardened
    
    ExportHardened --> ExportDebug
    DebugImageTests --> ExportDebug
    
    ExportDebug --> ExportVgHardened
    HardenedVgBuild --> ExportVgHardened
    
    ExportVgHardened --> ExportVgDebug
    DebugVgBuild --> ExportVgDebug

    %% Exports -> Measurements
    ExportHardened --> MeasureHardened
    ExportDebug --> MeasureDebug
    ExportVgHardened --> MeasureVgHardened
    ExportVgDebug --> MeasureVgDebug
```
### After Optimization (Parallel Exports)
```mermaid
graph TD
    subgraph Setup & Compilation
        Roots[DownloadGoogleRoots]
        BaseIdent[BaseImageIdent]
        KMCompile[KeyManagerCompile]
        LCompile[LauncherCompile]
        ExpBinary[DownloadExpBinary]
        GpuDrivers[DownloadGpuDrivers]
    end

    subgraph Image Builds
        DebugVgBuild[DebugVgImageBuild]
        HardenedVgBuild[HardenedVgImageBuild]
        DebugBuild[DebugImageBuild]
        HardenedBuild[HardenedImageBuild]
        DebugBcBuild[DebugBcImageBuild/Export]
        HardenedBcBuild[HardenedBcImageBuild/Export]
    end

    subgraph Integration Tests
        KeymanagerTests[KeymanagerTests]
        DebugImageTests[DebugImageTests]
        HardenedImageTests[HardenedImageTests]
        OtherDebug[Other Parallel Debug Tests]
        OtherHardened[Other Parallel Hardened Tests]
    end

    subgraph GCE Image Exports
        ExportHardened[ExportHardenedImage]
        ExportDebug[ExportDebugImage]
        ExportVgHardened[ExportVgHardenedImage]
        ExportVgDebug[ExportVgDebugImage]
    end

    subgraph Image Measurements
        MeasureHardened[MeasureHardenedImage]
        MeasureDebug[MeasureDebugImage]
        MeasureVgHardened[MeasureVgHardenedImage]
        MeasureVgDebug[MeasureVgDebugImage]
    end

    %% Setup -> Compilation
    KMCompile --> LCompile
    BaseIdent --> GpuDrivers

    %% Compilation -> Builds
    LCompile --> DebugVgBuild
    LCompile --> HardenedVgBuild
    LCompile --> DebugBuild
    LCompile --> HardenedBuild
    LCompile --> DebugBcBuild
    LCompile --> HardenedBcBuild
    Roots & BaseIdent & ExpBinary & GpuDrivers --> DebugVgBuild & HardenedVgBuild & DebugBuild & HardenedBuild & DebugBcBuild & HardenedBcBuild

    %% Builds -> Tests
    DebugVgBuild --> KeymanagerTests
    DebugBuild --> DebugImageTests & OtherDebug
    HardenedBuild --> HardenedImageTests & OtherHardened

    %% Tests -> Concurrent Exports (Optimized)
    HardenedImageTests --> ExportHardened
    
    DebugImageTests --> ExportDebug
    
    KeymanagerTests --> ExportVgHardened
    HardenedVgBuild --> ExportVgHardened
    
    KeymanagerTests --> ExportVgDebug
    DebugVgBuild --> ExportVgDebug

    %% Exports -> Measurements
    ExportHardened --> MeasureHardened
    ExportDebug --> MeasureDebug
    ExportVgHardened --> MeasureVgHardened
    ExportVgDebug --> MeasureVgDebug
```