### PR TITLE
launcher: set 10s polling interval on gcloud builds submit

### DIFF
--- a/launcher/cloudbuild.yaml
+++ b/launcher/cloudbuild.yaml
@@ -11,6 +11,7 @@ substitutions:
   '_BC_BASE_IMAGE': 'cos-bc-guest-125-19216-395-112'
   '_BC_DEBUG_IMAGE': 'cos-bcdbg-guest-125-19216-395-112'
   '_WSD_CONTAINER_IMAGE_REF': 'us-docker.pkg.dev/confidential-space-images-dev/key-protection-module-images/key-protection-module:acdec5c'
+  '_POLLING_INTERVAL': '10'
 
 
 steps:
@@ -126,7 +127,7 @@ steps:
     set -exuo pipefail
 
     echo "building the debug image: ${OUTPUT_IMAGE_NAME} with the base image: ${VG_BASE_IMAGE}"
-    gcloud builds submit --config=launcher/image/cloudbuild.yaml \
+    gcloud builds submit --polling-interval=$_POLLING_INTERVAL --config=launcher/image/cloudbuild.yaml \
     --region us-west1 \
     --substitutions \
     _BASE_IMAGE=${VG_BASE_IMAGE},\
@@ -156,7 +157,7 @@ steps:
     set -exuo pipefail
 
     echo "building the hardened image: ${OUTPUT_IMAGE_NAME} with the base image: ${VG_BASE_IMAGE}"
-    gcloud builds submit --config=launcher/image/cloudbuild.yaml \
+    gcloud builds submit --polling-interval=$_POLLING_INTERVAL --config=launcher/image/cloudbuild.yaml \
     --region us-west1 \
     --substitutions \
     _BASE_IMAGE=${VG_BASE_IMAGE},\
@@ -185,7 +186,7 @@ steps:
 
     base_image=$(cat /workspace/base_image.txt)
     echo "building the debug image: ${OUTPUT_IMAGE_NAME} with the base image: ${base_image}"
-    gcloud builds submit --config=launcher/image/cloudbuild.yaml \
+    gcloud builds submit --polling-interval=$_POLLING_INTERVAL --config=launcher/image/cloudbuild.yaml \
     --region us-west1 \
     --substitutions \
     _BASE_IMAGE=${base_image},\
@@ -215,7 +216,7 @@ steps:
 
     base_image=$(cat /workspace/base_image.txt)
     echo "building the hardened image: ${OUTPUT_IMAGE_NAME} with the base image: ${base_image}"
-    gcloud builds submit --config=launcher/image/cloudbuild.yaml \
+    gcloud builds submit --polling-interval=$_POLLING_INTERVAL --config=launcher/image/cloudbuild.yaml \
     --region us-west1 \
     --substitutions \
     _BASE_IMAGE=${base_image},\
@@ -247,7 +248,7 @@ steps:
     set -exuo pipefail
 
     echo "building the debug image with BC customizer with the base image: ${BC_BASE_IMAGE}"
-    gcloud builds submit --config=launcher/image/bc_cloudbuild.yaml \
+    gcloud builds submit --polling-interval=$_POLLING_INTERVAL --config=launcher/image/bc_cloudbuild.yaml \
     --region us-west1 \
     --substitutions \
     _BASE_IMAGE=${BC_BASE_IMAGE},\
@@ -276,7 +277,7 @@ steps:
     set -exuo pipefail
 
     echo "building the hardened image with BC customizer with the base image: ${BC_BASE_IMAGE}"
-    gcloud builds submit --config=launcher/image/bc_cloudbuild.yaml \
+    gcloud builds submit --polling-interval=$_POLLING_INTERVAL --config=launcher/image/bc_cloudbuild.yaml \
     --region us-west1 \
     --substitutions \
     _BASE_IMAGE=${BC_BASE_IMAGE},\
@@ -299,7 +300,7 @@ steps:
 
     cd launcher/image/test
     echo "running experiments client tests on ${OUTPUT_IMAGE_NAME}"
-    gcloud builds submit --config=test_experiments_client.yaml --region us-west1 \
+    gcloud builds submit --polling-interval=$_POLLING_INTERVAL --config=test_experiments_client.yaml --region us-west1 \
       --substitutions _IMAGE_NAME=${OUTPUT_IMAGE_NAME},_IMAGE_PROJECT=${PROJECT_ID}
     exit
 
@@ -314,7 +315,7 @@ steps:
 
     cd launcher/image/test
     echo "running http server tests on ${OUTPUT_IMAGE_NAME}"
-    gcloud builds submit --config=test_http_server.yaml --region us-west1 \
+    gcloud builds submit --polling-interval=$_POLLING_INTERVAL --config=test_http_server.yaml --region us-west1 \
       --substitutions _IMAGE_NAME=${OUTPUT_IMAGE_NAME},_IMAGE_PROJECT=${PROJECT_ID}
     exit
 
@@ -329,7 +330,7 @@ steps:
 
     cd launcher/image/test
     echo "running keymanager tests on ${OUTPUT_IMAGE_NAME}"
-    gcloud builds submit --config=test_keymanager_cloudbuild.yaml --region us-west1 \
+    gcloud builds submit --polling-interval=$_POLLING_INTERVAL --config=test_keymanager_cloudbuild.yaml --region us-west1 \
       --substitutions _IMAGE_NAME=${OUTPUT_IMAGE_NAME},_IMAGE_PROJECT=${PROJECT_ID}
     exit
 
@@ -344,7 +345,7 @@ steps:
 
     cd launcher/image/test
     echo "running debug image tests on ${OUTPUT_IMAGE_NAME}"
-    gcloud builds submit --config=test_debug_cloudbuild.yaml --region us-west1 \
+    gcloud builds submit --polling-interval=$_POLLING_INTERVAL --config=test_debug_cloudbuild.yaml --region us-west1 \
       --substitutions _IMAGE_NAME=${OUTPUT_IMAGE_NAME},_IMAGE_PROJECT=${PROJECT_ID}
     exit
 
@@ -359,7 +360,7 @@ steps:
 
     cd launcher/image/test
     echo "running debug image tests on ${OUTPUT_IMAGE_NAME}"
-    gcloud builds submit --config=test_debug_cloudbuild.yaml --region us-west1 \
+    gcloud builds submit --polling-interval=$_POLLING_INTERVAL --config=test_debug_cloudbuild.yaml --region us-west1 \
       --substitutions _CC=TDX,_IMAGE_NAME=${OUTPUT_IMAGE_NAME},_IMAGE_PROJECT=${PROJECT_ID}
     exit
 
@@ -374,7 +375,7 @@ steps:
 
     cd launcher/image/test
     echo "running hardened image tests on ${OUTPUT_IMAGE_NAME}"
-    gcloud builds submit --config=test_hardened_cloudbuild.yaml --region us-west1 \
+    gcloud builds submit --polling-interval=$_POLLING_INTERVAL --config=test_hardened_cloudbuild.yaml --region us-west1 \
       --substitutions _IMAGE_NAME=${OUTPUT_IMAGE_NAME},_IMAGE_PROJECT=${PROJECT_ID}
     exit
 
@@ -389,7 +390,7 @@ steps:
 
     cd launcher/image/test
     echo "running hardened image tests on ${OUTPUT_IMAGE_NAME}"
-    gcloud builds submit --config=test_hardened_cloudbuild.yaml --region us-west1 \
+    gcloud builds submit --polling-interval=$_POLLING_INTERVAL --config=test_hardened_cloudbuild.yaml --region us-west1 \
       --substitutions _CC=TDX,_IMAGE_NAME=${OUTPUT_IMAGE_NAME},_IMAGE_PROJECT=${PROJECT_ID}
     exit
 
@@ -404,7 +405,7 @@ steps:
 
     cd launcher/image/test
     echo "running launch policy tests on ${OUTPUT_IMAGE_NAME}"
-    gcloud builds submit --config=test_launchpolicy_cloudbuild.yaml --region us-west1 \
+    gcloud builds submit --polling-interval=$_POLLING_INTERVAL --config=test_launchpolicy_cloudbuild.yaml --region us-west1 \
       --substitutions _HARDENED_IMAGE_NAME=${OUTPUT_IMAGE_NAME},_IMAGE_PROJECT=${PROJECT_ID}
     exit
 
@@ -418,7 +419,7 @@ steps:
     #!/usr/bin/env bash
     cd launcher/image/test
     echo "running hardened image ingress network tests on ${OUTPUT_IMAGE_NAME}"
-    gcloud builds submit --config=test_ingress_network.yaml --region us-west1 \
+    gcloud builds submit --polling-interval=$_POLLING_INTERVAL --config=test_ingress_network.yaml --region us-west1 \
       --substitutions _IMAGE_NAME=${OUTPUT_IMAGE_NAME},_IMAGE_PROJECT=${PROJECT_ID}
     exit
 
@@ -432,7 +433,7 @@ steps:
     #!/usr/bin/env bash
     cd launcher/image/test
     echo "running debug image ingress network tests on ${OUTPUT_IMAGE_NAME}"
-    gcloud builds submit --config=test_ingress_network.yaml --region us-west1 \
+    gcloud builds submit --polling-interval=$_POLLING_INTERVAL --config=test_ingress_network.yaml --region us-west1 \
       --substitutions _IMAGE_NAME=${OUTPUT_IMAGE_NAME},_IMAGE_PROJECT=${PROJECT_ID}
     exit
 
@@ -447,7 +448,7 @@ steps:
 
     cd launcher/image/test
     echo "running log redirection tests on ${OUTPUT_IMAGE_NAME}"
-    gcloud builds submit --config=test_log_redirection.yaml --region us-west1 \
+    gcloud builds submit --polling-interval=$_POLLING_INTERVAL --config=test_log_redirection.yaml --region us-west1 \
       --substitutions _HARDENED_IMAGE_NAME=${OUTPUT_IMAGE_NAME},_IMAGE_PROJECT=${PROJECT_ID}
     exit
 
@@ -461,7 +462,7 @@ steps:
     #!/usr/bin/env bash
     cd launcher/image/test
     echo "running hardened image container signature tests on ${OUTPUT_IMAGE_NAME}"
-    gcloud builds submit --config=test_discover_signatures.yaml --region us-west1 \
+    gcloud builds submit --polling-interval=$_POLLING_INTERVAL --config=test_discover_signatures.yaml --region us-west1 \
       --substitutions _IMAGE_NAME=${OUTPUT_IMAGE_NAME},_IMAGE_PROJECT=${PROJECT_ID},_SIGNATURE_REPO=us-docker.pkg.dev/confidential-space-images-dev/cs-cosign-tests/hardened
     exit
 
@@ -475,7 +476,7 @@ steps:
     #!/usr/bin/env bash
     cd launcher/image/test
     echo "running debug image container signature tests on ${OUTPUT_IMAGE_NAME}"
-    gcloud builds submit --config=test_discover_signatures.yaml --region us-west1 \
+    gcloud builds submit --polling-interval=$_POLLING_INTERVAL --config=test_discover_signatures.yaml --region us-west1 \
       --substitutions _IMAGE_NAME=${OUTPUT_IMAGE_NAME},_IMAGE_PROJECT=${PROJECT_ID},_SIGNATURE_REPO=us-docker.pkg.dev/confidential-space-images-dev/cs-cosign-tests/debug
     exit
 
@@ -489,7 +490,7 @@ steps:
     #!/usr/bin/env bash
     cd launcher/image/test
     echo "running memory monitoring tests on ${OUTPUT_IMAGE_NAME}"
-    gcloud builds submit --config=test_memory_monitoring.yaml --region us-west1 \
+    gcloud builds submit --polling-interval=$_POLLING_INTERVAL --config=test_memory_monitoring.yaml --region us-west1 \
       --substitutions _IMAGE_NAME=${OUTPUT_IMAGE_NAME},_IMAGE_PROJECT=${PROJECT_ID}
     exit
 
@@ -503,7 +504,7 @@ steps:
     #!/usr/bin/env bash
     cd launcher/image/test
     echo "running health monitoring tests on ${OUTPUT_IMAGE_NAME}"
-    gcloud builds submit --config=test_health_monitoring.yaml --region us-west1 \
+    gcloud builds submit --polling-interval=$_POLLING_INTERVAL --config=test_health_monitoring.yaml --region us-west1 \
       --substitutions _IMAGE_NAME=${OUTPUT_IMAGE_NAME},_IMAGE_PROJECT=${PROJECT_ID}
     exit
 
@@ -517,7 +518,7 @@ steps:
     #!/usr/bin/env bash
     cd launcher/image/test
     echo "running ODA and signed container tests on ${OUTPUT_IMAGE_NAME}"
-    gcloud builds submit --config=test_oda_with_signed_container.yaml --region us-west1 \
+    gcloud builds submit --polling-interval=$_POLLING_INTERVAL --config=test_oda_with_signed_container.yaml --region us-west1 \
       --substitutions _IMAGE_NAME=${OUTPUT_IMAGE_NAME},_IMAGE_PROJECT=${PROJECT_ID}
     exit
 
@@ -533,7 +534,7 @@ steps:
     dev_shm_size_kb=$(shuf -i 70000-256000 -n 1)
     tmpfs_size_kb=$(shuf -i 256-256000 -n 1)
     echo "running mount tests on ${OUTPUT_IMAGE_NAME}"
-    gcloud builds submit --config=test_mounts.yaml --region us-west1 \
+    gcloud builds submit --polling-interval=$_POLLING_INTERVAL --config=test_mounts.yaml --region us-west1 \
       --substitutions _IMAGE_NAME=${OUTPUT_IMAGE_NAME},_IMAGE_PROJECT=${PROJECT_ID}
     exit
 
@@ -547,7 +548,7 @@ steps:
     #!/usr/bin/env bash
     cd launcher/image/test
     echo "running privileged tests on ${OUTPUT_IMAGE_NAME}"
-    gcloud builds submit --config=test_privileged.yaml --region us-west1 \
+    gcloud builds submit --polling-interval=$_POLLING_INTERVAL --config=test_privileged.yaml --region us-west1 \
       --substitutions _IMAGE_NAME=${OUTPUT_IMAGE_NAME},_IMAGE_PROJECT=${PROJECT_ID}
     exit
 
@@ -561,7 +562,7 @@ steps:
     #!/usr/bin/env bash
     cd launcher/image/test
     echo "running debug workload cleanup tests on ${OUTPUT_IMAGE_NAME}"
-    gcloud builds submit --config=test_workloadcleanup_cloudbuild.yaml --region us-west1 \
+    gcloud builds submit --polling-interval=$_POLLING_INTERVAL --config=test_workloadcleanup_cloudbuild.yaml --region us-west1 \
       --substitutions _IMAGE_NAME=${OUTPUT_IMAGE_NAME},_IMAGE_PROJECT=${PROJECT_ID}
     exit
 
@@ -575,7 +576,7 @@ steps:
     #!/usr/bin/env bash
     cd launcher/image/test
     echo "running hardened workload cleanup tests on ${OUTPUT_IMAGE_NAME}"
-    gcloud builds submit --config=test_workloadcleanup_cloudbuild.yaml --region us-west1 \
+    gcloud builds submit --polling-interval=$_POLLING_INTERVAL --config=test_workloadcleanup_cloudbuild.yaml --region us-west1 \
       --substitutions _IMAGE_NAME=${OUTPUT_IMAGE_NAME},_IMAGE_PROJECT=${PROJECT_ID}
     exit
 
@@ -687,5 +688,6 @@ steps:
     gsutil cp measure_output_vg_debug_sha384.json gs://${PROJECT_ID}-rims/${OUTPUT_IMAGE_NAME}_sha384.json
 
 options:
+  automapSubstitutions: true
   pool:
     name: 'projects/confidential-space-images-dev/locations/us-west1/workerPools/cs-image-build-vpc'

--- a/run_cloudbuild.sh
+++ b/run_cloudbuild.sh
@@ -14,7 +14,7 @@ echo "Running Cloud Build on directory $DIR"
 #
 # Ensure you grant Cloud Build access to Compute Images:
 # https://pantheon.corp.google.com/compute/images?referrer=search&tab=exports&project=$PROJECT_ID
-gcloud beta builds submit --config=${DIR}/cloudbuild.yaml \
+gcloud beta builds submit --polling-interval=10 --config=${DIR}/cloudbuild.yaml \
   --substitutions=_OUTPUT_IMAGE_SUFFIX="${IMAGE_SUFFIX}"
 
 echo "Image creation successful."


### PR DESCRIPTION
# launcher: set 10s polling interval on child builds

The default/unspecified value of 1 second is hitting our quota. Rather than raising quota, we were requested to increase the polling limit.

## Summary & Motivation
This PR sets `--polling-interval=10` on all nested `gcloud builds submit` invocations in `launcher/cloudbuild.yaml` and `run_cloudbuild.sh` to prevent `GetRequestsPerMinutePerProject` rate-limiting errors (`cloudbuild.googleapis.com`).

During presubmit runs, `launcher/cloudbuild.yaml` executes **22 concurrent child builds** (for image customization and integration test suites) via `gcloud builds submit` step containers. By default, `gcloud builds submit` polls Cloud Build status (`GetBuild` / `GetOperation` RPCs) **every 1 second**, generating excessive API traffic under parallel builds.

---

## Napkin Math: API Quota & Latency Impact

### 1. API Quota Consumption (Default vs New)

* **Default (`--polling-interval=1`)**:
  $$\text{1 child build} = 60 \text{ req/min}$$
  $$\text{22 concurrent child builds} = 22 \times 60 = \mathbf{1,320\text{ req/min per presubmit run}}$$
  * When 4 presubmits run concurrently (e.g. multi-PR testing or developer runs):
    $$4 \times 1,320 = \mathbf{5,280\text{ req/min}} \quad (\text{Exceeds default 5,000 req/min quota limit})$$

* **New (`--polling-interval=10`)**:
  $$\text{1 child build} = 6 \text{ req/min} \quad (\mathbf{90\% \text{ reduction}})$$
  $$\text{22 concurrent child builds} = 22 \times 6 = \mathbf{132\text{ req/min per presubmit run}}$$
  * When 4 presubmits run concurrently:
    $$4 \times 132 = \mathbf{528\text{ req/min}} \quad (\mathbf{10\times \text{ safety margin under 5,000 quota limit}})$$

### 2. Empirical Sub-Build Runtime Analysis
Telemetry from recent presubmit runs across `launcher/cloudbuild.yaml` shows the following step runtimes:
* **Short Test Suites** (`test_mounts.yaml`, `test_discover_signatures.yaml`): **1.5 to 4 minutes**.
* **Medium Test Suites** (`test_debug_cloudbuild.yaml`, `test_hardened_cloudbuild.yaml`): **5 to 8 minutes**.
* **Long Test Suites & Exports** (`test_launchpolicy_cloudbuild.yaml`, GCE image exports): **10 to 12 minutes**.
At a 10-second polling interval, a 10-minute step issues only **60 API requests** (down from 600), adding at worst +10 seconds of completion latency (< 0.5% overhead on a ~40-minute pipeline).