### PR TITLE
launcher/test: fix read_serial flakiness via time-bounded polling loop.

### DIFF
--- a/launcher/image/test/util/read_serial.sh
+++ b/launcher/image/test/util/read_serial.sh
@@ -3,43 +3,31 @@
 # read_serial attempts to read the serial output until the workload is finished
 # Use var=$(read_serial <VM_NAME> <ZONE>) to capture the output of this command into a variable.
 read_serial() {
-  local base_cmd='gcloud compute instances get-serial-port-output $1 --zone $2 2>/workspace/next_start_$1.txt'
-  local serial_out=$(eval ${base_cmd})
-  local last=''
+  local vm="$1"
+  local zone="$2"
+  local start_offset=0
+  local serial_out=""
+  local timeout="10 minute"
+  local endtime=$(date -ud "$timeout" +%s)
 
-  # timeout after 10 min
-  timeout="10 minute"
-  endtime=$(date -ud "$timeout" +%s)
+  while [[ $(date -u +%s) -lt $endtime ]]; do
+    local resp=$(gcloud compute instances get-serial-port-output "$vm" --zone="$zone" --start="${start_offset}" --format=json 2>/dev/null)
 
-  echo "Reading serial console..."
-  while [ -s /workspace/next_start_$1.txt ]; do
-    if [[ $(date -u +%s) -ge $endtime ]]; then
-      echo "timed out reading serial console, or the workload is running more than ${timeout}"
+    if [ -n "$resp" ]; then
+      local chunk
+      chunk=$(printf '%s' "$resp" | python3 -c "import sys, json; print(json.load(sys.stdin).get('contents', ''), end='')")
+      start_offset=$(printf '%s' "$resp" | python3 -c "import sys, json; print(json.load(sys.stdin).get('next', '0'))")
+      serial_out="${serial_out}${chunk}"
+    else
+      >&2 echo "Empty response from get-serial-port-output for ${vm} (instance not ready or stopped)."
+    fi
+
+    if [[ "$serial_out" == *"TEE container launcher exiting"* ]]; then
       break
     fi
 
-    # VM may already exit
-    if grep -qi 'Could not fetch serial port output' /workspace/next_start_$1.txt; then
-      serial_out="$serial_out $1 VM stopped"
-      break
-    fi
-
-    next=$(cat /workspace/next_start_$1.txt | sed -n 2p | cut -d ' ' -f2)
-    local next_cmd="${base_cmd} ${next}"
-    
-    # sleeping 5s for the next serial console read
     sleep 5
-
-    local tmp=$(eval ${next_cmd})
-    serial_out="$serial_out $tmp"
-
-    # break the loop if the workload is finished
-    if echo ${serial_out} | grep -qi "TEE container launcher exiting"; then
-      break
-    fi
-
-    last=$next
   done
 
-  echo $serial_out
+  printf '%s\n' "$serial_out"
 }


### PR DESCRIPTION
Replace the file-backed pagination loop in read_serial.sh with a time-bounded polling loop that retries until workload completion or VM exit.

### Problem
Integration tests (such as HealthMonitoringTests or RealGCAConnectionTest) experienced flakiness caused by an early-exit bug in `read_serial.sh`. 

`read_serial.sh` redirected `stderr` to `/workspace/next_start_$1.txt` (`2>`) and controlled its polling loop with `while [ -s /workspace/next_start_$1.txt ]`. 

When `gcloud compute instances get-serial-port-output` fetches unpaginated logs (which occurs when output is under 1 MB), `gcloud` writes **0 bytes to stderr**. Because `[ -s ]` evaluates to `false` for 0-byte files, `read_serial.sh` exited immediately on iteration 1 without polling, returning incomplete boot logs to the caller and writing `TEST FAILED.` to `/workspace/status.txt`.

### Historical Context & Root Cause
Prior to commit `19bf7ee1` (#794), `read_serial.sh` redirected `stderr` to a single shared file path (`/workspace/next_start.txt`). Because Cloud Build `/workspace` directories persist across build steps, leftover data from earlier test steps ensured `[ -s /workspace/next_start.txt ]` evaluated to `true` on turn 1.

PR #794 updated the path to be unique per VM (`/workspace/next_start_$1.txt`) to prevent parallel test steps from overwriting each other. Because each VM now gets a brand-new, isolated file, `gcloud` creates it as a 0-byte file when called before serial output is produced. This exposed the latent bug in `while [ -s ... ]`, causing `read_serial.sh` to exit immediately on turn 1 whenever a VM takes longer to initialize (such as real GCA verifier tests or GPU driver setup).

### Evidence
1. **Execution Timing Proof:** In Cloud Build child build `a3addce6-8e0f-49c6-8046-ca0e1fe11b09`, step `CheckMemoryOnlyMonitoringEnabled` called `read_serial` immediately after `sleep 120`:
```json 
{ 
  "step": "CheckMemoryOnlyMonitoringEnabled", 
  "startTime": "2026-07-23T19:38:54.832139205Z",
  "endTime":   "2026-07-23T19:38:55.551808167Z",
  "durationSeconds": 0.719
}
```
We know the loop condition evaluated to false immediately on iteration 1 because step execution logs show `read_serial` exited in 0.719s, bypassing the mandatory 5-second sleep inside the loop body.
