### PR TITLE
Fixing rust-toolchain pinning

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,7 +63,9 @@ jobs:
       - name: Install protoc-gen-go
         run: go install google.golang.org/protobuf/cmd/protoc-gen-go@v1.28.0
       - name: Setup Rust
-        uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable
+        uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # stable
+        with:
+          toolchain: stable
       - name: Install Build Dependencies (Linux)
         run: sudo apt-get update && sudo apt-get install -y cmake clang pkg-config libssl-dev
         if: runner.os == 'Linux' && matrix.architecture == 'x64'
@@ -138,7 +140,9 @@ jobs:
           go-version: ${{ matrix.go-version }}
           cache: false
       - name: Setup Rust
-        uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable
+        uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # stable
+        with:
+          toolchain: stable
       - name: Install Build Dependencies (Linux)
         run: sudo apt-get update && sudo apt-get install -y cmake clang pkg-config libssl-dev
       - name: Install bindgen-cli
@@ -184,7 +188,9 @@ jobs:
           go-version: ${{ matrix.go-version }}
           cache: false
       - name: Setup Rust
-        uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable
+        uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # stable
+        with:
+          toolchain: stable
       - name: Install Build Dependencies (Linux)
         run: sudo apt-get update && sudo apt-get install -y cmake clang pkg-config libssl-dev
       - name: Install bindgen-cli


### PR DESCRIPTION
The previous SHA https://github.com/dtolnay/rust-toolchain/commit/4cda84d5c5c54efe2404f9d843567869ab1699d4 has been removed.  
According to their documentation, commits that are not in the master branch history eventually get garbage-collected.

This PR updates the action to use the latest SHA (https://github.com/dtolnay/rust-toolchain/commit/6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772) from the `master` branch as [they recommend](https://github.com/dtolnay/rust-toolchain#choice-of-full-length-commit-sha).

Because newer versions of this action require the toolchain version to be explicitly defined when pinning by a commit SHA, I have also added `toolchain: stable` to the action configurations.