### PR TITLE
launcher: test launch policies in runner

### DIFF
--- a/launcher/container_runner_test.go
+++ b/launcher/container_runner_test.go
@@ -968,13 +968,16 @@ func TestNewRunner(t *testing.T) {
 	}
 
 	testCases := []struct {
-		name          string
-		imageLabels   map[string]string
-		envs          []spec.EnvVar
-		cmd           []string
-		wantErr       bool
-		wantErrSubstr string
-		verifyLogs    func(t *testing.T, logs []string)
+		name            string
+		imageLabels     map[string]string
+		envs            []spec.EnvVar
+		cmd             []string
+		emptyEntrypoint bool
+		logRedirect     spec.LogRedirectLocation
+		hardened        bool
+		wantErr         bool
+		wantErrSubstr   string
+		verifyLogs      func(t *testing.T, logs []string)
 	}{
 		{
 			name: "Success_RedactEnvs",
@@ -1023,6 +1026,62 @@ func TestNewRunner(t *testing.T) {
 			wantErr:       true,
 			wantErrSubstr: "CMD is not allowed to be overridden",
 		},
+		{
+			name: "Success_LaunchPolicyCmdAllowed",
+			imageLabels: map[string]string{
+				"tee.launch_policy.allow_cmd_override": "true",
+			},
+			cmd:     []string{"/override-cmd"},
+			wantErr: false,
+		},
+		{
+			name: "Success_LogRedirectAlways",
+			imageLabels: map[string]string{
+				"tee.launch_policy.log_redirect": "always",
+			},
+			logRedirect: spec.Everywhere,
+			hardened:    true,
+			wantErr:     false,
+		},
+		{
+			name: "Failure_LogRedirectNever",
+			imageLabels: map[string]string{
+				"tee.launch_policy.log_redirect": "never",
+			},
+			logRedirect:   spec.Everywhere,
+			hardened:      true,
+			wantErr:       true,
+			wantErrSubstr: "logging redirection not allowed by image",
+		},
+		{
+			name: "Success_LogRedirectDebugOnly_DebugImage",
+			imageLabels: map[string]string{
+				"tee.launch_policy.log_redirect": "debugonly",
+			},
+			logRedirect: spec.Everywhere,
+			hardened:    false,
+			wantErr:     false,
+		},
+		{
+			name: "Failure_LogRedirectDebugOnly_HardenedImage",
+			imageLabels: map[string]string{
+				"tee.launch_policy.log_redirect": "debugonly",
+			},
+			logRedirect:   spec.Everywhere,
+			hardened:      true,
+			wantErr:       true,
+			wantErrSubstr: "logging redirection only allowed on debug environment by image",
+		},
+		{
+			name: "Failure_EmptyEntrypoint",
+			imageLabels: map[string]string{
+				"tee.launch_policy.allow_cmd_override": "true",
+			},
+			cmd:             []string{"arg1"},
+			emptyEntrypoint: true,
+			wantErr:         true,
+			wantErrSubstr:   "is shorter or equal to the length of the given Cmd",
+		},
 	}
 
 	for _, tc := range testCases {
@@ -1033,8 +1092,12 @@ func TestNewRunner(t *testing.T) {
 				id:           "sha256:1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
 				contentStore: &fakeContentStore{blob: imageConfigJSON(tc.imageLabels)},
 			}
+			containerArgs := append([]string{"/entrypoint.sh"}, tc.cmd...)
+			if tc.emptyEntrypoint {
+				containerArgs = tc.cmd
+			}
 			fakeCont := &fakeContainer{
-				args: []string{"/entrypoint.sh", "arg1"},
+				args: containerArgs,
 			}
 			fakeCli := &fakeContainerdClient{
 				pullResult: fakeImg,
@@ -1052,6 +1115,8 @@ func TestNewRunner(t *testing.T) {
 					ImageRef:            "test-image",
 					Envs:                tc.envs,
 					Cmd:                 tc.cmd,
+					LogRedirect:         tc.logRedirect,
+					Hardened:            tc.hardened,
 					FakeVerifierEnabled: true,
 				},
 				Logger:         logger,


### PR DESCRIPTION
## Overview

Adds unit test coverage for container runner initialization, specifically validating launch policy enforcement (allowed command overrides, log redirection constraints) and entrypoint length assertions.

## Why

Container runner initialization enforces image author constraints defined in container image labels (`tee.launch_policy.*`) against operator-provided launch specifications (`tee-cmd`, `tee-container-log-redirect`, and image security mode).

Previously, these policies were only validated through full GCE virtual machine integration tests in `test_launchpolicy_cloudbuild.yaml` (`LaunchPolicyTests`). While `LaunchPolicy.Verify` had unit test coverage in isolation, the container runner initialization pipeline lacked unit test coverage for allowed command overrides, entrypoint length safety checks, and log redirection policies across debug and hardened modes.

Adding fast, in-memory unit tests in the container runner test suite ensures these policy invariants and safety assertions are verified hermetically before initiating workload execution.

```mermaid
flowchart TD
    A[containerd Image Config / Labels] --> B[Parse LaunchPolicy]
    C[LaunchSpec / Metadata Overrides] --> D[ContainerRunner Initialization]
    B --> D
    D --> E{Verify LaunchPolicy}
    E -->|CMD Override Disallowed| F[Reject Runner Construction]
    E -->|Log Redirect Violates Policy| F
    E -->|Container Args <= Cmd Length| F
    E -->|Policies & Entrypoint Valid| G[Create ContainerRunner Successfully]
```

## What Changed

- **Command Override Validation:** Added test coverage asserting that container runner initialization succeeds when command overrides are explicitly permitted by the image policy.
- **Entrypoint Safety Bounds:** Added test coverage verifying that container runner initialization fails if container process arguments are shorter than or equal to the overridden command, ensuring entrypoint binaries cannot be inadvertently stripped.
- **Log Redirection Rules:** Added test cases covering log redirection policies (`always`, `never`, `debugonly`) evaluated against both debug and hardened execution environments.
- **Test Harness Extensions:** Parameterized custom container process arguments, log redirection locations, and hardened image flags within the runner test suite.