### PR TITLE
launcher: run all integration tests on smaller workers

### DIFF
--- a/launcher/image/test/test_debug_cloudbuild.yaml
+++ b/launcher/image/test/test_debug_cloudbuild.yaml
@@ -78,4 +78,5 @@ steps:
 
 options:
   pool:
-    name: 'projects/confidential-space-images-dev/locations/us-west1/workerPools/cs-image-build-vpc'
+    name: 'projects/confidential-space-images-dev/locations/us-west1/workerPools/cs-image-test-vpc'
+

--- a/launcher/image/test/test_debug_unstable_cloudbuild.yaml
+++ b/launcher/image/test/test_debug_unstable_cloudbuild.yaml
@@ -37,4 +37,5 @@ steps:
   
 options:
   pool:
-    name: 'projects/confidential-space-images-dev/locations/us-west1/workerPools/cs-image-build-vpc'
+    name: 'projects/confidential-space-images-dev/locations/us-west1/workerPools/cs-image-test-vpc'
+

--- a/launcher/image/test/test_discover_signatures.yaml
+++ b/launcher/image/test/test_discover_signatures.yaml
@@ -66,4 +66,5 @@ steps:
 
 options:
   pool:
-    name: 'projects/confidential-space-images-dev/locations/us-west1/workerPools/cs-image-build-vpc'
+    name: 'projects/confidential-space-images-dev/locations/us-west1/workerPools/cs-image-test-vpc'
+

--- a/launcher/image/test/test_experiments_client.yaml
+++ b/launcher/image/test/test_experiments_client.yaml
@@ -37,4 +37,5 @@ steps:
 
 options:
   pool:
-    name: 'projects/confidential-space-images-dev/locations/us-west1/workerPools/cs-image-build-vpc'
+    name: 'projects/confidential-space-images-dev/locations/us-west1/workerPools/cs-image-test-vpc'
+

--- a/launcher/image/test/test_hardened_cloudbuild.yaml
+++ b/launcher/image/test/test_hardened_cloudbuild.yaml
@@ -76,4 +76,5 @@ steps:
 
 options:
   pool:
-    name: 'projects/confidential-space-images-dev/locations/us-west1/workerPools/cs-image-build-vpc'
+    name: 'projects/confidential-space-images-dev/locations/us-west1/workerPools/cs-image-test-vpc'
+

--- a/launcher/image/test/test_hardened_unstable_cloudbuild.yaml
+++ b/launcher/image/test/test_hardened_unstable_cloudbuild.yaml
@@ -37,4 +37,5 @@ steps:
   
 options:
   pool:
-    name: 'projects/confidential-space-images-dev/locations/us-west1/workerPools/cs-image-build-vpc'
+    name: 'projects/confidential-space-images-dev/locations/us-west1/workerPools/cs-image-test-vpc'
+

--- a/launcher/image/test/test_health_monitoring.yaml
+++ b/launcher/image/test/test_health_monitoring.yaml
@@ -94,4 +94,5 @@ steps:
 
 options:
   pool:
-    name: 'projects/confidential-space-images-dev/locations/us-west1/workerPools/cs-image-build-vpc'
+    name: 'projects/confidential-space-images-dev/locations/us-west1/workerPools/cs-image-test-vpc'
+

--- a/launcher/image/test/test_http_server.yaml
+++ b/launcher/image/test/test_http_server.yaml
@@ -39,4 +39,5 @@ steps:
 
 options:
   pool:
-    name: 'projects/confidential-space-images-dev/locations/us-west1/workerPools/cs-image-build-vpc'
+    name: 'projects/confidential-space-images-dev/locations/us-west1/workerPools/cs-image-test-vpc'
+

--- a/launcher/image/test/test_ingress_network.yaml
+++ b/launcher/image/test/test_ingress_network.yaml
@@ -64,4 +64,5 @@ steps:
 
 options:
   pool:
-    name: 'projects/confidential-space-images-dev/locations/us-west1/workerPools/cs-image-build-vpc'
+    name: 'projects/confidential-space-images-dev/locations/us-west1/workerPools/cs-image-test-vpc'
+

--- a/launcher/image/test/test_keymanager_cloudbuild.yaml
+++ b/launcher/image/test/test_keymanager_cloudbuild.yaml
@@ -46,4 +46,5 @@ steps:
 
 options:
   pool:
-    name: 'projects/confidential-space-images-dev/locations/us-west1/workerPools/cs-image-build-vpc'
+    name: 'projects/confidential-space-images-dev/locations/us-west1/workerPools/cs-image-test-vpc'
+

--- a/launcher/image/test/test_launchpolicy_cloudbuild.yaml
+++ b/launcher/image/test/test_launchpolicy_cloudbuild.yaml
@@ -284,4 +284,5 @@ steps:
 
 options:
   pool:
-    name: 'projects/confidential-space-images-dev/locations/us-west1/workerPools/cs-image-build-vpc'
+    name: 'projects/confidential-space-images-dev/locations/us-west1/workerPools/cs-image-test-vpc'
+

--- a/launcher/image/test/test_log_redirection.yaml
+++ b/launcher/image/test/test_log_redirection.yaml
@@ -141,3 +141,8 @@ steps:
   env:
   - 'BUILD_ID=$BUILD_ID'
   args: ['check_failure.sh']
+
+options:
+  pool:
+    name: 'projects/confidential-space-images-dev/locations/us-west1/workerPools/cs-image-test-vpc'
+

--- a/launcher/image/test/test_memory_monitoring.yaml
+++ b/launcher/image/test/test_memory_monitoring.yaml
@@ -68,4 +68,5 @@ steps:
 
 options:
   pool:
-    name: 'projects/confidential-space-images-dev/locations/us-west1/workerPools/cs-image-build-vpc'
+    name: 'projects/confidential-space-images-dev/locations/us-west1/workerPools/cs-image-test-vpc'
+

--- a/launcher/image/test/test_mounts.yaml
+++ b/launcher/image/test/test_mounts.yaml
@@ -154,3 +154,7 @@ steps:
   - 'BUILD_ID=$BUILD_ID'
   args: ['check_failure.sh']
   waitFor: ['CleanUpVMWithDefault', 'CleanUpVMWithMountsAllowed', 'CleanUpVMWithMountsDenied']
+
+options:
+  pool:
+    name: 'projects/confidential-space-images-dev/locations/us-west1/workerPools/cs-image-test-vpc'

--- a/launcher/image/test/test_oda_with_signed_container.yaml
+++ b/launcher/image/test/test_oda_with_signed_container.yaml
@@ -48,4 +48,5 @@ steps:
 
 options:
   pool:
-    name: 'projects/confidential-space-images-dev/locations/us-west1/workerPools/cs-image-build-vpc'
+    name: 'projects/confidential-space-images-dev/locations/us-west1/workerPools/cs-image-test-vpc'
+

--- a/launcher/image/test/test_privileged.yaml
+++ b/launcher/image/test/test_privileged.yaml
@@ -144,3 +144,8 @@ steps:
   env:
   - 'BUILD_ID=$BUILD_ID'
   args: ['check_failure.sh']
+
+options:
+  pool:
+    name: 'projects/confidential-space-images-dev/locations/us-west1/workerPools/cs-image-test-vpc'
+

--- a/launcher/image/test/test_workloadcleanup_cloudbuild.yaml
+++ b/launcher/image/test/test_workloadcleanup_cloudbuild.yaml
@@ -100,6 +100,7 @@ steps:
   args: ['check_failure.sh']
 
 options:
-  dynamic_substitutions: true
   pool:
-    name: 'projects/confidential-space-images-dev/locations/us-west1/workerPools/cs-image-build-vpc'
+    name: 'projects/confidential-space-images-dev/locations/us-west1/workerPools/cs-image-test-vpc'
+  dynamic_substitutions: true
+


### PR DESCRIPTION
Right-size integration test sub-build workers in the public pool to reduce CPU quota consumption and prevent presubmit queue timeouts.