### PR TITLE
launcher/test: check VM status on empty serial

### DIFF
--- a/launcher/image/test/util/read_serial.sh
+++ b/launcher/image/test/util/read_serial.sh
@@ -19,7 +19,13 @@ read_serial() {
       start_offset=$(printf '%s' "$resp" | python3 -c "import sys, json; print(json.load(sys.stdin).get('next', '0'))")
       serial_out="${serial_out}${chunk}"
     else
-      >&2 echo "Empty response from get-serial-port-output for ${vm} (instance not ready or stopped)."
+      local status
+      status=$(gcloud compute instances describe "$vm" --zone="$zone" --format="value(status)")
+      if [[ "$status" == "TERMINATED" || "$status" == "STOPPING" ]]; then
+        >&2 echo "Instance ${vm} is ${status,,}."
+        break
+      fi
+      >&2 echo "Empty response from get-serial-port-output for ${vm} (instance status: ${status})."
     fi
 
     if [[ "$serial_out" == *"TEE container launcher exiting"* ]]; then


### PR DESCRIPTION
## Overview
Check instance status when serial output is empty to stop waiting on finished VMs.

## Why
When tests check serial logs on an already-terminated VM, empty responses previously caused the test to wait for the full 10-minute timeout. Checking the VM status prevents 30 minutes of idle timeouts in hardened image test suites.

## What Changed
When serial output is empty, check if the instance is terminated and exit early.
