### PR TITLE
launcher/image/test: retry GPU VM creation on quota errors.

### DIFF
--- a/launcher/image/test/create_vm.sh
+++ b/launcher/image/test/create_vm.sh
@@ -82,20 +82,41 @@ create_vm() {
     PREEMPTIBLE_FLAG=""
   fi
 
-  gcloud compute instances create $VM_NAME \
-    $CONFIDENTIAL_COMPUTE_FLAGS \
-    --maintenance-policy=TERMINATE \
-    --machine-type=$MACHINE_TYPE \
-    --boot-disk-size=$DISK_SIZE_GB \
-    --scopes=cloud-platform \
-    --zone=$ZONE \
-    --image=$IMAGE_NAME \
-    --image-project=$PROJECT_NAME \
-    --shielded-secure-boot \
-    $ACCELERATOR_FLAGS \
-    $PREEMPTIBLE_FLAG \
-    $APPEND_METADATA \
-    $APPEND_METADATA_FILE
+  MAX_RETRIES=1
+  if [ -n "$GPU_TYPE" ]; then
+    MAX_RETRIES=5
+  fi
+
+  RETRY_COUNT=0
+  DELAY=30
+
+  while [ $RETRY_COUNT -lt $MAX_RETRIES ]; do
+    if gcloud compute instances create $VM_NAME \
+      $CONFIDENTIAL_COMPUTE_FLAGS \
+      --maintenance-policy=TERMINATE \
+      --machine-type=$MACHINE_TYPE \
+      --boot-disk-size=$DISK_SIZE_GB \
+      --scopes=cloud-platform \
+      --zone=$ZONE \
+      --image=$IMAGE_NAME \
+      --image-project=$PROJECT_NAME \
+      --shielded-secure-boot \
+      $ACCELERATOR_FLAGS \
+      $PREEMPTIBLE_FLAG \
+      $APPEND_METADATA \
+      $APPEND_METADATA_FILE; then
+      return 0
+    fi
+
+    RETRY_COUNT=$((RETRY_COUNT + 1))
+    if [ $RETRY_COUNT -lt $MAX_RETRIES ]; then
+      echo "VM creation failed for ${VM_NAME} (attempt ${RETRY_COUNT}/${MAX_RETRIES}). Retrying in ${DELAY}s..."
+      sleep $DELAY
+    fi
+  done
+
+  echo "Failed to create VM ${VM_NAME} after ${MAX_RETRIES} attempts."
+  exit 1
 }
 
 IMAGE_NAME=''


### PR DESCRIPTION
Retry `gcloud compute instances create` in `create_vm.sh` with a fixed 30s retry delay (up to 5 retries) specifically when creating GPU instances. Non-GPU VM creations remain set to 1 attempt to fail fast.

### Problem
Parallel presubmit runs and multi-VM test steps in `confidential-space-images-dev` frequently collide on the project's regional `PREEMPTIBLE_NVIDIA_H100_GPUS` quota (limit: 2 in `us-east5`). When overlapping test steps attempt to allocate a 3rd H100 GPU simultaneously, GCP rejects the creation request with `QUOTA_EXCEEDED`, causing transient presubmit test failures.

### Why This Approach
- **Empirically Sized for GPU Test Runtimes**: In passing integration tests, both H100 GPUs are held simultaneously for ~4 minutes during CUDA workload execution before being released in cleanup. A 5-retry sequence with 30s delays provides a 2-minute window for near-completion GPU tests to finish and release quota.
- **Negligible Impact on 60-Minute Timeout Budget**: A maximum retry delay of 2 minutes (4 x 30s) consumes <3.5% of the 60-minute presubmit execution budget.
- **Handles Cross-PR Collisions**: Protects against quota collisions when two independent PR presubmits execute concurrently.
- **Fail-Fast for Non-GPUs**: Restricting retries to GPU instances (`[ -n "$GPU_TYPE" ]`) ensures non-GPU VM tests fail immediately on genuine configuration errors without adding unnecessary delays.

### Shortcomings & Tradeoffs
- **Added Latency on Contested Quota**: When quota is contested, retries add up to 2 minutes of total delay before failing if quota remains unavailable.
- **Not a Complete Fix for High Concurrency**: If 3+ GPU tests start simultaneously and are early in their test run, 2 minutes of retries will expire before the earlier tests release their GPUs.