### PR TITLE
launcher: use us-west1-a and n2d for image builds

### DIFF
--- a/launcher/cloudbuild.yaml
+++ b/launcher/cloudbuild.yaml
@@ -635,7 +635,8 @@ steps:
   args: ['compute', 'images', 'export',
          '--destination-uri=gs://${PROJECT_ID}_raw-images/${_OUTPUT_IMAGE_PREFIX}-hardened-${_OUTPUT_IMAGE_SUFFIX}.tar.gz',
          '--image=${_OUTPUT_IMAGE_PREFIX}-hardened-${_OUTPUT_IMAGE_SUFFIX}',
-         '--project=${PROJECT_ID}']
+         '--project=${PROJECT_ID}',
+         '--zone=us-west1-a']
 
 - name: 'gcr.io/cloud-builders/gcloud'
   id: ExportDebugImage
@@ -644,7 +645,8 @@ steps:
   args: ['compute', 'images', 'export',
           '--destination-uri=gs://${PROJECT_ID}_raw-images/${_OUTPUT_IMAGE_PREFIX}-debug-${_OUTPUT_IMAGE_SUFFIX}.tar.gz',
           '--image=${_OUTPUT_IMAGE_PREFIX}-debug-${_OUTPUT_IMAGE_SUFFIX}',
-          '--project=${PROJECT_ID}']
+          '--project=${PROJECT_ID}',
+          '--zone=us-west1-a']
 
 - name: 'us-docker.pkg.dev/confidential-space-images-dev/cs-tools/measure@sha256:dae4766caef4a93c52736feb829bf2c505b7d48ce44d0ecb33e77d61bb4be888'
   id: MeasureHardenedImage
@@ -685,7 +687,8 @@ steps:
   args: ['compute', 'images', 'export',
          '--destination-uri=gs://${PROJECT_ID}_raw-images/${_OUTPUT_IMAGE_PREFIX}-vg-hardened-${_OUTPUT_IMAGE_SUFFIX}.tar.gz',
          '--image=${_OUTPUT_IMAGE_PREFIX}-vg-hardened-${_OUTPUT_IMAGE_SUFFIX}',
-         '--project=${PROJECT_ID}']
+         '--project=${PROJECT_ID}',
+         '--zone=us-west1-a']
 
 - name: 'gcr.io/cloud-builders/gcloud'
   id: ExportVgDebugImage
@@ -694,7 +697,8 @@ steps:
   args: ['compute', 'images', 'export',
           '--destination-uri=gs://${PROJECT_ID}_raw-images/${_OUTPUT_IMAGE_PREFIX}-vg-debug-${_OUTPUT_IMAGE_SUFFIX}.tar.gz',
           '--image=${_OUTPUT_IMAGE_PREFIX}-vg-debug-${_OUTPUT_IMAGE_SUFFIX}',
-          '--project=${PROJECT_ID}']
+          '--project=${PROJECT_ID}',
+          '--zone=us-west1-a']
 
 - name: 'us-docker.pkg.dev/confidential-space-images-dev/cs-tools/measure@sha256:dae4766caef4a93c52736feb829bf2c505b7d48ce44d0ecb33e77d61bb4be888'
   id: MeasureVgHardenedImage

--- a/launcher/image/bc_cloudbuild.yaml
+++ b/launcher/image/bc_cloudbuild.yaml
@@ -18,6 +18,7 @@ steps:
       - '--image=${_BASE_IMAGE}'
       - '--image-project=${_BASE_IMAGE_PROJECT}'
       - '--destination-uri=gs://${_BUCKET_NAME}/oem-preloader-${BUILD_ID}/${_BASE_IMAGE}.tar.gz'
+      - '--zone=us-west1-a'
   - name: 'gcr.io/cloud-builders/gcloud'
     id: 'DownloadImageFromGCS'
     entrypoint: 'gcloud'

--- a/launcher/image/cloudbuild.yaml
+++ b/launcher/image/cloudbuild.yaml
@@ -36,7 +36,8 @@ steps:
            '-image-project=${PROJECT_ID}',
            '-licenses=${_CS_LICENSE}',
            '-licenses=projects/confidential-space-images/global/licenses/ek-certificate-license',
-           '-zone=us-central1-a',
+           '-zone=us-west1-a',
+           '-machine-type=n2d-standard-2',
            '-project=${PROJECT_ID}']
 
 timeout: '3000s'

--- a/launcher/image/fixup_oem.sh
+++ b/launcher/image/fixup_oem.sh
@@ -4,7 +4,9 @@ main() {
   if [[ ! -d /mnt/disks/efi ]]; then
     mkdir /mnt/disks/efi
   fi
-  mount /dev/sda12 /mnt/disks/efi
+  # ChromiumOS / COS GPT disk layout uses partition 12 for the EFI System
+  # Partition (https://chromium.googlesource.com/chromiumos/docs/+/HEAD/disk_format.md).
+  mount "$(rootdev -s -d)12" /mnt/disks/efi
   sed -i -e 's|systemd.mask=usr-share-oem.mount||g' /mnt/disks/efi/efi/boot/grub.cfg
 
   # TODO: Remove this fix once the upstream customizer fixed the bug.
@@ -56,8 +58,9 @@ main() {
   fi
 
   # Since it's sealed, we mount it read-only to prevent changes
-  mount -o ro /dev/sda8 /mnt/disks/oem
-
+  # ChromiumOS / COS GPT disk layout uses partition 8 for the OEM partition
+  # (https://chromium.googlesource.com/chromiumos/docs/+/HEAD/disk_format.md).
+  mount -o ro "$(rootdev -s -d)8" /mnt/disks/oem
   ls -l /mnt/disks/oem/
   ls -l /mnt/disks/oem/confidential_space
 

--- a/launcher/image/preload.sh
+++ b/launcher/image/preload.sh
@@ -27,7 +27,9 @@ append_cmdline() {
   if [[ ! -d /mnt/disks/efi ]]; then
     mkdir /mnt/disks/efi
   fi
-  mount /dev/sda12 /mnt/disks/efi
+  # ChromiumOS / COS GPT disk layout uses partition 12 for the EFI System
+  # Partition (https://chromium.googlesource.com/chromiumos/docs/+/HEAD/disk_format.md).
+  mount "$(rootdev -s -d)12" /mnt/disks/efi
   sed -i -e "s|cros_efi|cros_efi ${arg}|g" /mnt/disks/efi/efi/boot/grub.cfg
   umount /mnt/disks/efi
 }

--- a/launcher/image/vgpreload.sh
+++ b/launcher/image/vgpreload.sh
@@ -32,7 +32,9 @@ append_cmdline() {
   if [[ ! -d /mnt/disks/efi ]]; then
     mkdir /mnt/disks/efi
   fi
-  mount /dev/sda12 /mnt/disks/efi
+  # ChromiumOS / COS GPT disk layout uses partition 12 for the EFI System
+  # Partition (https://chromium.googlesource.com/chromiumos/docs/+/HEAD/disk_format.md).
+  mount "$(rootdev -s -d)12" /mnt/disks/efi
   sed -i -e "s|cros_efi|cros_efi ${arg}|g" /mnt/disks/efi/efi/boot/grub.cfg
   umount /mnt/disks/efi
 }


### PR DESCRIPTION
launcher: use us-west1-a zone and n2d machine shape for image builds

Presubmit integration tests fail due to GCE resource pool stockouts (`ZONE_RESOURCE_POOL_EXHAUSTED`) when temporary build and export VMs are provisioned in capacity-constrained zones or default machine shapes.

### Audit Log Failure Evidence

Cloud Audit Logs recorded stockout failures across both classes of temporary VM workers:

1. **`cos-customizer finish-image-build`** (`2026-07-22T18:06:02Z`):
   ```json
   {
     "logName": "projects/confidential-space-images-dev/logs/cloudaudit.googleapis.com%2Factivity",
     "methodName": "v1.compute.instances.insert",
     "resourceName": "projects/confidential-space-images-dev/zones/us-central1-a/instances/preload-vm-build-image-p5txp",
     "status": {
       "code": 8,
       "message": "ZONE_RESOURCE_POOL_EXHAUSTED",
       "details": [{
         "errorInfo": [{
           "reason": "stockout",
           "vmType": "n1-standard-1",
           "zone": "us-central1-a"
         }],
         "localizedMessage": [{
           "message": "A n1-standard-1 VM instance is currently unavailable in the us-central1-a zone. Try requesting the VM in another zone."
         }]
       }]
     }
   }
   ```

2. **`gcloud compute images export`** (`2026-08-04T22:02:33Z`):
   ```json
   {
     "logName": "projects/confidential-space-images-dev/logs/cloudaudit.googleapis.com%2Factivity",
     "methodName": "v1.compute.instances.insert",
     "resourceName": "projects/confidential-space-images-dev/zones/us-central1-c/instances/inst-export-disk-image-export-ext-export-disk-280bg",
     "status": {
       "code": 8,
       "message": "ZONE_RESOURCE_POOL_EXHAUSTED",
       "details": [{
         "errorInfo": [{
           "reason": "stockout",
           "vmType": "n2-highcpu-4",
           "zone": "us-central1-c"
         }]
       }]
     }
   }
   ```

### Capacity Advisor Verification

To verify placement capacity for both VM shapes, we queried Compute Engine Capacity Advisor (`gcloud beta compute advice capacity --project=confidential-space-images-dev --region=us-west1 --zones=us-west1-a --provisioning-model=SPOT --size=1 --instance-selection-machine-types=n2d-standard-2,n2-highcpu-4 --target-distribution-shape=ANY`):

```yaml
recommendations:
- scores:
    estimatedUptime: 3600s
    obtainability: 0.9
  shards:
  - instanceCount: 1
    machineType: n2d-standard-2
    provisioningModel: SPOT
    zone: https://www.googleapis.com/compute/beta/projects/confidential-space-images-dev/zones/us-west1-a
- scores:
    estimatedUptime: 3600s
    obtainability: 0.9
  shards:
  - instanceCount: 1
    machineType: n2-highcpu-4
    provisioningModel: SPOT
    zone: https://www.googleapis.com/compute/beta/projects/confidential-space-images-dev/zones/us-west1-a
```

### Dynamic Boot Disk Resolution

Switching from legacy `n1-standard-1` to `n2d-standard-2` revealed an implicit dependency on legacy disk enumeration:

1. **Legacy `n1-standard-1` Disk Order**:
   - On `n1-standard-1`, GCE's legacy SCSI controller deterministically assigns `/dev/sda` to the primary boot disk across reboots. As a result, `preload.sh`, `vgpreload.sh`, and `fixup_oem.sh` hardcoded `/dev/sda12` (EFI System) and `/dev/sda8` (OEM).
2. **Multi-Queue SCSI Enumeration on `n2d-standard-2`**:
   - On `n2d-standard-2` (AMD EPYC), when `cos-customizer` attaches both the boot disk and an auxiliary seed/metadata disk (`cidata`), multi-queue SCSI enumeration assigns **`/dev/sdb`** to the boot disk after reboot (`Current root device is "/dev/sdb5"`). Consequently, hardcoded `/dev/sda12` and `/dev/sda8` mounts fail with `special device /dev/sda* does not exist` (causing `exit status 32` in `fixup_oem.sh`).

To eliminate this dependency and support any GCE machine shape, `preload.sh`, `vgpreload.sh`, and `fixup_oem.sh` are updated to dynamically resolve the boot disk block device using `rootdev -s -d` (e.g., `/dev/sdb` or `/dev/nvme0n1`), formatting partition paths accordingly (`/dev/sdb12`, `/dev/nvme0n1p12`).

### Solution

This PR explicitly configures `us-west1-a` across all Cloud Build image export and preloader customization steps (`launcher/cloudbuild.yaml`, `launcher/image/cloudbuild.yaml`, `launcher/image/bc_cloudbuild.yaml`) to route worker instances into a region with verified capacity (90%+ obtainability score for both `n2d-standard-2` and `n2-highcpu-4`). Additionally, `-machine-type=n2d-standard-2` is passed to `cos-customizer` to avoid legacy `n1-standard-1` pool exhaustion, and preloader customization scripts are updated to dynamically resolve the boot disk block device via `rootdev`.
