### PR TITLE
launcher: remove unused deviceROTs from ContainerRunner

### DIFF
--- a/launcher/container_runner.go
+++ b/launcher/container_runner.go
@@ -188,12 +188,6 @@ func NewRunner(ctx context.Context, cfg *RunnerConfig) (*ContainerRunner, error)
 		)
 	}
 
-	var deviceROTs []agent.DeviceROT
-	nvidiaAttester := gpu.NewNvidiaAttester(launchSpec.InstallGpuDriver)
-	if launchSpec.InstallGpuDriver {
-		deviceROTs = append(deviceROTs, nvidiaAttester)
-	}
-
 	specOpts, err := createOCISpecOpts(image, launchSpec, envs, listFilesWithPrefix, logger)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Remove unused `deviceROTs` array and `nvidiaAttester` assignment in `container_runner.go` left behind when `createOCISpecOpts` was extracted in #879. Fixes the `ineffassign` golangci-lint error on main.