### PR TITLE
Update pinned boringssl commit to match go version 1.26

### DIFF
--- a/keymanager/third_party/bssl-sys/Cargo.toml
+++ b/keymanager/third_party/bssl-sys/Cargo.toml
@@ -15,6 +15,9 @@ unexpected_cfgs = { level = "warn", check-cfg = ['cfg(bindgen_rs_file)'] }
 [lib]
 path = "../../boringssl/rust/bssl-sys/src/lib.rs"
 
+[dependencies.bssl-macros]
+path = "../../boringssl/rust/bssl-macros"
+
 [build-dependencies]
 cmake = "0.1"
 

--- a/keymanager/workload_service/integration_test.go
+++ b/keymanager/workload_service/integration_test.go
@@ -145,7 +145,7 @@ func TestIntegrationGenerateKeysUniqueMappings(t *testing.T) {
 
 func TestIntegrationDestroyKey(t *testing.T) {
 	kpsSvc := kps.NewService()
-	srv, err := NewServer(kpsSvc, &realWorkloadService{}, "")
+	srv, err := NewServer(kpsSvc, &realWorkloadService{}, filepath.Join(t.TempDir(), "test.sock"))
 	if err != nil {
 		t.Fatalf("failed to create server: %v", err)
 	}

--- a/launcher/cloudbuild.yaml
+++ b/launcher/cloudbuild.yaml
@@ -51,6 +51,8 @@ steps:
     - -c
     - |
       set -exuo pipefail
+      git config --global --add safe.directory /workspace
+      git submodule update --init --recursive
       # Build the Rust keymanager libraries using prebuilt toolchain
       cd keymanager
       cargo build --release


### PR DESCRIPTION
- Updates boringssl version to `440b43a` (current latest main commit) which is on go 1.26.5