### PR TITLE
launcher: isolate gcloud config globally in cloudbuild.yaml options

### DIFF
--- a/launcher/cloudbuild.yaml
+++ b/launcher/cloudbuild.yaml
@@ -743,3 +743,5 @@ options:
   automapSubstitutions: true
   pool:
     name: 'projects/confidential-space-images-dev/locations/us-west1/workerPools/cs-image-build-vpc'
+  env:
+  - 'CLOUDSDK_CONFIG=/tmp/gcloud'


### PR DESCRIPTION
# Isolate gcloud Configuration Globally in cloudbuild.yaml Options

### **Problem**
When running integration tests in the presubmit pipeline, multiple GCB steps are executed concurrently. By default, GCB runs all steps on the same worker VM and mounts `/builder/home` as a shared volume across all step containers.

Because the `gcloud` CLI writes its cached credentials and configurations to `$HOME/.config/gcloud/credentials.db` (SQLite), parallel invocations of `gcloud builds submit` concurrently read and write to this single database file. This results in SQLite write lock conflicts, causing the parent GCB step pollers to hang indefinitely even after their nested child builds finish.

---

### **Evidence**
In the parent Cloud Build logs, parallel steps emitted the following warning:
```text
WARNING: Could not store access token in cache: database is locked
```

According to the Cloud SDK team's design documentation:
> *"Parallel execution of multiple gcloud CLI commands is not supported. This is because gcloud interacts with a shared SQLite database and parallel execution can result in multiple invocations attempting to write to the database at the same time."*

*Note: Reviewers can DM me for links to internal Google CLs demonstrating identical Workarounds deployed in other internal build systems to resolve this exact SQLite lock crash.*

---

### **Solution**
We added `CLOUDSDK_CONFIG=/tmp/gcloud` to the global `options.env` block in `cloudbuild.yaml`. 

This resolves the lock contention because:
1. **Container Isolation**: Each Cloud Build step container runs in its own private root filesystem namespace. The `/tmp` directory is container-private (unlike the shared `/builder/home` volume), meaning that even if all parallel steps use the literal path `/tmp/gcloud`, their cache files are written to completely isolated filesystems.
2. **Ambient Authentication**: Inside GCB, `gcloud` relies on the ambient GCE Metadata Server to retrieve service account tokens. It does not require a pre-existing credentials file in the home directory. Setting `CLOUDSDK_CONFIG` to a fresh `/tmp` folder is fully safe and does not break authentication; `gcloud` will fetch the token and cache it locally in `/tmp` without sharing the database.