### PR TITLE
Introducing keep-sorted

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -203,3 +203,31 @@ jobs:
         run: CGO_CFLAGS=-Werror CC=gcc go build ./...
       - name: Check for CGO Warnings (clang)
         run: CGO_CFLAGS=-Werror CC=clang go build ./...
+
+  keep-sorted:
+    name: Keep Sorted Check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version: '1.24.x'
+          cache: false
+      - name: Install keep-sorted
+        run: go install github.com/google/keep-sorted@v0.9.1
+      - name: Check keep-sorted
+        run: |
+          if [ -n "${GITHUB_BASE_REF}" ]; then
+            git fetch origin ${GITHUB_BASE_REF} --depth=1
+            BASE_REF="origin/${GITHUB_BASE_REF}"
+          else
+            BASE_REF="HEAD~1"
+          fi
+          git diff --name-only -z --diff-filter=d "$BASE_REF" HEAD | while IFS= read -r -d '' file; do
+            if [ -f "$file" ]; then
+              keep-sorted "$file"
+            fi
+          done
+          git diff --exit-code

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -210,6 +210,7 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          fetch-depth: 2
           persist-credentials: false
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:

--- a/launcher/spec/launch_policy.go
+++ b/launcher/spec/launch_policy.go
@@ -13,14 +13,16 @@ import (
 // LaunchPolicy contains policies on starting the container.
 // The policy comes from the labels of the image.
 type LaunchPolicy struct {
-	AllowedEnvOverride       []string
+	// keep-sorted start
+	AllowCgroups             bool
 	AllowedCmdOverride       bool
+	AllowedEnvOverride       []string
 	AllowedLogRedirect       policy
 	AllowedMountDestinations []string
-	HardenedImageMonitoring  MonitoringType
 	DebugImageMonitoring     MonitoringType
+	HardenedImageMonitoring  MonitoringType
 	PrivilegedCaps           bool
-	AllowCgroups             bool
+	// keep-sorted end
 }
 
 type policy int
@@ -100,19 +102,21 @@ func toPolicy(policy, s string) (policy, error) {
 }
 
 const (
-	envOverride        = "tee.launch_policy.allow_env_override"
-	cmdOverride        = "tee.launch_policy.allow_cmd_override"
-	logRedirect        = "tee.launch_policy.log_redirect"
-	memoryMonitoring   = "tee.launch_policy.monitoring_memory_allow"
-	hardenedMonitoring = "tee.launch_policy.hardened_monitoring"
-	debugMonitoring    = "tee.launch_policy.debug_monitoring"
+	// keep-sorted start by_regex="([^"]+)"
+	privilegedCaps = "tee.launch_policy.allow_capabilities"
+	allowCgroups   = "tee.launch_policy.allow_cgroups"
+	cmdOverride    = "tee.launch_policy.allow_cmd_override"
+	envOverride    = "tee.launch_policy.allow_env_override"
 	// Values look like a PATH list, with ':' as a separator.
 	// Empty paths will be ignored and relative paths will be interpreted as
 	// relative to "/".
 	// Paths will be cleaned using filepath.Clean.
-	mountDestinations = "tee.launch_policy.allow_mount_destinations"
-	privilegedCaps    = "tee.launch_policy.allow_capabilities"
-	allowCgroups      = "tee.launch_policy.allow_cgroups"
+	mountDestinations  = "tee.launch_policy.allow_mount_destinations"
+	debugMonitoring    = "tee.launch_policy.debug_monitoring"
+	hardenedMonitoring = "tee.launch_policy.hardened_monitoring"
+	logRedirect        = "tee.launch_policy.log_redirect"
+	memoryMonitoring   = "tee.launch_policy.monitoring_memory_allow"
+	// keep-sorted end
 )
 
 func configureMonitoringPolicy(imageLabels map[string]string, launchPolicy *LaunchPolicy, logger logging.Logger) error {

--- a/launcher/spec/launch_spec.go
+++ b/launcher/spec/launch_spec.go
@@ -78,25 +78,27 @@ const (
 
 // Metadata variable names.
 const (
-	fakeVerifierKey            = "test-fake-verifier"
-	imageRefKey                = "tee-image-reference"
-	signedImageRepos           = "tee-signed-image-repos"
-	restartPolicyKey           = "tee-restart-policy"
-	cmdKey                     = "tee-cmd"
-	envKeyPrefix               = "tee-env-"
-	impersonateServiceAccounts = "tee-impersonate-service-accounts"
-	logRedirectKey             = "tee-container-log-redirect"
-	memoryMonitoringEnable     = "tee-monitoring-memory-enable"
-	monitoringEnable           = "tee-monitoring-enable"
-	devShmSizeKey              = "tee-dev-shm-size-kb"
-	mountKey                   = "tee-mount"
-	itaRegion                  = "ita-region"
+	// keep-sorted start by_regex="([^"]+)"
+	gcaServiceEnv              = "gca-service-env"
 	itaKey                     = "ita-api-key"
+	itaRegion                  = "ita-region"
 	addedCaps                  = "tee-added-capabilities"
 	cgroupNS                   = "tee-cgroup-ns"
-	gcaServiceEnv              = "gca-service-env"
-	installGpuDriver           = "tee-install-gpu-driver"
+	cmdKey                     = "tee-cmd"
+	logRedirectKey             = "tee-container-log-redirect"
+	devShmSizeKey              = "tee-dev-shm-size-kb"
 	disableGcaRefreshKey       = "tee-disable-gca-refresh"
+	envKeyPrefix               = "tee-env-"
+	imageRefKey                = "tee-image-reference"
+	impersonateServiceAccounts = "tee-impersonate-service-accounts"
+	installGpuDriver           = "tee-install-gpu-driver"
+	monitoringEnable           = "tee-monitoring-enable"
+	memoryMonitoringEnable     = "tee-monitoring-memory-enable"
+	mountKey                   = "tee-mount"
+	restartPolicyKey           = "tee-restart-policy"
+	signedImageRepos           = "tee-signed-image-repos"
+	fakeVerifierKey            = "test-fake-verifier"
+	// keep-sorted end
 )
 
 const (
@@ -124,25 +126,27 @@ type LaunchSpec struct {
 	FakeVerifierEnabled bool
 
 	// MDS-based values.
-	ImageRef                   string
-	SignedImageRepos           []string
-	RestartPolicy              RestartPolicy
-	Cmd                        []string
-	Envs                       []EnvVar
-	GcaAddress                 string
-	ImpersonateServiceAccounts []string
-	ProjectID                  string
-	Region                     string
-	Hardened                   bool
-	MonitoringEnabled          MonitoringType
-	LogRedirect                LogRedirectLocation
-	Mounts                     []launchermount.Mount
-	ITAConfig                  verifier.ITAConfig
-	DevShmSize                 int64 // DevShmSize is specified in kiB.
+	// keep-sorted start case=no
 	AddedCapabilities          []string
 	CgroupNamespace            bool
-	InstallGpuDriver           bool
+	Cmd                        []string
+	DevShmSize                 int64 // DevShmSize is specified in kiB.
 	DisableGcaRefresh          bool
+	Envs                       []EnvVar
+	GcaAddress                 string
+	Hardened                   bool
+	ImageRef                   string
+	ImpersonateServiceAccounts []string
+	InstallGpuDriver           bool
+	ITAConfig                  verifier.ITAConfig
+	LogRedirect                LogRedirectLocation
+	MonitoringEnabled          MonitoringType
+	Mounts                     []launchermount.Mount
+	ProjectID                  string
+	Region                     string
+	RestartPolicy              RestartPolicy
+	SignedImageRepos           []string
+	// keep-sorted end
 }
 
 // UnmarshalJSON unmarshals an instance attributes list in JSON format from the metadata

--- a/server/policy_constants.go
+++ b/server/policy_constants.go
@@ -16,6 +16,7 @@ import (
 // Taken from TCG PC Client Platform Firmware Profile Specification,
 // Table 14 Events.
 const (
+	// keep-sorted start by_regex=0x.*
 	NoAction                   uint32 = 0x00000003
 	Separator                  uint32 = 0x00000004
 	EventTag                   uint32 = 0x00000006
@@ -24,6 +25,7 @@ const (
 	NonhostInfo                uint32 = 0x00000011
 	EFIBootServicesApplication uint32 = 0x80000003
 	EFIAction                  uint32 = 0x80000007
+	// keep-sorted end
 )
 
 // EventTagLoadedImageHex used with type "EV_EVENT_TAG".


### PR DESCRIPTION
Introducing https://github.com/google/keep-sorted into our CI pipeline to enhance readability. Also, applying it to launch policy, launch spec, and policy constants.