### PR TITLE
Restore logging the launch spec used by image tests.

### DIFF
--- a/launcher/launcher/main.go
+++ b/launcher/launcher/main.go
@@ -114,6 +114,8 @@ func main() {
 		logger.Error(exitMessage, "exit_code", exitCode, "exit_msg", rcMessage[exitCode])
 		return
 	}
+	// Do not delete the folliwing line, this line is used for tests.
+	logger.Info(fmt.Sprintf("Launch Spec: %+v", launchSpec.LogFriendly()))
 
 	verifier := osMountVerifier{}
 	if err := verifyDiskIntegrity(verifier); err != nil {


### PR DESCRIPTION
Re-adds the launch spec logging. This log output is required by image integration tests (such as test_experiment_value.sh) that verify experiment values from the VM serial console.