### PR TITLE
launcher: parallelize image exports with tests

### DIFF
--- a/launcher/cloudbuild.yaml
+++ b/launcher/cloudbuild.yaml
@@ -630,7 +630,7 @@ steps:
 
 - name: 'gcr.io/cloud-builders/gcloud'
   id: ExportHardenedImage
-  waitFor: ['HardenedImageTests']
+  waitFor: ['HardenedImageBuild']
   entrypoint: 'gcloud'
   args: ['compute', 'images', 'export',
          '--destination-uri=gs://${PROJECT_ID}_raw-images/${_OUTPUT_IMAGE_PREFIX}-hardened-${_OUTPUT_IMAGE_SUFFIX}.tar.gz',
@@ -640,7 +640,7 @@ steps:
 
 - name: 'gcr.io/cloud-builders/gcloud'
   id: ExportDebugImage
-  waitFor: ['DebugImageTests']
+  waitFor: ['DebugImageBuild']
   entrypoint: 'gcloud'
   args: ['compute', 'images', 'export',
           '--destination-uri=gs://${PROJECT_ID}_raw-images/${_OUTPUT_IMAGE_PREFIX}-debug-${_OUTPUT_IMAGE_SUFFIX}.tar.gz',
@@ -682,7 +682,7 @@ steps:
 
 - name: 'gcr.io/cloud-builders/gcloud'
   id: ExportVgHardenedImage
-  waitFor: ['HardenedVgImageBuild', 'KeymanagerTests']
+  waitFor: ['HardenedVgImageBuild']
   entrypoint: 'gcloud'
   args: ['compute', 'images', 'export',
          '--destination-uri=gs://${PROJECT_ID}_raw-images/${_OUTPUT_IMAGE_PREFIX}-vg-hardened-${_OUTPUT_IMAGE_SUFFIX}.tar.gz',
@@ -692,7 +692,7 @@ steps:
 
 - name: 'gcr.io/cloud-builders/gcloud'
   id: ExportVgDebugImage
-  waitFor: ['DebugVgImageBuild', 'KeymanagerTests']
+  waitFor: ['DebugVgImageBuild']
   entrypoint: 'gcloud'
   args: ['compute', 'images', 'export',
           '--destination-uri=gs://${PROJECT_ID}_raw-images/${_OUTPUT_IMAGE_PREFIX}-vg-debug-${_OUTPUT_IMAGE_SUFFIX}.tar.gz',


### PR DESCRIPTION
In `launcher/cloudbuild.yaml`, image export steps (`ExportHardenedImage`, `ExportDebugImage`, `ExportVgHardenedImage`, `ExportVgDebugImage`) and downstream PCR measurement steps were serialized behind integration test suites (e.g. `HardenedImageTests`, `DebugImageTests`).

Exporting a GCE image to GCS and calculating reference integrity measurements only requires the GCE image build step to finish; it has no functional dependency on whether integration test suites pass.

This change updates the `waitFor` configuration of all image export steps to depend directly on their respective image build steps (`HardenedImageBuild`, `DebugImageBuild`, `HardenedVgImageBuild`, `DebugVgImageBuild`).

This enables image exports and PCR measurements to execute in parallel alongside integration tests, cutting approximately 3.5 minutes of serialization latency from the `/gcbrun` critical path.