### PR TITLE
Disable NVMe module in guest image

### DIFF
--- a/launcher/image/bc_cloudbuild.yaml
+++ b/launcher/image/bc_cloudbuild.yaml
@@ -158,6 +158,7 @@ steps:
           "s|,oemroot|;oemroot|g"
           "s|cros_efi|cros_efi module_blacklist=mlx5_core|g"
           "s|cros_efi|cros_efi systemd.mask=get-cloud-api-domains.service|g"
+          "s|cros_efi|cros_efi initcall_blacklist=nvme_init,nvme_core_init|g"
         )
 
         DEBUG_COMMANDS=(


### PR DESCRIPTION
Disable NVMe module in guest image

Description: This commit implements a defense-in-depth security measure by explicitly disabling the nvme storage module within the guest image's kernel utilizing an initialization blocklist via kernel boot parameters (initcall_blacklist=nvme_init,nvme_core_init). This restricts untrusted NVMe interactions from the guest.

Changes:

Appended initcall_blacklist=nvme_init,nvme_core_init to COMMON_COMMANDS in launcher/image/build_bc_standalone.yaml utilized during oem-preloader image expansion.

Bug: [b/544999684](http://b/544999684)