### PR TITLE
Launcher: journald JSON logging and add FluentBit

### DIFF
--- a/launcher/container_runner.go
+++ b/launcher/container_runner.go
@@ -50,7 +50,6 @@ type ContainerRunner struct {
 	launchSpec       spec.LaunchSpec
 	attestAgent      agent.AttestationAgent
 	logger           logging.Logger
-	workloadLogger   logging.Logger
 	deviceROTManager *device.ROTManager
 	serialConsole    *os.File
 	powerButton      *powerButtonListener // Populated only for a hardened image
@@ -105,7 +104,6 @@ type RunnerConfig struct {
 	WorkloadService  *workloadservice.Server
 	LaunchSpec       spec.LaunchSpec
 	Logger           logging.Logger
-	WorkloadLogger   logging.Logger
 	SerialConsole    *os.File
 }
 
@@ -114,7 +112,6 @@ func NewRunner(ctx context.Context, cfg *RunnerConfig) (*ContainerRunner, error)
 	cdClient := cfg.ContainerdClient
 	launchSpec := cfg.LaunchSpec
 	logger := cfg.Logger
-	workloadLogger := cfg.WorkloadLogger
 	serialConsole := cfg.SerialConsole
 	image := cfg.Image
 	attestAgent := cfg.AttestAgent
@@ -237,7 +234,6 @@ func NewRunner(ctx context.Context, cfg *RunnerConfig) (*ContainerRunner, error)
 		launchSpec:       launchSpec,
 		attestAgent:      attestAgent,
 		logger:           logger,
-		workloadLogger:   workloadLogger,
 		deviceROTManager: cfg.DeviceROTManager,
 		serialConsole:    serialConsole,
 		powerButton:      powerButton,
@@ -632,14 +628,11 @@ func (r *ContainerRunner) Run(ctx context.Context) error {
 		streamOpt = cio.WithStreams(nil, nil, nil)
 		r.logger.Info("Container stdout/stderr will not be redirected.")
 	case spec.Everywhere:
-		w := io.MultiWriter(os.Stdout, r.serialConsole)
-		streamOpt = cio.WithStreams(nil, w, w)
+		streamOpt = cio.WithStreams(nil, io.MultiWriter(logging.NewJSONInfoWriter(), r.serialConsole), io.MultiWriter(logging.NewJSONErrorWriter(), r.serialConsole))
 		r.logger.Info("Container stdout/stderr will be redirected to serial and Cloud Logging. This may result in performance issues due to slow serial console writes.")
 	case spec.CloudLogging:
-		stdoutWriter := logging.NewInfoWriter(r.workloadLogger)
-		stderrWriter := logging.NewErrorWriter(r.workloadLogger)
-		streamOpt = cio.WithStreams(nil, stdoutWriter, stderrWriter)
-		r.logger.Info("Container stdout/stderr will be redirected to Cloud Logging with INFO and ERROR severities respectively.")
+		streamOpt = cio.WithStreams(nil, logging.NewJSONInfoWriter(), logging.NewJSONErrorWriter())
+		r.logger.Info("Container stdout/stderr will be redirected to journald (JSON) for FluentBit scraping.")
 	case spec.Serial:
 		streamOpt = cio.WithStreams(nil, r.serialConsole, r.serialConsole)
 		r.logger.Info("Container stdout/stderr will be redirected to serial logging. This may result in performance issues due to slow serial console writes.")

--- a/launcher/container_runner_test.go
+++ b/launcher/container_runner_test.go
@@ -1119,8 +1119,7 @@ func TestNewRunner(t *testing.T) {
 					Hardened:            tc.hardened,
 					FakeVerifierEnabled: true,
 				},
-				Logger:         logger,
-				WorkloadLogger: logger,
+				Logger: logger,
 			}
 
 			_, err := NewRunner(context.Background(), cfg)

--- a/launcher/image/bc-guest/bc-fluent-bit-cs.conf
+++ b/launcher/image/bc-guest/bc-fluent-bit-cs.conf
@@ -37,6 +37,7 @@
     #
     # by default 'info' is set, that means it includes 'error' and 'warning'.
     log_level    info
+    parsers_file /etc/fluent-bit/parsers-cs.conf
     # Storage
     # =======
     # Fluent Bit can use memory and filesystem buffering based mechanisms
@@ -57,6 +58,13 @@
     Systemd_Filter _SYSTEMD_UNIT=container-runner.service
     DB /var/log/google-fluentbit/container-runner.log.db
     Read_From_Tail False
+
+[FILTER]
+    Name          parser
+    Match         confidential-space-launcher
+    Key_Name      MESSAGE
+    Parser        json
+    Reserve_Data  True
 
 # Collects Workload Service Daemon (WSD) logs
 [INPUT]

--- a/launcher/image/bc-guest/bcentrypoint.sh
+++ b/launcher/image/bc-guest/bcentrypoint.sh
@@ -22,6 +22,7 @@ EOF
   # Override default fluent-bit config.
   mkdir -p /etc/fluent-bit
   cp /usr/share/oem/confidential_space/bc-fluent-bit-cs.conf /etc/fluent-bit/fluent-bit.conf
+  cp /usr/share/oem/confidential_space/parsers-cs.conf /etc/fluent-bit/parsers-cs.conf
 
   mkdir /tmp/container_launcher
   chmod +rw /tmp/container_launcher

--- a/launcher/image/bc_cloudbuild.yaml
+++ b/launcher/image/bc_cloudbuild.yaml
@@ -58,6 +58,7 @@ steps:
            ./launcher/image/launcher \
            ./launcher/image/container-runner.service \
            ./launcher/image/bc-guest/bc-fluent-bit-cs.conf \
+           ./launcher/image/parsers-cs.conf \
            ./launcher/image/exit_script.sh \
            ./launcher/image/bc-guest/bc_network_setup.sh \
            ./launcher/image/bc-guest/bc_network_optimization.sh \

--- a/launcher/image/entrypoint.sh
+++ b/launcher/image/entrypoint.sh
@@ -5,6 +5,7 @@ main() {
   cp /usr/share/oem/confidential_space/container-runner.service /etc/systemd/system/container-runner.service
   # Override default fluent-bit config.
   cp /usr/share/oem/confidential_space/fluent-bit-cs.conf /etc/fluent-bit/fluent-bit.conf
+  cp /usr/share/oem/confidential_space/parsers-cs.conf /etc/fluent-bit/parsers-cs.conf
 
   # Override default system-stats-monitor.json for node-problem-detector.
   cp /usr/share/oem/confidential_space/system-stats-monitor-cs.json /etc/node_problem_detector/system-stats-monitor.json
@@ -16,8 +17,8 @@ main() {
   cp /usr/share/oem/confidential_space/kernel-monitor-cs.json /etc/node_problem_detector/kernel-monitor.json
   systemctl daemon-reload
   systemctl enable container-runner.service
+  systemctl restart fluent-bit.service
   systemctl start container-runner.service
-  systemctl start fluent-bit.service
 }
 
 main

--- a/launcher/image/fluent-bit-cs.conf
+++ b/launcher/image/fluent-bit-cs.conf
@@ -37,6 +37,7 @@
     #
     # by default 'info' is set, that means it includes 'error' and 'warning'.
     log_level    info
+    parsers_file /etc/fluent-bit/parsers-cs.conf
     # Storage
     # =======
     # Fluent Bit can use memory and filesystem buffering based mechanisms
@@ -57,6 +58,13 @@
     Systemd_Filter _SYSTEMD_UNIT=container-runner.service
     DB /var/log/google-fluentbit/container-runner.log.db
     Read_From_Tail False
+
+[FILTER]
+    Name          parser
+    Match         confidential-space-launcher
+    Key_Name      MESSAGE
+    Parser        json
+    Reserve_Data  True
 
 [OUTPUT]
     Name        stackdriver

--- a/launcher/image/parsers-cs.conf
+++ b/launcher/image/parsers-cs.conf
@@ -1,0 +1,19 @@
+#
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+[PARSER]
+    Name        json
+    Format      json

--- a/launcher/image/preload.sh
+++ b/launcher/image/preload.sh
@@ -69,6 +69,7 @@ configure_necessary_systemd_units() {
 configure_cloud_logging() {
   # Copy CS-specific fluent-bit config to OEM partition.
   cp fluent-bit-cs.conf "${CS_PATH}"
+  cp parsers-cs.conf "${CS_PATH}"
 }
 
 configure_node_problem_detector() {

--- a/launcher/image/test/scripts/test_log_redirect.sh
+++ b/launcher/image/test/scripts/test_log_redirect.sh
@@ -18,13 +18,21 @@ elif [[ "$1" == "cloud_logging" ]]; then
         
         # If logs are expected and found, return early
         if [[ $output == *"Token looks okay"* ]] && [[ "$2" == "true" ]]; then
-            break
+            if [[ "$1" != "cloud_logging" ]] || echo "$output" | grep -q 'INFO.*Token looks okay'; then
+                break
+            fi
         fi
 
         # Check if VM is done running
         vm_status=$(gcloud compute instances describe "$3" --zone "$4" --format="value(status)" || echo "TERMINATED")
         if [[ "$vm_status" == "TERMINATED" ]]; then
-            break
+            if [[ "$2" == "false" ]]; then
+                # VM is terminated and logs are not expected; wait briefly to ensure nothing is in-flight, then break.
+                sleep 15
+                output=$(read_cloud_logging $3 || true)
+                break
+            fi
+            # If logs ARE expected, continue polling until MAX_WAIT_SECONDS or until logs arrive in Cloud Logging.
         fi
 
         sleep $INTERVAL_SECONDS
@@ -35,13 +43,19 @@ else
     exit 1
 fi
 
-if [[ $output != *"Token looks okay"* ]] && [[ "$2" == "true" ]]; then
-    echo "FAILED: did not find workload logs in $1, but expected to:"
-    echo $output
-    echo 'TEST FAILED.' > /workspace/status.txt
-elif [[ $output == *"Token looks okay"* ]] && [[ "$2" == "false" ]]; then
+if [[ "$2" == "true" ]]; then
+    if [[ "$1" == "cloud_logging" ]] && ! echo "$output" | grep -q 'INFO.*Token looks okay'; then
+        echo "FAILED: did not find workload logs with INFO severity in cloud_logging, but expected to:"
+        echo "$output"
+        echo 'TEST FAILED.' > /workspace/status.txt
+    elif [[ "$1" != "cloud_logging" ]] && [[ $output != *"Token looks okay"* ]]; then
+        echo "FAILED: did not find workload logs in $1, but expected to:"
+        echo "$output"
+        echo 'TEST FAILED.' > /workspace/status.txt
+    fi
+elif [[ "$2" == "false" ]] && [[ $output == *"Token looks okay"* ]]; then
     echo "FAILED: found workload logs in $1, but did not expect to:"
-    echo $output
+    echo "$output"
     echo 'TEST FAILED.' > /workspace/status.txt
 fi
 

--- a/launcher/image/test/util/read_cloud_logging.sh
+++ b/launcher/image/test/util/read_cloud_logging.sh
@@ -6,5 +6,5 @@
 read_cloud_logging() {
   gcloud logging read "resource.type=\"gce_instance\" jsonPayload._HOSTNAME=\"$1\"
 log_name=\"projects/$PROJECT_ID/logs/confidential-space-launcher\"" \
---format="value(jsonPayload.MESSAGE)" --order asc
+--format="value(severity, jsonPayload.message, jsonPayload.MESSAGE)" --order asc
 }

--- a/launcher/image/vgentrypoint.sh
+++ b/launcher/image/vgentrypoint.sh
@@ -17,6 +17,7 @@ main() {
   cp /usr/share/oem/confidential_space/container-runner.service /etc/systemd/system/container-runner.service
   # Override default fluent-bit config.
   cp /usr/share/oem/confidential_space/fluent-bit-cs.conf /etc/fluent-bit/fluent-bit.conf
+  cp /usr/share/oem/confidential_space/parsers-cs.conf /etc/fluent-bit/parsers-cs.conf
 
   mkdir /tmp/container_launcher
   chmod +rw /tmp/container_launcher
@@ -32,8 +33,8 @@ main() {
   cp /usr/share/oem/confidential_space/kernel-monitor-cs.json /etc/node_problem_detector/kernel-monitor.json
   systemctl daemon-reload
   systemctl enable container-runner.service
+  systemctl restart fluent-bit.service
   systemctl start container-runner.service
-  systemctl start fluent-bit.service
 }
 
 main

--- a/launcher/image/vgpreload.sh
+++ b/launcher/image/vgpreload.sh
@@ -74,6 +74,7 @@ configure_necessary_systemd_units() {
 configure_cloud_logging() {
   # Copy CS-specific fluent-bit config to OEM partition.
   cp fluent-bit-cs.conf "${CS_PATH}"
+  cp parsers-cs.conf "${CS_PATH}"
 }
 
 configure_node_problem_detector() {

--- a/launcher/internal/logging/logging.go
+++ b/launcher/internal/logging/logging.go
@@ -6,10 +6,12 @@ import (
 	"context"
 	"crypto/tls"
 	"crypto/x509"
+	"encoding/json"
 	"fmt"
 	"io"
 	"log/slog"
 	"os"
+	"strings"
 
 	"cloud.google.com/go/compute/metadata"
 	clogging "cloud.google.com/go/logging"
@@ -302,37 +304,45 @@ func (n *nullLogger) Warn(_ string, _ ...any)                     {}
 func (n *nullLogger) Error(_ string, _ ...any)                    {}
 func (n *nullLogger) Close()                                      {}
 
-// SeverityWriter wraps a Logger and implements io.Writer to write to the Logger at a specific severity level.
-type SeverityWriter struct {
-	l        Logger
-	severity clogging.Severity
+// JSONSeverityWriter wraps an io.Writer (such as os.Stdout or os.Stderr) and formats log lines as structured JSON.
+type JSONSeverityWriter struct {
+	Target   io.Writer
+	Severity string // "INFO" or "ERROR"
 }
 
-// NewSeverityWriter returns an io.Writer that writes to the provided Logger with a specific severity.
-func NewSeverityWriter(l Logger, severity clogging.Severity) io.Writer {
-	return &SeverityWriter{l: l, severity: severity}
-}
-
-// NewInfoWriter returns an io.Writer that writes logs to the provided Logger with Info severity.
-func NewInfoWriter(l Logger) io.Writer {
-	return NewSeverityWriter(l, clogging.Info)
-}
-
-// NewErrorWriter returns an io.Writer that writes logs to the provided Logger with Error severity.
-func NewErrorWriter(l Logger) io.Writer {
-	return NewSeverityWriter(l, clogging.Error)
-}
-
-// Write implements the io.Writer interface, redirecting logs to the Logger with the configured severity.
-func (w *SeverityWriter) Write(p []byte) (n int, err error) {
-	// Trim any trailing newline.
-	end := len(p)
-	for end > 0 && p[end-1] == '\n' {
-		end--
+// Write formats p as JSON {"severity": "...", "message": "..."} and writes it to the underlying Target.
+func (w *JSONSeverityWriter) Write(p []byte) (n int, err error) {
+	text := strings.TrimRight(string(p), "\r\n")
+	if text == "" {
+		return len(p), nil
 	}
-	msg := string(p[:end])
 
-	w.l.Log(w.severity, msg)
-
+	for _, line := range strings.Split(text, "\n") {
+		line = strings.TrimRight(line, "\r")
+		if line == "" {
+			continue
+		}
+		record, marshalErr := json.Marshal(map[string]string{
+			"severity": w.Severity,
+			"message":  line,
+		})
+		if marshalErr != nil {
+			return 0, marshalErr
+		}
+		record = append(record, '\n')
+		if _, err = w.Target.Write(record); err != nil {
+			return 0, err
+		}
+	}
 	return len(p), nil
+}
+
+// NewJSONInfoWriter returns an io.Writer that formats lines as JSON with INFO severity to os.Stdout.
+func NewJSONInfoWriter() io.Writer {
+	return &JSONSeverityWriter{Target: os.Stdout, Severity: "INFO"}
+}
+
+// NewJSONErrorWriter returns an io.Writer that formats lines as JSON with ERROR severity to os.Stderr.
+func NewJSONErrorWriter() io.Writer {
+	return &JSONSeverityWriter{Target: os.Stderr, Severity: "ERROR"}
 }

--- a/launcher/internal/logging/logging_test.go
+++ b/launcher/internal/logging/logging_test.go
@@ -4,11 +4,12 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	"io"
 	"log/slog"
+	"os"
 	"reflect"
 	"strings"
 	"testing"
+	"time"
 
 	clogging "cloud.google.com/go/logging"
 	"github.com/google/go-cmp/cmp"
@@ -324,86 +325,126 @@ func TestLogFunctions(t *testing.T) {
 	}
 }
 
-func TestSeverityWriter(t *testing.T) {
-	tests := []struct {
-		name         string
-		writerFunc   func(Logger) io.Writer
-		input        string
-		wantMsg      string
-		wantSeverity clogging.Severity
-	}{
-		{
-			name:         "InfoWriter without newline",
-			writerFunc:   NewInfoWriter,
-			input:        "test info log",
-			wantMsg:      "test info log",
-			wantSeverity: clogging.Info,
-		},
-		{
-			name:         "InfoWriter strips trailing newlines",
-			writerFunc:   NewInfoWriter,
-			input:        "test info log\n\n",
-			wantMsg:      "test info log",
-			wantSeverity: clogging.Info,
-		},
-		{
-			name:         "ErrorWriter with trailing newline",
-			writerFunc:   NewErrorWriter,
-			input:        "test error log\n",
-			wantMsg:      "test error log",
-			wantSeverity: clogging.Error,
-		},
-		{
-			name:         "Preserves internal newlines",
-			writerFunc:   NewInfoWriter,
-			input:        "line 1\nline 2\n\n",
-			wantMsg:      "line 1\nline 2",
-			wantSeverity: clogging.Info,
-		},
-		{
-			name:         "Empty input",
-			writerFunc:   NewInfoWriter,
-			input:        "",
-			wantMsg:      "",
-			wantSeverity: clogging.Info,
-		},
-		{
-			name:         "Only newlines",
-			writerFunc:   NewInfoWriter,
-			input:        "\n\n\n",
-			wantMsg:      "",
-			wantSeverity: clogging.Info,
-		},
-	}
-
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			mock := &mockLogger{}
-			writer := tc.writerFunc(mock)
-			n, err := writer.Write([]byte(tc.input))
-			if err != nil || n != len(tc.input) {
-				t.Fatalf("Write failed: got n=%v, err=%v", n, err)
-			}
-			if mock.severity != tc.wantSeverity {
-				t.Errorf("Severity: got %v, want %v", mock.severity, tc.wantSeverity)
-			}
-			if mock.msg != tc.wantMsg {
-				t.Errorf("Message: got %q, want %q", mock.msg, tc.wantMsg)
-			}
-		})
-	}
+type errorWriter struct {
+	err error
 }
 
-type mockLogger struct {
-	severity clogging.Severity
-	msg      string
+func (e *errorWriter) Write(_ []byte) (int, error) {
+	return 0, e.err
 }
 
-func (m *mockLogger) Log(severity clogging.Severity, msg string, _ ...any) {
-	m.severity = severity
-	m.msg = msg
+func TestJSONSeverityWriter(t *testing.T) {
+	t.Run("single line", func(t *testing.T) {
+		var buf bytes.Buffer
+		writer := &JSONSeverityWriter{Target: &buf, Severity: "ERROR"}
+
+		input := "workload error line\n"
+		n, err := writer.Write([]byte(input))
+		if err != nil || n != len(input) {
+			t.Fatalf("Write failed: n=%d, err=%v", n, err)
+		}
+
+		want := `{"message":"workload error line","severity":"ERROR"}` + "\n"
+		if buf.String() != want {
+			t.Errorf("JSONSeverityWriter output = %q, want %q", buf.String(), want)
+		}
+	})
+
+	t.Run("multi line", func(t *testing.T) {
+		var buf bytes.Buffer
+		writer := &JSONSeverityWriter{Target: &buf, Severity: "INFO"}
+
+		input := "first line\r\nsecond line\nthird line\n"
+		n, err := writer.Write([]byte(input))
+		if err != nil || n != len(input) {
+			t.Fatalf("Write failed: n=%d, err=%v", n, err)
+		}
+
+		want := `{"message":"first line","severity":"INFO"}` + "\n" +
+			`{"message":"second line","severity":"INFO"}` + "\n" +
+			`{"message":"third line","severity":"INFO"}` + "\n"
+		if buf.String() != want {
+			t.Errorf("JSONSeverityWriter output = %q, want %q", buf.String(), want)
+		}
+	})
+
+	t.Run("empty or whitespace only", func(t *testing.T) {
+		var buf bytes.Buffer
+		writer := &JSONSeverityWriter{Target: &buf, Severity: "INFO"}
+
+		input := "\r\n\n"
+		n, err := writer.Write([]byte(input))
+		if err != nil || n != len(input) {
+			t.Fatalf("Write failed: n=%d, err=%v", n, err)
+		}
+
+		if buf.Len() != 0 {
+			t.Errorf("JSONSeverityWriter output = %q, want empty", buf.String())
+		}
+	})
+
+	t.Run("constructor helpers", func(t *testing.T) {
+		infoW := NewJSONInfoWriter()
+		jsonInfo, ok := infoW.(*JSONSeverityWriter)
+		if !ok || jsonInfo.Target != os.Stdout || jsonInfo.Severity != "INFO" {
+			t.Errorf("NewJSONInfoWriter() = %+v, want Target:os.Stdout, Severity:INFO", infoW)
+		}
+
+		errW := NewJSONErrorWriter()
+		jsonErr, ok := errW.(*JSONSeverityWriter)
+		if !ok || jsonErr.Target != os.Stderr || jsonErr.Severity != "ERROR" {
+			t.Errorf("NewJSONErrorWriter() = %+v, want Target:os.Stderr, Severity:ERROR", errW)
+		}
+	})
+
+	t.Run("target write error", func(t *testing.T) {
+		errWriter := &errorWriter{err: errors.New("underlying write error")}
+		writer := &JSONSeverityWriter{Target: errWriter, Severity: "ERROR"}
+
+		input := "error triggering payload\n"
+		n, err := writer.Write([]byte(input))
+		if err == nil {
+			t.Fatal("Expected error from writer.Write, got nil")
+		}
+		if n >= len(input) {
+			t.Errorf("Expected n < len(input) on error per io.Writer standard, got n=%d, len=%d", n, len(input))
+		}
+	})
+
+	t.Run("high throughput burst", func(t *testing.T) {
+		var buf bytes.Buffer
+		writer := &JSONSeverityWriter{Target: &buf, Severity: "INFO"}
+
+		const lineCount = 50000
+		start := time.Now()
+
+		for i := 1; i <= lineCount; i++ {
+			msg := fmt.Sprintf("high rate log message sequence=%d\n", i)
+			n, err := writer.Write([]byte(msg))
+			if err != nil || n != len(msg) {
+				t.Fatalf("Write %d failed: n=%d, err=%v", i, n, err)
+			}
+		}
+
+		elapsed := time.Since(start)
+		t.Logf("Wrote and verified %d structured JSON log lines in %v", lineCount, elapsed)
+
+		// Verify line count in output buffer
+		output := buf.String()
+		lines := strings.Split(strings.TrimRight(output, "\n"), "\n")
+		if len(lines) != lineCount {
+			t.Fatalf("Expected %d formatted JSON lines, got %d", lineCount, len(lines))
+		}
+
+		// Verify first and last line formatting
+		firstWant := `{"message":"high rate log message sequence=1","severity":"INFO"}`
+		if lines[0] != firstWant {
+			t.Errorf("First line = %q, want %q", lines[0], firstWant)
+		}
+
+		lastWant := fmt.Sprintf(`{"message":"high rate log message sequence=%d","severity":"INFO"}`, lineCount)
+		if lines[lineCount-1] != lastWant {
+			t.Errorf("Last line = %q, want %q", lines[lineCount-1], lastWant)
+		}
+	})
 }
-func (m *mockLogger) Info(_ string, _ ...any)  {}
-func (m *mockLogger) Warn(_ string, _ ...any)  {}
-func (m *mockLogger) Error(_ string, _ ...any) {}
-func (m *mockLogger) Close()                   {}

--- a/launcher/launcher/main.go
+++ b/launcher/launcher/main.go
@@ -80,16 +80,16 @@ func main() {
 		return
 	}
 
-	workloadLogger, err := logging.NewCloudLogger(ctx, pool)
+	cloudLogger, err := logging.NewCloudLogger(ctx, pool)
 	if err != nil {
 		serialLogger.Error(fmt.Sprintf("failed to initialize cloud logging: %v", err))
 		exitCode = failRC
 		serialLogger.Error(exitMessage, "exit_code", exitCode, "exit_msg", rcMessage[exitCode])
 		return
 	}
-	defer workloadLogger.Close()
+	defer cloudLogger.Close()
 
-	logger := logging.DualLogger(workloadLogger, serialLogger)
+	logger := logging.DualLogger(cloudLogger, serialLogger)
 
 	pinnedTransport, err := launcher.PinnedHTTPTransport(pool)
 	if err != nil {
@@ -158,7 +158,7 @@ func main() {
 			logger.Info(exitMessage, "exit_code", exitCode)
 		}
 	}()
-	if err = launcher.StartLauncher(ctx, launchSpec, logger, workloadLogger, serialConsole, pinnedClient, googleClient); err != nil {
+	if err = launcher.StartLauncher(ctx, launchSpec, logger, serialConsole, pinnedClient, googleClient); err != nil {
 		logger.Error(err.Error())
 		var tpmOpenErr *launcher.TPMOpenError
 		if errors.As(err, &tpmOpenErr) {

--- a/launcher/start.go
+++ b/launcher/start.go
@@ -44,7 +44,7 @@ var expectedTPMDAParams = TPMDAParams{
 
 // StartLauncher orchestrates the client creation, image pulling, attestation agent setup,
 // and runs the ContainerRunner.
-func StartLauncher(ctx context.Context, launchSpec spec.LaunchSpec, logger logging.Logger, workloadLogger logging.Logger, serialConsole *os.File, pinnedClient *http.Client, googleClient *http.Client) error {
+func StartLauncher(ctx context.Context, launchSpec spec.LaunchSpec, logger logging.Logger, serialConsole *os.File, pinnedClient *http.Client, googleClient *http.Client) error {
 	if pinnedClient == nil {
 		return errors.New("pinnedClient must be non-nil")
 	}
@@ -170,7 +170,6 @@ func StartLauncher(ctx context.Context, launchSpec spec.LaunchSpec, logger loggi
 		WorkloadService:  workloadService,
 		LaunchSpec:       launchSpec,
 		Logger:           logger,
-		WorkloadLogger:   workloadLogger,
 		SerialConsole:    serialConsole,
 	})
 	if err != nil {


### PR DESCRIPTION
Upgrades the Confidential Space launcher to emit structured JSON workload logs to `journald`, allowing Fluent Bit to map `INFO`/`ERROR` severities to Google Cloud Logging while preserving local disk audit trails and preventing container thread stalls.

* **Structured JSON Logging (`JSONSeverityWriter`):** Formats container stdout/stderr as JSON lines (`{"severity":"...", "message":"..."}`) written to `os.Stdout`/`os.Stderr`.
* **Fluent Bit JSON Parser:** Added `parsers-cs.conf` and a parser filter to `fluent-bit-cs.conf` & `bc-fluent-bit-cs.conf` to extract and promote `severity` to Cloud Logging.
* **Boot Service Lifecycle:** Updated `entrypoint.sh`, `vgentrypoint.sh`, and `bcentrypoint.sh` to install `parsers-cs.conf` and restart `fluent-bit.service` before workload launch.
* **Cleanup:** Removed obsolete direct Cloud Logging writers (`SeverityWriter`, `NewInfoWriter`, `NewErrorWriter`) and `workloadLogger` from `container_runner.go`, `logging.go`, `start.go`, and `main.go`.
* **Testing & CI:** Added unit tests (`TestJSONSeverityWriter`) with 50k-line throughput verification, updated Cloud Build integration tests (`read_cloud_logging.sh` & `test_log_redirect.sh`) to verify `INFO` severity.