### PR TITLE
launcher: extract KeyManager server from runner

### DIFF
--- a/launcher/container_runner.go
+++ b/launcher/container_runner.go
@@ -30,7 +30,6 @@ import (
 	"github.com/google/go-tpm-tools/agent"
 	"github.com/google/go-tpm-tools/agent/device"
 	"github.com/google/go-tpm-tools/cel"
-	keymanager "github.com/google/go-tpm-tools/keymanager/km_common/proto"
 	workloadservice "github.com/google/go-tpm-tools/keymanager/workload_service"
 	"github.com/google/go-tpm-tools/launcher/internal/healthmonitoring/nodeproblemdetector"
 	"github.com/google/go-tpm-tools/launcher/internal/logging"
@@ -56,12 +55,12 @@ type ContainerRunner struct {
 	serialConsole    *os.File
 	powerButton      *powerButtonListener // Populated only for a hardened image
 	attestClients    teeserver.AttestClients
+	workloadService  *workloadservice.Server
 }
 
 const tokenFileTmp = ".token.tmp"
 
 const teeServerSocket = "teeserver.sock"
-const keyManagerSocket = "kmaserver.sock"
 const keyManagerGrpcSocket = "kmaserver-grpc.sock"
 
 // Since we only allow one container on a VM, using a deterministic id is probably fine
@@ -103,6 +102,7 @@ type RunnerConfig struct {
 	AttestAgent      agent.AttestationAgent
 	DeviceROTManager *device.ROTManager
 	AttestClients    teeserver.AttestClients
+	WorkloadService  *workloadservice.Server
 	LaunchSpec       spec.LaunchSpec
 	Logger           logging.Logger
 	WorkloadLogger   logging.Logger
@@ -233,15 +233,16 @@ func NewRunner(ctx context.Context, cfg *RunnerConfig) (*ContainerRunner, error)
 	}
 
 	return &ContainerRunner{
-		container,
-		launchSpec,
-		attestAgent,
-		logger,
-		workloadLogger,
-		cfg.DeviceROTManager,
-		serialConsole,
-		powerButton,
-		cfg.AttestClients,
+		container:        container,
+		launchSpec:       launchSpec,
+		attestAgent:      attestAgent,
+		logger:           logger,
+		workloadLogger:   workloadLogger,
+		deviceROTManager: cfg.DeviceROTManager,
+		serialConsole:    serialConsole,
+		powerButton:      powerButton,
+		attestClients:    cfg.AttestClients,
+		workloadService:  cfg.WorkloadService,
 	}, nil
 }
 
@@ -608,26 +609,8 @@ func (r *ContainerRunner) Run(ctx context.Context) error {
 	// create and start the TEE server
 	r.logger.Info("EnableOnDemandAttestation is enabled: initializing TEE server.")
 
-	var workloadService *workloadservice.Server
-	// create and start the key manager server
-	if r.launchSpec.Experiments.EnableKeyManager {
-		r.logger.Info("EnableKeyManager experiment is enabled: initializing KeyManager server.")
-		keyManagerSocketPath := path.Join(launcherfile.HostTmpPath, keyManagerSocket)
-		keyManagerServer, err := workloadservice.New(ctx, keyManagerSocketPath, keymanager.KeyProtectionMechanism_KEY_PROTECTION_VM_EMULATED)
-
-		if err != nil {
-			return fmt.Errorf("failed to create the KeyManager server: %v", err)
-		}
-		if err := verifySocketPermissions(keyManagerSocketPath); err != nil {
-			return fmt.Errorf("failed to verify KeyManager socket permissions: %w", err)
-		}
-		workloadService = keyManagerServer
-		go func() { _ = keyManagerServer.Serve() }()
-		defer func() { _ = keyManagerServer.Shutdown(ctx) }()
-	}
-
 	teeServerSocketPath := path.Join(launcherfile.HostTmpPath, teeServerSocket)
-	teeServer, err := teeserver.New(ctx, teeServerSocketPath, r.attestAgent, r.logger, r.launchSpec, r.attestClients, workloadService)
+	teeServer, err := teeserver.New(ctx, teeServerSocketPath, r.attestAgent, r.logger, r.launchSpec, r.attestClients, r.workloadService)
 	if err != nil {
 		return fmt.Errorf("failed to create the TEE server: %v", err)
 	}
@@ -847,15 +830,4 @@ func (r *ContainerRunner) Close(ctx context.Context) {
 	// Delete container and close connection to attestation service.
 	// TODO: consider handling or logging cleanup error.
 	_ = r.container.Delete(ctx, containerd.WithSnapshotCleanup)
-}
-
-func verifySocketPermissions(socketPath string) error {
-	info, err := os.Stat(socketPath)
-	if err != nil {
-		return fmt.Errorf("failed to stat socket: %w", err)
-	}
-	if perm := info.Mode().Perm(); perm != 0777 {
-		return fmt.Errorf("socket %s has permissions %04o, want 0777", socketPath, perm)
-	}
-	return nil
 }

--- a/launcher/start.go
+++ b/launcher/start.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"net/http"
 	"os"
+	"path"
 
 	"cloud.google.com/go/compute/metadata"
 	"cos.googlesource.com/cos/tools.git/src/cmd/cos_gpu_installer/deviceinfo"
@@ -16,8 +17,10 @@ import (
 	"github.com/google/go-tpm-tools/agent"
 	"github.com/google/go-tpm-tools/agent/device"
 	"github.com/google/go-tpm-tools/client"
+	workloadservice "github.com/google/go-tpm-tools/keymanager/workload_service"
 	"github.com/google/go-tpm-tools/launcher/internal/gpu"
 	"github.com/google/go-tpm-tools/launcher/internal/logging"
+	"github.com/google/go-tpm-tools/launcher/launcherfile"
 	"github.com/google/go-tpm-tools/launcher/registryauth"
 	"github.com/google/go-tpm-tools/launcher/spec"
 	"github.com/google/go-tpm-tools/launcher/teeserver"
@@ -27,7 +30,11 @@ import (
 	"github.com/google/go-tpm-tools/verifier/util"
 	"github.com/google/go-tpm/legacy/tpm2"
 	"google.golang.org/api/option"
+
+	kmcommonpb "github.com/google/go-tpm-tools/keymanager/km_common/proto"
 )
+
+const keyManagerSocket = "kmaserver.sock"
 
 var expectedTPMDAParams = TPMDAParams{
 	MaxTries:        0x20,    // 32 tries
@@ -138,12 +145,29 @@ func StartLauncher(ctx context.Context, launchSpec spec.LaunchSpec, logger loggi
 		return err
 	}
 
+	var workloadService *workloadservice.Server
+	if launchSpec.Experiments.EnableKeyManager {
+		logger.Info("EnableKeyManager experiment is enabled: initializing KeyManager server.")
+		keyManagerSocketPath := path.Join(launcherfile.HostTmpPath, keyManagerSocket)
+		keyManagerServer, err := workloadservice.New(ctx, keyManagerSocketPath, kmcommonpb.KeyProtectionMechanism_KEY_PROTECTION_VM_EMULATED)
+		if err != nil {
+			return fmt.Errorf("failed to create the KeyManager server: %v", err)
+		}
+		if err := verifySocketPermissions(keyManagerSocketPath); err != nil {
+			return fmt.Errorf("failed to verify KeyManager socket permissions: %w", err)
+		}
+		workloadService = keyManagerServer
+		go func() { _ = keyManagerServer.Serve() }()
+		defer func() { _ = keyManagerServer.Shutdown(ctx) }()
+	}
+
 	r, err := NewRunner(ctx, &RunnerConfig{
 		ContainerdClient: containerdClient,
 		Image:            image,
 		AttestAgent:      attestAgent,
 		DeviceROTManager: deviceROTManager,
 		AttestClients:    attestClients,
+		WorkloadService:  workloadService,
 		LaunchSpec:       launchSpec,
 		Logger:           logger,
 		WorkloadLogger:   workloadLogger,
@@ -242,4 +266,15 @@ func createAttestClients(ctx context.Context, launchSpec spec.LaunchSpec, logger
 	}
 	attestClients.GCA = gcaClient
 	return attestClients, nil
+}
+
+func verifySocketPermissions(socketPath string) error {
+	info, err := os.Stat(socketPath)
+	if err != nil {
+		return fmt.Errorf("failed to stat socket: %w", err)
+	}
+	if perm := info.Mode().Perm(); perm != 0777 {
+		return fmt.Errorf("socket %s has permissions %04o, want 0777", socketPath, perm)
+	}
+	return nil
 }

--- a/launcher/start_test.go
+++ b/launcher/start_test.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path"
 	"strings"
 	"testing"
 
@@ -149,6 +151,43 @@ func TestCreateAttestClients_Behaviors(t *testing.T) {
 			}
 			if tc.wantITANotNil && clients.ITA == nil {
 				t.Error("expected ITA client to be non-nil")
+			}
+		})
+	}
+}
+
+func TestVerifySocketPermissions(t *testing.T) {
+	tests := []struct {
+		name    string
+		mode    os.FileMode
+		wantErr bool
+	}{
+		{
+			name:    "valid 0777 permissions",
+			mode:    0777,
+			wantErr: false,
+		},
+		{
+			name:    "invalid 0644 permissions",
+			mode:    0644,
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			tmpDir := t.TempDir()
+			sockPath := path.Join(tmpDir, "test.sock")
+			if err := os.WriteFile(sockPath, []byte(""), tc.mode); err != nil {
+				t.Fatalf("failed to create test file: %v", err)
+			}
+			if err := os.Chmod(sockPath, tc.mode); err != nil {
+				t.Fatalf("failed to chmod test file: %v", err)
+			}
+
+			err := verifySocketPermissions(sockPath)
+			if (err != nil) != tc.wantErr {
+				t.Errorf("verifySocketPermissions(%q) error = %v, wantErr = %v", sockPath, err, tc.wantErr)
 			}
 		})
 	}


### PR DESCRIPTION
# launcher: extract KeyManager server from runner

## Overview

This PR refactors the initialization and lifecycle management of the `KeyManager` workload service daemon by extracting it from `ContainerRunner.Run` and lifting it into `StartLauncher` (`launcher/start.go`). The initialized service instance is now passed via dependency injection through `RunnerConfig` into `ContainerRunner`.

---

## Why

1. **Separation of Concerns & Orchestration**:
   The `KeyManager` server is a host-level background service providing key management across the environment. `ContainerRunner` is responsible for container execution and workload monitoring. Coupling daemon socket creation, permission verification, and the background serving loop directly inside `ContainerRunner.Run` mixed host infrastructure setup with container execution logic.

2. **Decoupled Lifecycle & Resource Scoping**:
   By managing the `KeyManager` daemon at the `StartLauncher` layer, its lifecycle is cleanly scoped to the overall launcher process. Deferred shutdown (`Shutdown(ctx)`) is tied to launcher completion rather than the internal execution flow of a container run, making resource management explicit and predictable.

3. **Improved Testability & Dependency Injection**:
   Lifting `workloadservice.Server` into `RunnerConfig` follows the dependency injection pattern used for other launcher dependencies (such as `AttestAgent`, `DeviceROTManager`, and `AttestClients`). This simplifies `ContainerRunner`, removes hidden side effects from `Run()`, and enables easier unit testing with mock services.

---

## What Changed

- **Extracted KeyManager Setup to `StartLauncher`**: Moved `workloadservice.New`, socket permission validation, asynchronous `Serve()`, and deferred `Shutdown()` into `StartLauncher`.
- **Dependency Injection via `RunnerConfig`**: Added `WorkloadService` to `RunnerConfig` and `ContainerRunner`, wiring the configured service directly into `teeserver.New`.
- **Socket Permissions Verification**: Relocated `verifySocketPermissions` helper to `launcher/start.go` alongside socket configuration constants.
- **Unit Testing**: Added `TestVerifySocketPermissions` in `launcher/start_test.go`.

---

## Lifecycle Flow

```mermaid
sequenceDiagram
    autonumber
    participant SL as StartLauncher
    participant KM as KeyManager Server
    participant RC as RunnerConfig
    participant CR as ContainerRunner
    participant TS as TEE Server
    participant CW as Workload Container

    Note over SL,CW: Initialization & Dependency Injection
    SL->>SL: Evaluate LaunchSpec Experiments
    alt EnableKeyManager is enabled
        SL->>KM: workloadservice.New(keyManagerSocketPath)
        SL->>KM: verifySocketPermissions()
        SL->>KM: go Serve() (Background Daemon)
        Note over SL: defer Shutdown(ctx)
    end

    SL->>RC: Populate RunnerConfig(WorkloadService, ...)
    SL->>CR: NewRunner(ctx, cfg)

    Note over SL,CW: Workload Execution
    SL->>CR: Run(ctx)
    CR->>TS: teeserver.New(..., r.workloadService)
    CR->>CW: Launch & Monitor Container Workload
    CW-->>CR: Container Exits

    Note over SL,CW: Teardown
    CR-->>SL: Run(ctx) returns
    alt EnableKeyManager was enabled
        SL->>KM: defer: Shutdown(ctx)
    end
```