### PR TITLE
launcher: prune redundant fakeverifier test steps

### DIFF
--- a/launcher/cloudbuild.yaml
+++ b/launcher/cloudbuild.yaml
@@ -340,35 +340,6 @@ steps:
         }
       }'
 
-- name: 'gcr.io/cloud-builders/gcloud'
-  id: ExperimentsTests
-  waitFor: ['DebugImageBuild']
-  env:
-  - 'OUTPUT_IMAGE_NAME=${_OUTPUT_IMAGE_PREFIX}-debug-${_OUTPUT_IMAGE_SUFFIX}'
-  - 'PROJECT_ID=$PROJECT_ID'
-  script: |
-    #!/usr/bin/env bash
-
-    cd launcher/image/test
-    echo "running experiments client tests on ${OUTPUT_IMAGE_NAME}"
-    gcloud builds submit --polling-interval=$_POLLING_INTERVAL --config=test_experiments_client.yaml --region us-west1 \
-      --substitutions _IMAGE_NAME=${OUTPUT_IMAGE_NAME},_IMAGE_PROJECT=${PROJECT_ID}
-    exit
-
-- name: 'gcr.io/cloud-builders/gcloud'
-  id: HttpServerTests
-  waitFor: ['DebugImageBuild']
-  env:
-  - 'OUTPUT_IMAGE_NAME=${_OUTPUT_IMAGE_PREFIX}-debug-${_OUTPUT_IMAGE_SUFFIX}'
-  - 'PROJECT_ID=$PROJECT_ID'
-  script: |
-    #!/usr/bin/env bash
-
-    cd launcher/image/test
-    echo "running http server tests on ${OUTPUT_IMAGE_NAME}"
-    gcloud builds submit --polling-interval=$_POLLING_INTERVAL --config=test_http_server.yaml --region us-west1 \
-      --substitutions _IMAGE_NAME=${OUTPUT_IMAGE_NAME},_IMAGE_PROJECT=${PROJECT_ID}
-    exit
 
 - name: 'gcr.io/cloud-builders/gcloud'
   id: KeymanagerTests
@@ -476,20 +447,6 @@ steps:
       --substitutions _CC=TDX,_IMAGE_NAME=${OUTPUT_IMAGE_NAME},_IMAGE_PROJECT=${PROJECT_ID}
     exit
 
-- name: 'gcr.io/cloud-builders/gcloud'
-  id: LaunchPolicyTests
-  waitFor: ['HardenedImageBuild']
-  env:
-  - 'OUTPUT_IMAGE_NAME=${_OUTPUT_IMAGE_PREFIX}-hardened-${_OUTPUT_IMAGE_SUFFIX}'
-  - 'PROJECT_ID=$PROJECT_ID'
-  script: |
-    #!/usr/bin/env bash
-
-    cd launcher/image/test
-    echo "running launch policy tests on ${OUTPUT_IMAGE_NAME}"
-    gcloud builds submit --polling-interval=$_POLLING_INTERVAL --config=test_launchpolicy_cloudbuild.yaml --region us-west1 \
-      --substitutions _HARDENED_IMAGE_NAME=${OUTPUT_IMAGE_NAME},_IMAGE_PROJECT=${PROJECT_ID}
-    exit
 
 - name: 'gcr.io/cloud-builders/gcloud'
   id: HardenedNetworkIngressTests
@@ -519,20 +476,6 @@ steps:
       --substitutions _IMAGE_NAME=${OUTPUT_IMAGE_NAME},_IMAGE_PROJECT=${PROJECT_ID}
     exit
 
-- name: 'gcr.io/cloud-builders/gcloud'
-  id: LogRedirectionTests
-  waitFor: ['HardenedImageBuild']
-  env:
-  - 'OUTPUT_IMAGE_NAME=${_OUTPUT_IMAGE_PREFIX}-hardened-${_OUTPUT_IMAGE_SUFFIX}'
-  - 'PROJECT_ID=$PROJECT_ID'
-  script: |
-    #!/usr/bin/env bash
-
-    cd launcher/image/test
-    echo "running log redirection tests on ${OUTPUT_IMAGE_NAME}"
-    gcloud builds submit --polling-interval=$_POLLING_INTERVAL --config=test_log_redirection.yaml --region us-west1 \
-      --substitutions _HARDENED_IMAGE_NAME=${OUTPUT_IMAGE_NAME},_IMAGE_PROJECT=${PROJECT_ID}
-    exit
 
 - name: 'gcr.io/cloud-builders/gcloud'
   id: HardenedDiscoverContainerSignatureTests
@@ -604,21 +547,6 @@ steps:
       --substitutions _IMAGE_NAME=${OUTPUT_IMAGE_NAME},_IMAGE_PROJECT=${PROJECT_ID}
     exit
 
-- name: 'gcr.io/cloud-builders/gcloud'
-  id: MountTests
-  waitFor: ['HardenedImageBuild']
-  env:
-  - 'OUTPUT_IMAGE_NAME=${_OUTPUT_IMAGE_PREFIX}-hardened-${_OUTPUT_IMAGE_SUFFIX}'
-  - 'PROJECT_ID=$PROJECT_ID'
-  script: |
-    #!/usr/bin/env bash
-    cd launcher/image/test
-    dev_shm_size_kb=$(shuf -i 70000-256000 -n 1)
-    tmpfs_size_kb=$(shuf -i 256-256000 -n 1)
-    echo "running mount tests on ${OUTPUT_IMAGE_NAME}"
-    gcloud builds submit --polling-interval=$_POLLING_INTERVAL --config=test_mounts.yaml --region us-west1 \
-      --substitutions _IMAGE_NAME=${OUTPUT_IMAGE_NAME},_IMAGE_PROJECT=${PROJECT_ID}
-    exit
 
 - name: 'gcr.io/cloud-builders/gcloud'
   id: GpuDriverInstallationHardenedImageTests


### PR DESCRIPTION
## Overview

This PR removes five redundant integration test suites from [`launcher/cloudbuild.yaml`](file:///launcher/cloudbuild.yaml) (`ExperimentsTests`, `HttpServerTests`, `LaunchPolicyTests`, `LogRedirectionTests`, and `MountTests`). The policy validation and configuration parsing previously exercised by these suites are now fully covered by in-memory Go unit tests, saving 11 VM provisions per presubmit run while preserving comprehensive test coverage.

## Why

The removed integration test suites spun up nested Confidential Space VMs against `fakeverifier` purely to assert input metadata permutations—such as whether overriding `Cmd` or requesting `log_redirect` fails when disallowed by image labels, or whether `/dev/shm` and `tmpfs` mounts are created with requested sizes.

Running these permutations through full VM provisioning cycles added significant presubmit quota overhead and failure points without testing hypervisor- or hardware-specific behavior.

### Testing Strategy & Safety Invariants

1. **Combinatorial Coverage via Unit Tests:**
   The full matrix of launch policy overrides (`allow_cmd_override`, regex environment variable filtering, `log_redirect` options `always`/`never`/`debugonly`, empty entrypoints, and mount specifications) is exhaustively tested in microseconds via in-memory unit tests in [`launcher/container_runner_test.go`](file:///launcher/container_runner_test.go) and [`launcher/spec/launch_policy_test.go`](file:///launcher/spec/launch_policy_test.go).

2. **Representative End-to-End Rejection Preserved:**
   VM-level enforcement of invalid metadata flags remains actively verified by [`PrivilegedTests`](file:///launcher/image/test/test_privileged.yaml). Steps `CheckCgroupDenied` and `CheckCapsDenied` boot actual compute instances with unauthorized metadata (`tee-cgroup-ns=true` and `tee-added-capabilities=["CAP_SYS_ADMIN"]`), asserting that the launcher rejects invalid configurations and terminates before workload execution.

3. **End-to-End Success Path Preserved:**
   [`DebugImageTests`](file:///launcher/image/test/test_debug_cloudbuild.yaml), [`HardenedImageTests`](file:///launcher/image/test/test_hardened_cloudbuild.yaml), and the attestation suites continue to validate the complete runtime initialization pipeline on real GCE instances.

```mermaid
flowchart TD
    subgraph LocalUnitTests ["Fast In-Memory Unit Tests"]
        UT1["Launch Policy Matrix (Cmd, Env, LogRedirect)"]
        UT2["OCI Spec Setup (/dev/shm, tmpfs)"]
        UT3["Server Decoupling & Socket Permissions"]
    end

    subgraph IntegrationTests ["Real VM Integration Tests"]
        IT1["PrivilegedTests: Real VM Policy Rejection (Cgroups, Caps)"]
        IT2["DebugImageTests & HardenedImageTests: Real VM End-to-End Boot"]
        IT3["RealGCA / RealITA: Live Attestation Verification"]
    end

    UT1 --> Engine["ContainerRunner Core"]
    UT2 --> Engine
    UT3 --> Engine
    IT1 --> Engine
    IT2 --> Engine
    IT3 --> Engine
```

## What Changed

- **Pruned Redundant Presubmit Steps:** Removed `ExperimentsTests`, `HttpServerTests`, `LaunchPolicyTests`, `LogRedirectionTests`, and `MountTests` from [`launcher/cloudbuild.yaml`](file:///launcher/cloudbuild.yaml).
- **Reduced Resource Overhead:** Eliminated 11 redundant VM provisioning cycles per presubmit build.
- **Maintained Pipeline Integrity:** Kept all image export, attestation, and representative policy rejection test steps intact.
