### PR TITLE
launcher: run all child builds in private worker pool

### DIFF
--- a/launcher/image/bc_cloudbuild.yaml
+++ b/launcher/image/bc_cloudbuild.yaml
@@ -273,5 +273,7 @@ steps:
 timeout: '3000s'
 
 options:
-  machine_type: 'E2_HIGHCPU_32'
   dynamic_substitutions: true
+  pool:
+    name: 'projects/confidential-space-images-dev/locations/us-west1/workerPools/cs-image-build-vpc'
+

--- a/launcher/image/cloudbuild.yaml
+++ b/launcher/image/cloudbuild.yaml
@@ -44,3 +44,5 @@ timeout: '3000s'
 
 options:
   dynamic_substitutions: true
+  pool:
+    name: 'projects/confidential-space-images-dev/locations/us-west1/workerPools/cs-image-build-vpc'


### PR DESCRIPTION
Parallel integration test execution was hitting a hard 1-hour parent timeout due to GCB queue starvation. The root cause was saturation of the 128 CPU regional default pool quota limit in us-west1.

This CPU cap was exceeded because GCB does not propagate the parent build's pool context to child builds submitted via `gcloud builds submit`. While the parent build was restricted to the private VPC worker pool, several nested child builds lacked explicit pool configurations and defaulted to the public pool. Running multiple PR presubmits concurrently flooded the default pool with image and test build requests, triggering queue delays.

To resolve this, we configured all integration test and image compilation child builds to run inside our private VPC worker pool by declaring the pool options in their respective YAML configurations. This unifies our compute resource consumption inside the private pool, completely clearing usage on the default pool, and allowing us to bypass the 128 CPU regional cap by scaling the private pool's E2 CPU quota.