### PR TITLE
launcher: isolate signature repositories per build in cloudbuild.yaml

### DIFF
--- a/launcher/cloudbuild.yaml
+++ b/launcher/cloudbuild.yaml
@@ -495,7 +495,7 @@ steps:
     cd launcher/image/test
     echo "running hardened image container signature tests on ${OUTPUT_IMAGE_NAME}"
     gcloud builds submit --polling-interval=$_POLLING_INTERVAL --config=test_discover_signatures.yaml --region us-west1 \
-      --substitutions _IMAGE_NAME=${OUTPUT_IMAGE_NAME},_IMAGE_PROJECT=${PROJECT_ID},_SIGNATURE_REPO=us-docker.pkg.dev/confidential-space-images-dev/cs-cosign-tests/hardened
+      --substitutions _IMAGE_NAME=${OUTPUT_IMAGE_NAME},_IMAGE_PROJECT=${PROJECT_ID},_SIGNATURE_REPO=us-docker.pkg.dev/confidential-space-images-dev/cs-cosign-tests/hardened-$BUILD_ID
     exit
 
 - name: 'gcr.io/cloud-builders/gcloud'
@@ -509,7 +509,7 @@ steps:
     cd launcher/image/test
     echo "running debug image container signature tests on ${OUTPUT_IMAGE_NAME}"
     gcloud builds submit --polling-interval=$_POLLING_INTERVAL --config=test_discover_signatures.yaml --region us-west1 \
-      --substitutions _IMAGE_NAME=${OUTPUT_IMAGE_NAME},_IMAGE_PROJECT=${PROJECT_ID},_SIGNATURE_REPO=us-docker.pkg.dev/confidential-space-images-dev/cs-cosign-tests/debug
+      --substitutions _IMAGE_NAME=${OUTPUT_IMAGE_NAME},_IMAGE_PROJECT=${PROJECT_ID},_SIGNATURE_REPO=us-docker.pkg.dev/confidential-space-images-dev/cs-cosign-tests/debug-$BUILD_ID
     exit
 
 - name: 'gcr.io/cloud-builders/gcloud'


### PR DESCRIPTION
## Problem Statement

When multiple presubmit builds (`/gcbrun`) run concurrently on GitHub pull requests, container signature discovery tests (`HardenedDiscoverContainerSignatureTests` and `DebugDiscoverContainerSignatureTests`) frequently fail with transient errors.

Depending on the exact timing interleaving of concurrent builds, the test fails with one of two distinct symptoms:

1. **`404 NOT_FOUND` (Missing Signature)**: Occurs when Build A finishes its test run quickly and executes `DeleteContainerSignatures`, deleting the shared `sha256-<digest>.sig` tag from Artifact Registry while Build B is still attempting to read it.
2. **Signature Count Mismatch**: Occurs when both Build A and Build B run `cosign sign` against the same workload image digest before either VM reads signatures. Cosign appends multiple signature layers under the same `sha256-<digest>.sig` tag, causing the VM to discover extra signatures and logging `counts = 2` (or `4`) instead of the expected `1` (or `3`).

### Root Cause Analysis

In `launcher/cloudbuild.yaml`, test steps invoke `test_discover_signatures.yaml` using static repository paths:
- `_SIGNATURE_REPO = us-docker.pkg.dev/confidential-space-images-dev/cs-cosign-tests/hardened`
- `_SIGNATURE_REPO = us-docker.pkg.dev/confidential-space-images-dev/cs-cosign-tests/debug`

Because the repository path is static, concurrent build runs target the **exact same Artifact Registry repository path**. Because test workloads use standard digests (`basic-test:latest` or `happypath`), both builds attempt to write, read, and delete the same tag (`sha256-<digest>.sig`).

```mermaid
sequenceDiagram
    autonumber
    participant B1 as Presubmit Build A
    participant AR as Shared AR Repo (/cs-cosign-tests/hardened)
    participant B2 as Presubmit Build B

    Note over B1,B2: Concurrent presubmit executions on shared image digest
    B1->>AR: Step 1 (SignContainer): Pushes sha256-digest.sig
    B2->>AR: Step 1 (SignContainer): Appends second signature layer to sha256-digest.sig
    
    B1->>AR: Step 2 (CreateVM): Reads signatures (DISCOVERS 2 SIGS -> Count Mismatch!)
    
    B1->>AR: Step 5 (DeleteContainerSignatures): Deletes sha256-digest.sig
    Note over AR: sha256-digest.sig DELETED from repo!
    
    B2->>AR: Step 2 (CreateVM): Tries to read sha256-digest.sig
    Note over B2: ❌ FAIL: 404 NOT_FOUND!
```

---

## Solution

Append `-$BUILD_ID` to `_SIGNATURE_REPO` in `launcher/cloudbuild.yaml`:

- **Hardened**: `us-docker.pkg.dev/confidential-space-images-dev/cs-cosign-tests/hardened-$BUILD_ID`
- **Debug**: `us-docker.pkg.dev/confidential-space-images-dev/cs-cosign-tests/debug-$BUILD_ID`

Because `$BUILD_ID` is a 128-bit UUIDv4 uniquely generated per Cloud Build execution, every presubmit run executes in its own isolated repository namespace:

```mermaid
sequenceDiagram
    autonumber
    participant B1 as Build A ($BUILD_ID=aaa)
    participant AR1 as Private AR Repo (/hardened-aaa)
    participant B2 as Build B ($BUILD_ID=bbb)
    participant AR2 as Private AR Repo (/hardened-bbb)

    B1->>AR1: Pushes sha256-digest.sig to /hardened-aaa
    B2->>AR2: Pushes sha256-digest.sig to /hardened-bbb
    
    B1->>AR1: VM reads signatures from /hardened-aaa (SUCCESS)
    B2->>AR2: VM reads signatures from /hardened-bbb (SUCCESS)
    
    B1->>AR1: Deletes /hardened-aaa (Cleaned up)
    B2->>AR2: Deletes /hardened-bbb (Cleaned up)
    
    Note over B1,B2: ✅ SUCCESS: Both builds run completely isolated!
```