### PR TITLE
bc: blacklist mlx5_core module

### DIFF
--- a/launcher/image/bc_cloudbuild.yaml
+++ b/launcher/image/bc_cloudbuild.yaml
@@ -155,10 +155,10 @@ steps:
           "s|systemd.mask=usr-share-oem.mount||g"
           "s|dm-m2d|dm-mod|g"
           "s|,oemroot|;oemroot|g"
+          "s|cros_efi|cros_efi module_blacklist=mlx5_core|g"
         )
 
         DEBUG_COMMANDS=(
-          "s|cros_efi|cros_efi systemd.mask=konlet-startup.service|g"
           "s|cros_efi|cros_efi systemd.mask=update-engine.service|g"
           "s|cros_efi|cros_efi confidential-space.hardened=false|g"
         )
@@ -177,7 +177,6 @@ steps:
           "s|cros_efi|cros_efi systemd.mask=google-osconfig-agent.service|g"
           "s|cros_efi|cros_efi systemd.mask=google-startup-scripts.service|g"
           "s|cros_efi|cros_efi systemd.mask=google-shutdown-scripts.service|g"
-          "s|cros_efi|cros_efi systemd.mask=konlet-startup.service|g"
           "s|cros_efi|cros_efi systemd.mask=crash-reporter.service|g"
           "s|cros_efi|cros_efi systemd.mask=device_policy_manager.service|g"
           "s|cros_efi|cros_efi systemd.mask=docker-events-collector-fluent-bit.service|g"


### PR DESCRIPTION
Also remove konlet mask from kernel command line to avoid going over the command line size limit. Konlet is not installed on these images, so that is unnecessary.