### PR TITLE
Change GetCertificateChain to GetAKIntermediateCerts in cert.go

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -344,7 +344,7 @@ func (a *agent) AttestWithClient(ctx context.Context, opts AttestAgentOpts, clie
 
 		v.CanonicalEventLog = cosCel.Bytes()
 
-		certChain, err := internal.GetCertificateChain(a.fetchedAK.Cert(), http.DefaultClient)
+		certChain, err := internal.GetAKIntermediateCerts(a.fetchedAK.Cert(), http.DefaultClient)
 		if err != nil {
 			return nil, fmt.Errorf("failed when fetching certificate chain: %w", err)
 		}

--- a/client/attest.go
+++ b/client/attest.go
@@ -313,7 +313,7 @@ func (k *Key) Attest(opts AttestOpts) (*pb.Attestation, error) {
 	// Attempt to construct certificate chain. fetchIssuingCertificate checks if
 	// AK cert is present and contains intermediate cert URLs.
 	if opts.CertChainFetcher != nil {
-		attestation.IntermediateCerts, err = internal.GetCertificateChain(k.cert, opts.CertChainFetcher)
+		attestation.IntermediateCerts, err = internal.GetAKIntermediateCerts(k.cert, opts.CertChainFetcher)
 		if err != nil {
 			return nil, fmt.Errorf("fetching certificate chain: %w", err)
 		}

--- a/client/attest_network_test.go
+++ b/client/attest_network_test.go
@@ -25,7 +25,7 @@ func TestNetworkFetchIssuingCertificate(t *testing.T) {
 		t.Fatalf("Error parsing AK Cert: %v", err)
 	}
 
-	certChain, err := internal.GetCertificateChain(akCert, externalClient)
+	certChain, err := internal.GetAKIntermediateCerts(akCert, externalClient)
 	if err != nil {
 		t.Error(err)
 	}

--- a/internal/cert.go
+++ b/internal/cert.go
@@ -1,6 +1,7 @@
 package internal
 
 import (
+	"bytes"
 	"crypto/x509"
 	"fmt"
 	"io"
@@ -12,12 +13,39 @@ const (
 	maxCertChainLength        = 4
 )
 
-// GetCertificateChain constructs the certificate chain for the key's certificate.
-// If an error is encountered in the process, return what has been constructed so far.
-func GetCertificateChain(cert *x509.Certificate, client *http.Client) ([][]byte, error) {
+var knownRootKeyIDs = [][]byte{
+	// tpm_ek_root_1.cer
+	{0x65, 0xF4, 0xE4, 0xE6, 0xAA, 0xF6, 0xFD, 0x5A, 0xD2, 0x88, 0x9C, 0xA8, 0x53, 0x55, 0xF7, 0x00, 0x8E, 0x08, 0xF7, 0xA5},
+	// gcp_ek_ak_ca_root.crt (Cloud CAS)
+	{0x49, 0xE7, 0x4A, 0x5B, 0x56, 0x29, 0xF5, 0x9D, 0x79, 0xB7, 0xA6, 0x30, 0x3C, 0x03, 0xB2, 0x8F, 0xE7, 0x14, 0xDD, 0x4C},
+}
+
+// isIssuedByKnownRoot checks if the certificate was signed by a known Google Root CA
+// using the AuthorityKeyId extension.
+func isIssuedByKnownRoot(cert *x509.Certificate) bool {
+	if cert == nil || len(cert.AuthorityKeyId) == 0 {
+		return false
+	}
+	for _, rootKeyID := range knownRootKeyIDs {
+		if bytes.Equal(cert.AuthorityKeyId, rootKeyID) {
+			return true
+		}
+	}
+	return false
+}
+
+// GetAKIntermediateCerts constructs the AK's intermediate certificate chain.
+// If an error is encountered in the process, return a nil slice and the error.
+// Stops before fetching the root certificate to avoid depending on the Root CA's
+// region being available in the CS Client (since GCA separately gets the root
+// certificate for verification).
+func GetAKIntermediateCerts(cert *x509.Certificate, client *http.Client) ([][]byte, error) {
 	var certs [][]byte
 	currentCert := cert
 	for len(certs) <= maxCertChainLength {
+		if isIssuedByKnownRoot(currentCert) {
+			return certs, nil
+		}
 		issuingCert, err := fetchIssuingCertificate(client, currentCert)
 		if err != nil {
 			return nil, err

--- a/internal/cert_test.go
+++ b/internal/cert_test.go
@@ -43,7 +43,7 @@ func TestFetchIssuingCertificateReturnsErrorIfMalformedCertificateFound(t *testi
 	}
 }
 
-func TestGetCertificateChainSucceeds(t *testing.T) {
+func TestGetAKIntermediateCertsSucceeds(t *testing.T) {
 	// Create CA and corresponding server.
 	testCA, caKey := test.GetTestCert(t, nil, nil, nil)
 
@@ -66,11 +66,11 @@ func TestGetCertificateChainSucceeds(t *testing.T) {
 	// Create leaf cert.
 	leafCert, _ := test.GetTestCert(t, []string{intermediateServer.URL}, intermediateCert, intermediateKey)
 
-	certChain, err := GetCertificateChain(leafCert, localClient)
+	certChain, err := GetAKIntermediateCerts(leafCert, localClient)
 	if err != nil {
 		t.Fatal(err)
 	}
 	if len(certChain) != 2 {
-		t.Fatalf("GetCertificateChain did not return the expected number of certificates: got %v, want 2", len(certChain))
+		t.Fatalf("GetAKIntermediateCerts did not return the expected number of certificates: got %v, want 2", len(certChain))
 	}
 }


### PR DESCRIPTION
- Adds partial certificate chain fetching to avoid needing to fetch the root CA in CS client by hard coding the known rootKeyIDs and checking if the issuer of the current cert has that rootKeyID before fetching from the CA.