### PR TITLE
client: add `FindHandle` to look up a persistent key by its public key

### DIFF
--- a/client/handles.go
+++ b/client/handles.go
@@ -1,6 +1,8 @@
 package client
 
 import (
+	"crypto"
+	"errors"
 	"fmt"
 	"io"
 	"math"
@@ -45,6 +47,41 @@ const (
 func isHierarchy(h tpmutil.Handle) bool {
 	return h == tpm2.HandleOwner || h == tpm2.HandleEndorsement ||
 		h == tpm2.HandlePlatform || h == tpm2.HandleNull
+}
+
+// ErrNoKeyFound is returned by FindHandle when no persistent key in the TPM
+// matches the given public key.
+var ErrNoKeyFound = errors.New("no persistent key matches the public key")
+
+// FindHandle returns the handle of the persistent key whose public key is pub,
+// or ErrNoKeyFound if no persistent key matches. The result can be passed to
+// LoadCachedKey to use the key.
+func FindHandle(rw io.ReadWriter, pub crypto.PublicKey) (tpmutil.Handle, error) {
+	want, ok := pub.(interface{ Equal(crypto.PublicKey) bool })
+	if !ok {
+		return 0, fmt.Errorf("public key of type %T cannot be compared", pub)
+	}
+
+	handles, err := Handles(rw, tpm2.HandleTypePersistent)
+	if err != nil {
+		return 0, err
+	}
+	for _, h := range handles {
+		pubArea, _, _, err := tpm2.ReadPublic(rw, h)
+		if err != nil {
+			// Not readable by us, skip it
+			continue
+		}
+		key, err := pubArea.Key()
+		if err != nil {
+			// A persistent object with no crypto.PublicKey form.
+			continue
+		}
+		if want.Equal(key) {
+			return h, nil
+		}
+	}
+	return 0, ErrNoKeyFound
 }
 
 // Handles returns a slice of tpmutil.Handle objects of all handles within

--- a/client/handles_test.go
+++ b/client/handles_test.go
@@ -1,6 +1,12 @@
 package client_test
 
 import (
+	"crypto"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/sha256"
+	"errors"
 	"reflect"
 	"testing"
 
@@ -37,5 +43,152 @@ func TestHandles(t *testing.T) {
 		if err := tpm2.FlushContext(rwc, handle); err != nil {
 			t.Error(err)
 		}
+	}
+}
+
+func TestFindHandle(t *testing.T) {
+	rwc := test.GetTPM(t)
+	defer client.CheckedClose(t, rwc)
+
+	// Persist three keys: two ECC and one RSA. Finding each key proves the
+	// public keys were actually compared: with two ECC keys in the TPM,
+	// matching on the algorithm alone is not enough.
+	akECC, err := client.AttestationKeyECC(rwc)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer akECC.Close()
+
+	akRSA, err := client.AttestationKeyRSA(rwc)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer akRSA.Close()
+
+	// This key sits at a higher handle than the ECC AK, and handles are
+	// searched in ascending order, so finding this key means FindHandle
+	// walked past a same-algorithm key and rejected it.
+	signingECC, err := client.NewCachedKey(rwc, tpm2.HandleOwner, templateECC(tpm2.AlgSHA256), tpmutil.Handle(0x81008F02))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer signingECC.Close()
+
+	keys := []struct {
+		name string
+		key  *client.Key
+	}{
+		{"AK-ECC", akECC},
+		{"AK-RSA", akRSA},
+		{"Signing-ECC", signingECC},
+	}
+	for _, k := range keys {
+		t.Run(k.name, func(t *testing.T) {
+			handle, err := client.FindHandle(rwc, k.key.PublicKey())
+			if err != nil {
+				t.Fatal(err)
+			}
+			if handle != k.key.Handle() {
+				t.Errorf("expected handle %v, got: %v", k.key.Handle(), handle)
+			}
+		})
+	}
+}
+
+func TestFindHandleFoundKeySigns(t *testing.T) {
+	rwc := test.GetTPM(t)
+	defer client.CheckedClose(t, rwc)
+
+	// Create a signing key in the TPM, keeping only its public key. This
+	// mirrors a real client, who knows the public key from a certificate
+	// but does not know the handle.
+	provisioned, err := client.NewCachedKey(rwc, tpm2.HandleOwner, templateECC(tpm2.AlgSHA256), tpmutil.Handle(0x81008F02))
+	if err != nil {
+		t.Fatal(err)
+	}
+	pub := provisioned.PublicKey()
+	provisioned.Close()
+
+	handle, err := client.FindHandle(rwc, pub)
+	if err != nil {
+		t.Fatal(err)
+	}
+	key, err := client.LoadCachedKey(rwc, handle, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer key.Close()
+
+	signer, err := key.GetSigner()
+	if err != nil {
+		t.Fatal(err)
+	}
+	digest := sha256.Sum256([]byte("proof of possession"))
+	sig, err := signer.Sign(nil, digest[:], crypto.SHA256)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !verifyECC(pub, crypto.SHA256, digest[:], sig) {
+		t.Error("signature from recovered key does not verify against the public key that found it")
+	}
+}
+
+func TestFindHandleIgnoresTransientKeys(t *testing.T) {
+	rwc := test.GetTPM(t)
+	defer client.CheckedClose(t, rwc)
+
+	// LoadRandomExternalKey loads its key with TPM2_LoadExternal, and every
+	// loaded object is transient. The check below guards against the helper
+	// changing.
+	handle := test.LoadRandomExternalKey(t, rwc)
+	defer func() {
+		if err := tpm2.FlushContext(rwc, handle); err != nil {
+			t.Error(err)
+		}
+	}()
+	if byte(handle>>24) != byte(tpm2.HandleTypeTransient) {
+		t.Fatalf("expected a transient handle, got: %#x", handle)
+	}
+
+	pubArea, _, _, err := tpm2.ReadPublic(rwc, handle)
+	if err != nil {
+		t.Fatal(err)
+	}
+	pub, err := pubArea.Key()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := client.FindHandle(rwc, pub); !errors.Is(err, client.ErrNoKeyFound) {
+		t.Errorf("expected ErrNoKeyFound, got: %v", err)
+	}
+}
+
+// keyWithoutEqual mimics a public key type with no Equal method, such as the
+// *dsa.PublicKey an x509.Certificate carrying a DSA key yields.
+type keyWithoutEqual struct{}
+
+func TestFindHandleUncomparableKey(t *testing.T) {
+	rwc := test.GetTPM(t)
+	defer client.CheckedClose(t, rwc)
+
+	_, err := client.FindHandle(rwc, keyWithoutEqual{})
+	if err == nil || errors.Is(err, client.ErrNoKeyFound) {
+		t.Errorf("expected a comparison error, got: %v", err)
+	}
+}
+
+func TestFindHandleNoKeyFound(t *testing.T) {
+	rwc := test.GetTPM(t)
+	defer client.CheckedClose(t, rwc)
+
+	// A key the TPM has never seen.
+	priv, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := client.FindHandle(rwc, priv.Public()); !errors.Is(err, client.ErrNoKeyFound) {
+		t.Errorf("expected ErrNoKeyFound, got: %v", err)
 	}
 }


### PR DESCRIPTION
Closes #901

`client.LoadCachedKey` requires the caller to know a key's handle, but that handle is set at provisioning and can differ between machines, so applications end up carrying it in config and keeping it in sync with provisioning.

If you have an X.509 certificate for a TPM key, the certificate's public key is the key's public half, so the key can be found by matching that public key against the TPM's persistent keys, with no configured handle needed.

This PR adds `FindHandle` to the client package. It returns the handle of the persistent key whose public key matches, or `ErrNoKeyFound` when none does. The result feeds into `LoadCachedKey`.

The search on purpose covers only persistent handles: transient handles never cross a process boundary.

Matching uses `Equal` that all current standard library public key types implement; the one type without it (deprecated [crypto/dsa](https://pkg.go.dev/crypto/dsa@go1.26.5)) gets an error rather than a false not-found. Persistent objects that have no [crypto.PublicKey](https://pkg.go.dev/crypto#PublicKey) form, or that cannot be read, are skipped rather than failing the search.