### PR TITLE
releaser: fix dtolnay/rust-toolchain commit SHA

### DIFF
--- a/.github/workflows/releaser.yaml
+++ b/.github/workflows/releaser.yaml
@@ -51,7 +51,7 @@ jobs:
         run: sudo apt-get update && sudo apt-get -y install libssl-dev cmake clang pkg-config
         if: runner.os == 'Linux'
       - name: Setup Rust
-        uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable
+        uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # stable
       - name: Install bindgen-cli
         run: cargo install bindgen-cli
         if: runner.os == 'Linux'


### PR DESCRIPTION
## Overview

Update the `dtolnay/rust-toolchain` commit SHA pin in `.github/workflows/releaser.yaml` to match the valid SHA used in `ci.yml`.

## Why

In [#915](https://github.com/google/go-tpm-tools/pull/915), `dtolnay/rust-toolchain` was pinned to valid commit `6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772` across all three jobs in `ci.yml` (lines 66, 143, 191), but was mistakenly pinned to `4cda84d5c5c54efe2404f9d843567869ab1699d4` in `releaser.yaml` (line 54).

Because `4cda84d...` does not exist in `dtolnay/rust-toolchain`'s upstream git history, the `zizmor` security scanner flags it as an `impostor-commit` violation and fails any workflow scan on `releaser.yaml`.

Updating `releaser.yaml` to `6c977a6...` makes all 4 toolchain declarations consistent across the repo and resolves the `zizmor` security check.