### PR TITLE
launcher: fix timing race in log redirection integration test

### DIFF
--- a/launcher/image/test/scripts/test_log_redirect.sh
+++ b/launcher/image/test/scripts/test_log_redirect.sh
@@ -3,19 +3,36 @@ set -euxo pipefail
 source util/read_serial.sh
 source util/read_cloud_logging.sh
 
-# Allow VM some time to boot and start the workload.
-sleep 150
-
 output=""
 if [[ "$1" == "serial" ]]; then
+    # read_serial has built-in dynamic polling and waits for task exit.
     echo "Reading from serial console for VM $3 in zone $4"
     output=$(read_serial $3 $4)
 elif [[ "$1" == "cloud_logging" ]]; then
-    echo "Reading from cloud logging for VM $3"
-    output=$(read_cloud_logging $3)
+    echo "Polling cloud logging for VM $3 in zone $4"
+    MAX_WAIT_SECONDS=600
+    INTERVAL_SECONDS=15
+    ELAPSED=0
+    while [ $ELAPSED -lt $MAX_WAIT_SECONDS ]; do
+        output=$(read_cloud_logging $3 || true)
+        
+        # If logs are expected and found, return early
+        if [[ $output == *"Token looks okay"* ]] && [[ "$2" == "true" ]]; then
+            break
+        fi
+
+        # Check if VM is done running
+        vm_status=$(gcloud compute instances describe "$3" --zone "$4" --format="value(status)" || echo "TERMINATED")
+        if [[ "$vm_status" == "TERMINATED" ]]; then
+            break
+        fi
+
+        sleep $INTERVAL_SECONDS
+        ELAPSED=$((ELAPSED + INTERVAL_SECONDS))
+    done
 else 
     echo "Usage: test_log_redirect.sh <serial|cloud_logging> <expectLogs=true|false> <VM_NAME> <ZONE>"
-    return 1
+    exit 1
 fi
 
 if [[ $output != *"Token looks okay"* ]] && [[ "$2" == "true" ]]; then


### PR DESCRIPTION
# Fix Timing Race in Log Redirection Integration Test

### **Problem**
The integration test `LogRedirectionTests` (running under `test_log_redirection.yaml`) frequently flakes or fails with a false-negative result because of a timing race condition:
1. The test script `test_log_redirect.sh` had a hardcoded `sleep 150` (2.5 minutes) to wait for the GCE VM to boot up and run the workload.
2. Under heavy GCB system load, VM image pulling and container runner startup on the GCE instance can take up to **5 minutes**.
3. Because the sleep duration (2.5 minutes) was shorter than the startup time (5 minutes), the verification step ran `read_cloud_logging` before the workload had booted or written any logs, causing the test to fail.

### **Solution**
This PR replaces the hardcoded `sleep 150` with a dynamic polling loop:
* **Cloud Logging verification**: The script now queries the Cloud Logging API every 15 seconds. If the expected log pattern (`"Token looks okay"`) is found, it exits early (reducing test runtime). If the logs aren't found, it continues polling until the GCE VM shuts down (`TERMINATED` status) or the 10-minute timeout is reached.