### PR TITLE
launcher: route customizer image builds to test pool

### DIFF
--- a/launcher/image/cloudbuild.yaml
+++ b/launcher/image/cloudbuild.yaml
@@ -45,4 +45,4 @@ timeout: '3000s'
 options:
   dynamic_substitutions: true
   pool:
-    name: 'projects/confidential-space-images-dev/locations/us-west1/workerPools/cs-image-build-vpc'
+    name: 'projects/confidential-space-images-dev/locations/us-west1/workerPools/cs-image-test-vpc'


### PR DESCRIPTION
In `launcher/image/cloudbuild.yaml`, child image build steps were routed to `cs-image-build-vpc` (which provisions `e2-standard-16` / 16 vCPU worker instances).

Because `cos-customizer` sub-builds only execute lightweight CLI commands that orchestrate GCE customization VMs via API calls and do not perform local compilation, allocating 16-vCPU workers across all 4 concurrent image builds consumed 64 vCPUs of build pool capacity.

This change routes `launcher/image/cloudbuild.yaml` to `cs-image-test-vpc` (which uses `e2-medium` / 1 vCPU workers), freeing 60 vCPUs in the build pool for compilation jobs without affecting image customization speed.