### PR TITLE
[launcher] Explicitly creating uvm device

### DIFF
--- a/launcher/image/bc-guest/bc_gpu_setup.sh
+++ b/launcher/image/bc-guest/bc_gpu_setup.sh
@@ -1,6 +1,10 @@
 #!/bin/bash
 set -euo pipefail
 
+NVIDIA_BIN_DIR="/opt/nvidia/595.58.03/bin"
+
+echo "modprobe nvidia modules" | tee /dev/console
+
 # Install gpu drivers
 modprobe nvidia
 modprobe nvidia-uvm
@@ -11,5 +15,12 @@ systemd-run -p Type=forking --unit=nvidia-persistenced-transient /opt/nvidia/595
 
 echo "Waiting 1 minute for nvidia-persistenced to initialize..." | tee /dev/console
 sleep 60s
+
+echo "run nvidia-modprobe -u -c 0" | tee /dev/console
+"${NVIDIA_BIN_DIR}/nvidia-modprobe" -u -c 0
+
+ls -a /dev/*nvidia* | tee /dev/console
+echo "run nvidia-smi" | tee /dev/console
+"${NVIDIA_BIN_DIR}/nvidia-smi" | tee /dev/console
 
 echo "GPU daemon ready" | tee /dev/console


### PR DESCRIPTION
It's possible nvidia-uvm is not created by just loading the module