### PR TITLE
launcher: wait for containerd task IO to drain on exit

### DIFF
--- a/launcher/container_runner.go
+++ b/launcher/container_runner.go
@@ -860,6 +860,11 @@ func (r *ContainerRunner) Run(ctx context.Context) error {
 		return &RetryableError{err}
 	}
 	defer task.Delete(ctx)
+	defer func() {
+		if task.IO() != nil {
+			task.IO().Wait()
+		}
+	}()
 
 	r.enableGracefulShutdown(ctx, task)
 


### PR DESCRIPTION
## Problem
For short-lived container workloads (e.g., those that exit in less than a second), the Confidential Space Launcher was frequently failing to export the last few lines of the workload's stdout/stderr logs to Cloud Logging before the VM shut down. 
This occurred due to a race condition between the workload exit detection and the background I/O copying loop managed by the `containerd` Go client library:
1. **Background I/O copy loop**: When a task is created, the `containerd` library spawns background goroutines to copy data from the container's stdout/stderr FIFO pipes to our configured log writers (`stdoutWriter`/`stderrWriter`).
2. **Immediate exit**: When the container process terminates, the exit status is sent to the launcher immediately via the `exitStatusC` channel.
3. **Premature cleanup**: Without waiting for the I/O copy goroutines to finish draining the pipes, the launcher proceeded to cleanup (`task.Delete(ctx)`), which calls `cio.IO.Close()` and closes the client side of the pipes.
4. **VM shutdown**: The launcher then called `os.Exit()`, and the VM initiated shutdown, abruptly killing any background copy tasks and truncating logs.


## Technical Details & Documentation Links
*   **`cio.IO` Interface Definition**: [containerd/cio/io.go (Lines 53–63)](https://github.com/containerd/containerd/blob/v1.7.20/cio/io.go#L53-L63)
    *   This defines the strict contract for `Wait()` and `Close()` on task I/O:
    ```go
    type IO interface {
        // Wait blocks until all io copy operations have completed.
        Wait()
        // Close cleans up all open io resources.
        Close() error
    }
    ```
*   **`task.Delete` Implementation**: [containerd/task.go (Lines 329–332)](https://github.com/containerd/containerd/blob/v1.7.20/task.go#L329-L332)
    *   This confirms that `task.Delete` calls `t.io.Close()` immediately during task cleanup:
    ```go
    // io.Close first (https://github.com/containerd/containerd/issues/5621)
    if t.io != nil {
        t.io.Close()
    }
    ```
*   **`cio.Wait` Copy Loop Synchronization**: [containerd/cio/io.go (Lines 191–195)](https://github.com/containerd/containerd/blob/v1.7.20/cio/io.go#L191-L195)
    *   This shows that the `Wait()` implementation blocks on the internal WaitGroup that tracks active background copy goroutines:
    ```go
    func (c *cio) Wait() {
        if c.wg != nil {
            c.wg.Wait()
        }
    }
    ```
---

## Execution Flow Comparison (Mermaid)

Because of Go's LIFO defer execution order, when the runner's `Run()` function returns:
*   `task.IO().Wait()` is invoked first. It blocks the launcher process until all background I/O copy goroutines have read to EOF and exited.
*   `task.Delete(ctx)` is invoked second, safely cleaning up the task and closing the pipes only after they have been fully drained.

```mermaid
sequenceDiagram
    autonumber
    participant Workload as Workload Container
    participant FIFO as FIFO Pipes (stdout/stderr)
    participant CopyLoop as Client Copy Loop (Goroutine in Launcher)
    participant Launcher as Launcher Main Process
    participant CloudLogging as Cloud Logging API

    Note over Workload, Launcher: Task started, background Client Copy Loop initiated

    Workload->>FIFO: Writes log lines
    FIFO->>CopyLoop: Pipes stream bytes
    CopyLoop->>Launcher: Writes to stdoutWriter (calls cloudLogger.Log)
    Launcher->>CloudLogging: API request (blocks on Flush)

    Note over Workload: Workload exits instantly (e.g. 10ms)
    Workload-->>Launcher: exitStatusC channel unblocks

    rect rgb(240, 240, 240)
        Note over Launcher: FIXED PATHWAY (with task.IO().Wait())
        Launcher->>Launcher: Defer: task.IO().Wait() blocks
        FIFO->>CopyLoop: Reads remaining bytes to EOF
        CopyLoop->>Launcher: Writes remaining logs
        Note over CopyLoop: Goroutine exits (dec WaitGroup)
        Launcher->>Launcher: task.IO().Wait() unblocks (WaitGroup is 0)
        Launcher->>Launcher: Defer: task.Delete() (closes pipes)
        Launcher->>CloudLogging: Defer: workloadLogger.Close() (flushes SDK buffers)
        Launcher->>Launcher: os.Exit() & VM shuts down
    end

    rect rgb(255, 230, 230)
        Note over Launcher: BROKEN PATHWAY (without task.IO().Wait())
        Launcher->>Launcher: Defer: task.Delete() runs immediately
        Launcher->>FIFO: Closes client pipes (cio.IO.Close)
        Note over CopyLoop: copy loop receives premature EOF / aborts
        Note over CopyLoop: Remaining logs in pipes are lost
        Launcher->>CloudLogging: Defer: workloadLogger.Close()
        Launcher->>Launcher: os.Exit() & VM shuts down (remaining buffers killed)
    end
```

---

## Bug Introduction

This bug was exposed by the transition to structured Cloud Logging in #595:

*   **Before #595**: Container logs were written directly to `os.Stdout` (local serial console). Because writing to a local file descriptor is near-instantaneous, containerd's background copy loop routinely finished draining the FIFO pipes before the Launcher executed the task cleanup.
*   **After #595**: Workload logs were redirected to `SeverityWriter`, which blocks on synchronous, outbound network RPCs to the Cloud Logging API.
*   **The Contention**: The slow network writes bottlenecked the copy loop. As a result, the copy loop consistently lost the race against the Launcher's cleanup thread (`task.Delete(ctx)`), which would execute and close the pipes while logs were still in transit.