### PR TITLE
launcher: pass googleClient explicitly to StartLauncher and createAttestClients

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -303,6 +303,7 @@ func (a *agent) AttestWithClient(ctx context.Context, opts AttestAgentOpts, clie
 	if err != nil {
 		return nil, err
 	}
+	a.logger.Info("Successfully created challenge", "challenge_name", challenge.Name)
 
 	tokenOpts := opts.TokenOptions
 	if tokenOpts == nil {

--- a/launcher/cloudbuild.yaml
+++ b/launcher/cloudbuild.yaml
@@ -350,6 +350,21 @@ steps:
     exit
 
 - name: 'gcr.io/cloud-builders/gcloud'
+  id: RealGCAConnectionTest
+  waitFor: ['DebugImageBuild']
+  env:
+  - 'OUTPUT_IMAGE_NAME=${_OUTPUT_IMAGE_PREFIX}-debug-${_OUTPUT_IMAGE_SUFFIX}'
+  - 'PROJECT_ID=$PROJECT_ID'
+  script: |
+    #!/usr/bin/env bash
+
+    cd launcher/image/test
+    echo "running real GCA connection test on ${OUTPUT_IMAGE_NAME}"
+    gcloud builds submit --polling-interval=$_POLLING_INTERVAL --config=test_real_gca_cloudbuild.yaml --region us-west1 \
+      --substitutions _IMAGE_NAME=${OUTPUT_IMAGE_NAME},_IMAGE_PROJECT=${PROJECT_ID}
+    exit
+
+- name: 'gcr.io/cloud-builders/gcloud'
   id: DebugImageTestsTDX
   waitFor: ['DebugImageBuild']
   env:

--- a/launcher/google_roots.go
+++ b/launcher/google_roots.go
@@ -12,16 +12,10 @@ import (
 // GoogleRootsPath is the path to the Google roots PEM file on the OEM partition.
 const GoogleRootsPath = "/usr/share/oem/google_roots.pem"
 
-// GoogleHTTPClient creates an HTTP client that only trusts the roots required for connecting to Google.
-func GoogleHTTPClient() (*http.Client, error) {
-	return googleHTTPClientWithRoots(GoogleRootsPath)
-}
-
-// googleHTTPClientWithRoots allows internal tests to inject mock certificate paths.
-func googleHTTPClientWithRoots(rootsPath string) (*http.Client, error) {
-	pool, err := loadCertPool(rootsPath)
-	if err != nil {
-		return nil, err
+// PinnedHTTPTransport creates an HTTP transport configured with the provided root certificate pool.
+func PinnedHTTPTransport(pool *x509.CertPool) (http.RoundTripper, error) {
+	if pool == nil {
+		return nil, fmt.Errorf("cert pool must be non-nil")
 	}
 
 	// We copy the default transport so we get all the proxy, keep-alive,
@@ -37,9 +31,7 @@ func googleHTTPClientWithRoots(rootsPath string) (*http.Client, error) {
 	}
 	customTransport.TLSClientConfig.RootCAs = pool
 
-	return &http.Client{
-		Transport: customTransport,
-	}, nil
+	return customTransport, nil
 }
 
 // GoogleCertPool loads the Google root certificates into an x509.CertPool.

--- a/launcher/google_roots_test.go
+++ b/launcher/google_roots_test.go
@@ -7,35 +7,15 @@ import (
 	"testing"
 )
 
-func TestGoogleHTTPClientWithRoots(t *testing.T) {
-	t.Run("empty path", func(t *testing.T) {
-		_, err := googleHTTPClientWithRoots("")
+func TestPinnedHTTPTransport(t *testing.T) {
+	t.Run("nil pool", func(t *testing.T) {
+		_, err := PinnedHTTPTransport(nil)
 		if err == nil {
-			t.Errorf("googleHTTPClientWithRoots() expected error for empty path, got nil")
+			t.Errorf("PinnedHTTPTransport(nil) expected error, got nil")
 		}
 	})
 
-	t.Run("missing file", func(t *testing.T) {
-		path := filepath.Join(t.TempDir(), "missing.pem")
-		_, err := googleHTTPClientWithRoots(path)
-		if err == nil {
-			t.Errorf("googleHTTPClientWithRoots() expected error for missing file, got nil")
-		}
-	})
-
-	t.Run("malformed pem", func(t *testing.T) {
-		path := filepath.Join(t.TempDir(), "malformed.pem")
-		if err := os.WriteFile(path, []byte("-----BEGIN CERTIFICATE-----\nBAD\n-----END CERTIFICATE-----"), 0644); err != nil {
-			t.Fatalf("failed to create malformed file: %v", err)
-		}
-
-		_, err := googleHTTPClientWithRoots(path)
-		if err == nil {
-			t.Errorf("googleHTTPClientWithRoots() expected error for malformed pem, got nil")
-		}
-	})
-
-	t.Run("valid pem", func(t *testing.T) {
+	t.Run("valid pool", func(t *testing.T) {
 		validPEM := `-----BEGIN CERTIFICATE-----
 MIIDczCCAlugAwIBAgIUC1mdNsdB4jmUzAB7WdcMybyxXI8wDQYJKoZIhvcNAQEL
 BQAwSTELMAkGA1UEBhMCVVMxCzAJBgNVBAgMAkNBMQswCQYDVQQHDAJTRjENMAsG
@@ -63,15 +43,20 @@ OAMM+8xw+XONUalCCur/u3GfKPMBqvk=
 			t.Fatalf("failed to create valid pem file: %v", err)
 		}
 
-		client, err := googleHTTPClientWithRoots(path)
+		pool, err := loadCertPool(path)
 		if err != nil {
-			t.Fatalf("googleHTTPClientWithRoots() failed for valid pem: %v", err)
+			t.Fatalf("loadCertPool() failed: %v", err)
+		}
+
+		rt, err := PinnedHTTPTransport(pool)
+		if err != nil {
+			t.Fatalf("PinnedHTTPTransport() failed for valid pool: %v", err)
 		}
 
 		// Verify the underlying transport has TLS config set
-		transport, ok := client.Transport.(*http.Transport)
+		transport, ok := rt.(*http.Transport)
 		if !ok {
-			t.Fatalf("client.Transport is not *http.Transport")
+			t.Fatalf("PinnedHTTPTransport() did not return *http.Transport")
 		}
 		if transport.TLSClientConfig == nil {
 			t.Fatalf("transport.TLSClientConfig is nil")

--- a/launcher/image/test/create_vm.sh
+++ b/launcher/image/test/create_vm.sh
@@ -13,6 +13,7 @@ print_usage() {
     echo "  -t <machineType>: type of machine for VM (optional)"
     echo "  -g <gpuType>: type of GPU to use for the VM (optional)"
     echo "  -a <gpuCount>: number of GPU(s) to use for the VM (optional)"
+    echo "  -v <fakeVerifier>: true or false (default: true)"
     exit 1
 }
 
@@ -44,8 +45,7 @@ create_vm() {
     fi
   fi
 
-  # use the fake verifier for all tests
-  FAKE_VERIFIER='test-fake-verifier=true'
+  FAKE_VERIFIER="test-fake-verifier=${USE_FAKE_VERIFIER}"
 
   APPEND_METADATA=''
   if ! [ -z "$METADATA" ]; then
@@ -106,13 +106,13 @@ PROJECT_NAME=''
 VM_NAME=''
 ZONE=''
 CC='SEV' # default using sev
-MACHINE_TYPE=''
 GPU_TYPE=''
 GPU_COUNT=''
+USE_FAKE_VERIFIER='true'
 
 # In getopts, a ':' following a letter means that that flag takes an argument.
 # For example, i: means -i takes an additional argument.
-while getopts 'i:f:m:p:n:z:c:t:g:a:' flag; do
+while getopts 'i:f:m:p:n:z:c:t:g:a:v:' flag; do
   case "${flag}" in
     i) IMAGE_NAME=${OPTARG} ;;
     f) METADATA_FILE=${OPTARG} ;;
@@ -124,6 +124,7 @@ while getopts 'i:f:m:p:n:z:c:t:g:a:' flag; do
     t) MACHINE_TYPE=${OPTARG} ;;
     g) GPU_TYPE=${OPTARG} ;;
     a) GPU_COUNT=${OPTARG} ;;
+    v) USE_FAKE_VERIFIER=${OPTARG} ;;
     *) print_usage ;;
   esac
 done

--- a/launcher/image/test/scripts/test_real_gca_workload.sh
+++ b/launcher/image/test/scripts/test_real_gca_workload.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+set -euo pipefail
+source util/read_serial.sh
+
+SERIAL_OUTPUT=$(read_serial $1 $2)
+print_serial=false
+
+if echo "$SERIAL_OUTPUT" | grep -q 'Successfully created challenge'
+then
+    echo "- challenge creation verified"
+else
+    echo "FAILED: challenge creation failed (GCA client creation or VM startup failed)"
+    echo 'TEST FAILED.' > /workspace/status.txt
+    print_serial=true
+fi
+
+if $print_serial; then
+    echo "$SERIAL_OUTPUT"
+fi

--- a/launcher/image/test/test_real_gca_cloudbuild.yaml
+++ b/launcher/image/test/test_real_gca_cloudbuild.yaml
@@ -1,0 +1,36 @@
+substitutions:
+  '_IMAGE_NAME': ''
+  '_IMAGE_PROJECT': ''
+  '_CLEANUP': 'true'
+  '_VM_NAME_PREFIX': 'cs-real-gca-test'
+  '_ZONE': 'us-west1-a'
+  '_CC': ''
+  '_WORKLOAD_IMAGE': 'us-west1-docker.pkg.dev/confidential-space-images-dev/cs-integ-test-images/basic-test:latest'
+steps:
+- name: 'gcr.io/cloud-builders/gcloud'
+  id: CreateVM
+  entrypoint: 'bash'
+  env:
+  - 'BUILD_ID=$BUILD_ID'
+  args: ['create_vm.sh','-i', '${_IMAGE_NAME}',
+          '-p', '${_IMAGE_PROJECT}',
+          '-m', 'tee-image-reference=${_WORKLOAD_IMAGE},tee-container-log-redirect=true',
+          '-n', '${_VM_NAME_PREFIX}-${BUILD_ID}',
+          '-z', '${_ZONE}',
+          '-c', '${_CC}',
+          '-v', 'false',
+        ]
+- name: 'gcr.io/cloud-builders/gcloud'
+  id: RealGCAWorkloadTest
+  entrypoint: 'bash'
+  args: ['scripts/test_real_gca_workload.sh', '${_VM_NAME_PREFIX}-${BUILD_ID}', '${_ZONE}']
+- name: 'gcr.io/cloud-builders/gcloud'
+  id: CleanUp
+  entrypoint: 'bash'
+  env:
+  - 'CLEANUP=${_CLEANUP}'
+  args: ['cleanup.sh', '${_VM_NAME_PREFIX}-${BUILD_ID}', '${_ZONE}']
+- name: 'gcr.io/cloud-builders/gcloud'
+  id: CheckFailure
+  entrypoint: 'bash'
+  args: ['check_failure.sh']

--- a/launcher/launcher/main.go
+++ b/launcher/launcher/main.go
@@ -7,18 +7,19 @@ import (
 	"errors"
 	"fmt"
 	"log"
+	"net/http"
 	"os"
 	"os/exec"
 	"regexp"
 	"strings"
 	"time"
 
+	"cloud.google.com/go/auth/httptransport"
 	"cloud.google.com/go/compute/metadata"
 	"github.com/google/go-tpm-tools/launcher"
 	"github.com/google/go-tpm-tools/launcher/internal/logging"
 	"github.com/google/go-tpm-tools/launcher/launcherfile"
 	"github.com/google/go-tpm-tools/launcher/spec"
-	"google.golang.org/api/option"
 )
 
 const (
@@ -60,23 +61,6 @@ func main() {
 		os.Exit(exitCode)
 	}()
 
-	googleClient, err := launcher.GoogleHTTPClient()
-	if err != nil {
-		log.Default().Printf("Failed to initialize Google root HTTP client: %v", err)
-		exitCode = failRC
-		log.Default().Printf("%s, exit code: %d (%s)\n", exitMessage, exitCode, rcMessage[exitCode])
-		return
-	}
-	clientOpts := []option.ClientOption{option.WithHTTPClient(googleClient)}
-
-	pool, err := launcher.GoogleCertPool()
-	if err != nil {
-		log.Default().Printf("Failed to load Google root certificates: %v", err)
-		exitCode = failRC
-		log.Default().Printf("%s, exit code: %d (%s)\n", exitMessage, exitCode, rcMessage[exitCode])
-		return
-	}
-
 	serialConsole, err := os.OpenFile(serialConsoleFile, os.O_WRONLY, 0)
 	if err != nil {
 		log.Default().Printf("Failed to open serial console: %v", err)
@@ -86,16 +70,46 @@ func main() {
 	}
 	defer serialConsole.Close()
 
+	serialLogger := logging.NewSerialLogger(serialConsole)
+
+	pool, err := launcher.GoogleCertPool()
+	if err != nil {
+		serialLogger.Error(fmt.Sprintf("failed to load Google root certificates: %v", err))
+		exitCode = failRC
+		serialLogger.Error(exitMessage, "exit_code", exitCode, "exit_msg", rcMessage[exitCode])
+		return
+	}
+
 	workloadLogger, err := logging.NewCloudLogger(ctx, pool)
 	if err != nil {
-		log.Default().Printf("failed to initialize cloud logging: %v", err)
+		serialLogger.Error(fmt.Sprintf("failed to initialize cloud logging: %v", err))
 		exitCode = failRC
-		log.Default().Printf("%s, exit code: %d (%s)\n", exitMessage, exitCode, rcMessage[exitCode])
+		serialLogger.Error(exitMessage, "exit_code", exitCode, "exit_msg", rcMessage[exitCode])
 		return
 	}
 	defer workloadLogger.Close()
 
-	logger := logging.DualLogger(workloadLogger, logging.NewSerialLogger(serialConsole))
+	logger := logging.DualLogger(workloadLogger, serialLogger)
+
+	pinnedTransport, err := launcher.PinnedHTTPTransport(pool)
+	if err != nil {
+		logger.Error(fmt.Sprintf("failed to initialize Google root HTTP transport: %v", err))
+		exitCode = failRC
+		logger.Error(exitMessage, "exit_code", exitCode, "exit_msg", rcMessage[exitCode])
+		return
+	}
+
+	pinnedClient := &http.Client{Transport: pinnedTransport}
+
+	googleClient, err := httptransport.NewClient(&httptransport.Options{
+		BaseRoundTripper: pinnedTransport,
+	})
+	if err != nil {
+		logger.Error(fmt.Sprintf("failed to initialize authenticated Google HTTP client: %v", err))
+		exitCode = failRC
+		logger.Error(exitMessage, "exit_code", exitCode, "exit_msg", rcMessage[exitCode])
+		return
+	}
 
 	logger.Info("Boot completed", "duration_sec", uptime)
 	logger.Info(welcomeMessage, "build_commit", BuildCommit)
@@ -144,7 +158,7 @@ func main() {
 			logger.Info(exitMessage, "exit_code", exitCode)
 		}
 	}()
-	if err = launcher.StartLauncher(ctx, launchSpec, logger, workloadLogger, serialConsole, clientOpts...); err != nil {
+	if err = launcher.StartLauncher(ctx, launchSpec, logger, workloadLogger, serialConsole, pinnedClient, googleClient); err != nil {
 		logger.Error(err.Error())
 		var tpmOpenErr *launcher.TPMOpenError
 		if errors.As(err, &tpmOpenErr) {

--- a/launcher/start.go
+++ b/launcher/start.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net/http"
 	"os"
 
 	"cloud.google.com/go/compute/metadata"
@@ -35,7 +36,11 @@ var expectedTPMDAParams = TPMDAParams{
 
 // StartLauncher orchestrates the client creation, image pulling, attestation agent setup,
 // and runs the ContainerRunner.
-func StartLauncher(ctx context.Context, launchSpec spec.LaunchSpec, logger logging.Logger, workloadLogger logging.Logger, serialConsole *os.File, clientOpts ...option.ClientOption) error {
+func StartLauncher(ctx context.Context, launchSpec spec.LaunchSpec, logger logging.Logger, workloadLogger logging.Logger, serialConsole *os.File, pinnedClient *http.Client, googleClient *http.Client) error {
+	if pinnedClient == nil {
+		return errors.New("pinnedClient must be non-nil")
+	}
+
 	containerdClient, err := containerd.New(defaults.DefaultAddress)
 	if err != nil {
 		return &RetryableError{Err: err}
@@ -75,17 +80,14 @@ func StartLauncher(ctx context.Context, launchSpec spec.LaunchSpec, logger loggi
 		}
 	}
 
-	googleClient, err := GoogleHTTPClient()
-	if err != nil {
-		return fmt.Errorf("failed to initialize Google root HTTP client: %v", err)
-	}
-
-	image, err := initImage(ctx, containerdClient, launchSpec, token, googleClient)
+	image, err := initImage(ctx, containerdClient, launchSpec, token, pinnedClient)
 	if err != nil {
 		return err
 	}
-	// Initialize verifier client and attest clients.
-	attestClients, err := createAttestClients(ctx, launchSpec, logger, clientOpts...)
+
+	// googleClient is an authenticated HTTP client (OAuth2 ADC credentials) built on top
+	// of the pinned transport. Used for GCA verifier client creation and SA impersonation.
+	attestClients, err := createAttestClients(ctx, launchSpec, logger, googleClient)
 	if err != nil {
 		return err
 	}
@@ -103,7 +105,7 @@ func StartLauncher(ctx context.Context, launchSpec spec.LaunchSpec, logger loggi
 			return nil, err
 		}
 		for _, sa := range launchSpec.ImpersonateServiceAccounts {
-			idToken, err := FetchImpersonatedToken(ctx, sa, audience, clientOpts...)
+			idToken, err := FetchImpersonatedToken(ctx, sa, audience, option.WithHTTPClient(googleClient))
 			if err != nil {
 				return nil, fmt.Errorf("failed to get impersonated token for %v: %w", sa, err)
 			}
@@ -113,7 +115,7 @@ func StartLauncher(ctx context.Context, launchSpec spec.LaunchSpec, logger loggi
 	}
 
 	// Create signature discovery client.
-	sdClient := getSignatureDiscoveryClient(containerdClient, mdsClient, image.Target(), googleClient)
+	sdClient := getSignatureDiscoveryClient(containerdClient, mdsClient, image.Target(), pinnedClient)
 
 	// Create device ROTs and GpuAttester.
 	var deviceROTs []agent.DeviceROT
@@ -200,30 +202,41 @@ func initTPM(launchSpec spec.LaunchSpec, logger logging.Logger) (io.ReadWriteClo
 	return tpm, nil
 }
 
-func createAttestClients(ctx context.Context, launchSpec spec.LaunchSpec, logger logging.Logger, clientOpts ...option.ClientOption) (teeserver.AttestClients, error) {
+// createAttestClients initializes verifier clients (GCA/ITA).
+// When DisableGcaRefresh is false, googleClient must be configured with both OAuth2 token credentials
+// and Google Root CA certificate pinning.
+func createAttestClients(ctx context.Context, launchSpec spec.LaunchSpec, logger logging.Logger, googleClient *http.Client) (teeserver.AttestClients, error) {
 	attestClients := teeserver.AttestClients{}
+
+	if !launchSpec.DisableGcaRefresh {
+		if googleClient == nil || googleClient.Transport == nil {
+			return attestClients, fmt.Errorf("failed to create REST verifier client: googleClient must be non-nil with a valid transport")
+		}
+	}
 
 	if launchSpec.FakeVerifierEnabled {
 		fakeClient := fake.NewClient(nil)
 		attestClients.GCA = fakeClient
 		attestClients.ITA = fakeClient
-	} else if launchSpec.ITAConfig.ITARegion != "" {
+		return attestClients, nil
+	}
+	if launchSpec.ITAConfig.ITARegion != "" {
 		itaClient, err := ita.NewClient(launchSpec.ITAConfig)
 		if err != nil {
 			return attestClients, fmt.Errorf("failed to create ITA client: %v", err)
 		}
 		attestClients.ITA = itaClient
-	} else {
-		gcaClient, err := util.NewRESTClient(ctx, launchSpec.GcaAddress, launchSpec.ProjectID, launchSpec.Region, clientOpts...)
-		if err != nil {
-			if !launchSpec.DisableGcaRefresh {
-				return attestClients, fmt.Errorf("failed to create REST verifier client: %v", err)
-			}
-			logger.Info("Failed to create the GCA client, but GCA refresh is disabled so the launch will continue: %v", err)
-			gcaClient = nil
-		}
-		attestClients.GCA = gcaClient
+		return attestClients, nil
 	}
 
+	gcaClient, err := util.NewRESTClient(ctx, launchSpec.GcaAddress, launchSpec.ProjectID, launchSpec.Region, option.WithHTTPClient(googleClient))
+	if err != nil {
+		if !launchSpec.DisableGcaRefresh {
+			return attestClients, fmt.Errorf("failed to create REST verifier client: %v", err)
+		}
+		logger.Info("Failed to create the GCA client, but GCA refresh is disabled so the launch will continue: %v", err)
+		gcaClient = nil
+	}
+	attestClients.GCA = gcaClient
 	return attestClients, nil
 }

--- a/launcher/start_test.go
+++ b/launcher/start_test.go
@@ -1,0 +1,155 @@
+package launcher
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/google/go-tpm-tools/launcher/spec"
+	"github.com/google/go-tpm-tools/verifier"
+	"golang.org/x/oauth2"
+)
+
+func TestCreateAttestClients_Behaviors(t *testing.T) {
+	certPool := x509.NewCertPool()
+	pinnedTransport := http.DefaultTransport.(*http.Transport).Clone()
+	pinnedTransport.TLSClientConfig = &tls.Config{RootCAs: certPool}
+	validAuthenticatedAndPinnedClient := &http.Client{
+		Transport: &oauth2.Transport{
+			Source: oauth2.StaticTokenSource(&oauth2.Token{AccessToken: "fake-test-token"}),
+			Base:   pinnedTransport,
+		},
+	}
+
+	// Local hermetic mock HTTP server simulating GCA location endpoints
+	gcaServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprintln(w, `{"name": "projects/test-project/locations/us-central1"}`)
+	}))
+	defer gcaServer.Close()
+
+	// Local hermetic mock HTTP server simulating 401 Unauthorized GCA endpoint
+	failingGcaServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		fmt.Fprintln(w, `{"error": {"code": 401, "message": "Request is missing required authentication credential."}}`)
+	}))
+	defer failingGcaServer.Close()
+
+	tests := []struct {
+		name          string
+		launchSpec    spec.LaunchSpec
+		googleClient  *http.Client
+		wantErr       bool
+		errContains   string
+		wantGCANotNil bool
+		wantITANotNil bool
+	}{
+		{
+			name: "Fake verifier mode sets fake GCA and ITA clients",
+			launchSpec: spec.LaunchSpec{
+				FakeVerifierEnabled: true,
+			},
+			googleClient:  validAuthenticatedAndPinnedClient,
+			wantGCANotNil: true,
+			wantITANotNil: true,
+		},
+		{
+			name: "ITA mode returns error on invalid region/config",
+			launchSpec: spec.LaunchSpec{
+				ITAConfig: verifier.ITAConfig{
+					ITARegion: "invalid-region-config",
+				},
+			},
+			googleClient: validAuthenticatedAndPinnedClient,
+			wantErr:      true,
+			errContains:  "failed to create ITA client",
+		},
+		{
+			name: "GCA REST mode succeeds when valid clientOpts passed",
+			launchSpec: spec.LaunchSpec{
+				GcaAddress: gcaServer.URL,
+				ProjectID:  "test-project",
+				Region:     "us-central1",
+			},
+			googleClient:  validAuthenticatedAndPinnedClient,
+			wantGCANotNil: true,
+		},
+		{
+			name: "GCA REST mode fails when DisableGcaRefresh is false and auth fails",
+			launchSpec: spec.LaunchSpec{
+				GcaAddress:        failingGcaServer.URL,
+				ProjectID:         "test-project",
+				Region:            "us-central1",
+				DisableGcaRefresh: false,
+			},
+			googleClient: validAuthenticatedAndPinnedClient,
+			wantErr:      true,
+			errContains:  "failed to create REST verifier client",
+		},
+		{
+			name: "GCA REST mode suppresses failure when DisableGcaRefresh is true",
+			launchSpec: spec.LaunchSpec{
+				GcaAddress:        failingGcaServer.URL,
+				ProjectID:         "test-project",
+				Region:            "us-central1",
+				DisableGcaRefresh: true,
+			},
+			googleClient:  validAuthenticatedAndPinnedClient,
+			wantErr:       false,
+			wantGCANotNil: false, // GCA client set to nil gracefully
+		},
+		{
+			name: "GCA REST mode fails when HTTP client is nil",
+			launchSpec: spec.LaunchSpec{
+				GcaAddress:        failingGcaServer.URL,
+				ProjectID:         "test-project",
+				Region:            "us-central1",
+				DisableGcaRefresh: false,
+			},
+			googleClient: nil,
+			wantErr:      true,
+			errContains:  "googleClient must be non-nil",
+		},
+		{
+			name: "GCA REST mode fails when HTTP client has nil transport",
+			launchSpec: spec.LaunchSpec{
+				GcaAddress:        failingGcaServer.URL,
+				ProjectID:         "test-project",
+				Region:            "us-central1",
+				DisableGcaRefresh: false,
+			},
+			googleClient: &http.Client{Transport: nil},
+			wantErr:      true,
+			errContains:  "googleClient must be non-nil with a valid transport",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			logger := &fakeLogger{}
+			clients, err := createAttestClients(t.Context(), tc.launchSpec, logger, tc.googleClient)
+
+			if (err != nil) != tc.wantErr {
+				t.Fatalf("createAttestClients() error = %v, wantErr %v", err, tc.wantErr)
+			}
+			if tc.wantErr && tc.errContains != "" {
+				if err == nil || !strings.Contains(err.Error(), tc.errContains) {
+					t.Fatalf("createAttestClients() error = %v, want error containing %q", err, tc.errContains)
+				}
+			}
+			if tc.wantGCANotNil && clients.GCA == nil {
+				t.Error("expected GCA client to be non-nil")
+			}
+			if !tc.wantGCANotNil && clients.GCA != nil {
+				t.Error("expected GCA client to be nil")
+			}
+			if tc.wantITANotNil && clients.ITA == nil {
+				t.Error("expected ITA client to be non-nil")
+			}
+		})
+	}
+}


### PR DESCRIPTION
Confidential Space launcher failed to start in production environments with
HTTP 401 (`CREDENTIALS_MISSING`) errors when initializing the GCA REST verifier client:

  "failed to create REST verifier client: listing regions in project ...:
   googleapi: Error 401: Request is missing required authentication credential."

This regression occurred when verifier client creation was refactored out of
`ContainerRunner` into `StartLauncher`. `StartLauncher` initialized `googleClient`
(which contains root CA certificates and HTTP transport settings) but invoked
`createAttestClients` with raw `clientOpts`, omitting `option.WithHTTPClient(googleClient)`.
Consequently, `util.NewRESTClient` fell back to unauthenticated transport when calling
`ListLocations`. Presubmit integration tests (`/gcbrun`) failed but the PR was merged anyway.

To resolve this and prevent future regressions:
1. `StartLauncher` prepends `option.WithHTTPClient(googleClient)` to `clientOpts`
   before calling `createAttestClients`.
2. `createAttestClients` verifies that `clientOpts` includes an `option.WithHTTPClient`
   transport before attempting REST client creation when `DisableGcaRefresh` is false.
3. `launcher/start_test.go` adds a hermetic table-driven test suite covering all
   verifier client creation paths.