### PR TITLE
launcher: extract TEE server from runner

### DIFF
--- a/launcher/container_runner.go
+++ b/launcher/container_runner.go
@@ -30,15 +30,13 @@ import (
 	"github.com/google/go-tpm-tools/agent"
 	"github.com/google/go-tpm-tools/agent/device"
 	"github.com/google/go-tpm-tools/cel"
-	workloadservice "github.com/google/go-tpm-tools/keymanager/workload_service"
 	"github.com/google/go-tpm-tools/launcher/internal/healthmonitoring/nodeproblemdetector"
 	"github.com/google/go-tpm-tools/launcher/internal/logging"
 	"github.com/google/go-tpm-tools/launcher/internal/signaturediscovery"
 	"github.com/google/go-tpm-tools/launcher/launcherfile"
 	"github.com/google/go-tpm-tools/launcher/registryauth"
 	"github.com/google/go-tpm-tools/launcher/spec"
-	"github.com/google/go-tpm-tools/launcher/teeserver"
-	v1 "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/opencontainers/image-spec/specs-go/v1"
 	"google.golang.org/protobuf/proto"
 
 	attestationpb "github.com/GoogleCloudPlatform/confidential-space/server/proto/gen/attestation"
@@ -53,13 +51,10 @@ type ContainerRunner struct {
 	deviceROTManager *device.ROTManager
 	serialConsole    *os.File
 	powerButton      *powerButtonListener // Populated only for a hardened image
-	attestClients    teeserver.AttestClients
-	workloadService  *workloadservice.Server
 }
 
 const tokenFileTmp = ".token.tmp"
 
-const teeServerSocket = "teeserver.sock"
 const keyManagerGrpcSocket = "kmaserver-grpc.sock"
 
 // Since we only allow one container on a VM, using a deterministic id is probably fine
@@ -100,8 +95,6 @@ type RunnerConfig struct {
 	Image            containerd.Image
 	AttestAgent      agent.AttestationAgent
 	DeviceROTManager *device.ROTManager
-	AttestClients    teeserver.AttestClients
-	WorkloadService  *workloadservice.Server
 	LaunchSpec       spec.LaunchSpec
 	Logger           logging.Logger
 	SerialConsole    *os.File
@@ -237,8 +230,6 @@ func NewRunner(ctx context.Context, cfg *RunnerConfig) (*ContainerRunner, error)
 		deviceROTManager: cfg.DeviceROTManager,
 		serialConsole:    serialConsole,
 		powerButton:      powerButton,
-		attestClients:    cfg.AttestClients,
-		workloadService:  cfg.WorkloadService,
 	}, nil
 }
 
@@ -602,21 +593,6 @@ func (r *ContainerRunner) Run(ctx context.Context) error {
 			return fmt.Errorf("failed to fetch and write OIDC token: %v", err)
 		}
 	}
-
-	// create and start the TEE server
-	r.logger.Info("EnableOnDemandAttestation is enabled: initializing TEE server.")
-
-	teeServerSocketPath := path.Join(launcherfile.HostTmpPath, teeServerSocket)
-	teeServer, err := teeserver.New(ctx, teeServerSocketPath, r.attestAgent, r.logger, r.launchSpec, r.attestClients, r.workloadService)
-	if err != nil {
-		return fmt.Errorf("failed to create the TEE server: %v", err)
-	}
-	if err := verifySocketPermissions(teeServerSocketPath); err != nil {
-		return fmt.Errorf("failed to verify TEE server socket permissions: %w", err)
-	}
-
-	go func() { _ = teeServer.Serve() }()
-	defer func() { _ = teeServer.Shutdown(ctx) }()
 
 	// Avoids breaking existing memory monitoring tests that depend on this log.
 	if r.launchSpec.MonitoringEnabled == spec.None {

--- a/launcher/start.go
+++ b/launcher/start.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"os"
 	"path"
@@ -17,6 +18,7 @@ import (
 	"github.com/google/go-tpm-tools/agent"
 	"github.com/google/go-tpm-tools/agent/device"
 	"github.com/google/go-tpm-tools/client"
+	kmcommonpb "github.com/google/go-tpm-tools/keymanager/km_common/proto"
 	workloadservice "github.com/google/go-tpm-tools/keymanager/workload_service"
 	"github.com/google/go-tpm-tools/launcher/internal/gpu"
 	"github.com/google/go-tpm-tools/launcher/internal/logging"
@@ -30,11 +32,12 @@ import (
 	"github.com/google/go-tpm-tools/verifier/util"
 	"github.com/google/go-tpm/legacy/tpm2"
 	"google.golang.org/api/option"
-
-	kmcommonpb "github.com/google/go-tpm-tools/keymanager/km_common/proto"
 )
 
-const keyManagerSocket = "kmaserver.sock"
+const (
+	teeServerSocket  = "teeserver.sock"
+	keyManagerSocket = "kmaserver.sock"
+)
 
 var expectedTPMDAParams = TPMDAParams{
 	MaxTries:        0x20,    // 32 tries
@@ -145,29 +148,49 @@ func StartLauncher(ctx context.Context, launchSpec spec.LaunchSpec, logger loggi
 		return err
 	}
 
-	var workloadService *workloadservice.Server
+	var keyClaimsProvider workloadservice.KeyClaimsProvider
 	if launchSpec.Experiments.EnableKeyManager {
 		logger.Info("EnableKeyManager experiment is enabled: initializing KeyManager server.")
-		keyManagerSocketPath := path.Join(launcherfile.HostTmpPath, keyManagerSocket)
-		keyManagerServer, err := workloadservice.New(ctx, keyManagerSocketPath, kmcommonpb.KeyProtectionMechanism_KEY_PROTECTION_VM_EMULATED)
+		kmServer, err := workloadservice.New(
+			ctx,
+			path.Join(launcherfile.HostTmpPath, keyManagerSocket),
+			kmcommonpb.KeyProtectionMechanism_KEY_PROTECTION_VM_EMULATED,
+		)
 		if err != nil {
-			return fmt.Errorf("failed to create the KeyManager server: %v", err)
+			return fmt.Errorf("failed to create KeyManager server: %w", err)
 		}
-		if err := verifySocketPermissions(keyManagerSocketPath); err != nil {
-			return fmt.Errorf("failed to verify KeyManager socket permissions: %w", err)
-		}
-		workloadService = keyManagerServer
-		go func() { _ = keyManagerServer.Serve() }()
-		defer func() { _ = keyManagerServer.Shutdown(ctx) }()
+		go func() { _ = kmServer.Serve() }()
+		defer kmServer.Shutdown(ctx)
+		keyClaimsProvider = kmServer
 	}
+
+	logger.Info("Initializing TEE server.")
+	teeSocket, err := listenUnixSocket(path.Join(launcherfile.HostTmpPath, teeServerSocket))
+	if err != nil {
+		return err
+	}
+	teeServer, err := teeserver.New(
+		ctx,
+		teeSocket,
+		attestAgent,
+		logger,
+		launchSpec.Experiments.BcMode,
+		launchSpec.Experiments.EnableHostAttestation,
+		attestClients,
+		keyClaimsProvider,
+	)
+	if err != nil {
+		teeSocket.Close()
+		return fmt.Errorf("failed to create TEE server: %w", err)
+	}
+	go func() { _ = teeServer.Serve() }()
+	defer teeServer.Shutdown(ctx)
 
 	r, err := NewRunner(ctx, &RunnerConfig{
 		ContainerdClient: containerdClient,
 		Image:            image,
 		AttestAgent:      attestAgent,
 		DeviceROTManager: deviceROTManager,
-		AttestClients:    attestClients,
-		WorkloadService:  workloadService,
 		LaunchSpec:       launchSpec,
 		Logger:           logger,
 		SerialConsole:    serialConsole,
@@ -265,6 +288,18 @@ func createAttestClients(ctx context.Context, launchSpec spec.LaunchSpec, logger
 	}
 	attestClients.GCA = gcaClient
 	return attestClients, nil
+}
+
+func listenUnixSocket(socketPath string) (net.Listener, error) {
+	nl, err := net.Listen("unix", socketPath)
+	if err != nil {
+		return nil, fmt.Errorf("cannot listen to socket [%s]: %w", socketPath, err)
+	}
+	if err := os.Chmod(socketPath, 0777); err != nil {
+		nl.Close()
+		return nil, fmt.Errorf("failed to chmod unix socket %s: %w", socketPath, err)
+	}
+	return nl, nil
 }
 
 func verifySocketPermissions(socketPath string) error {

--- a/launcher/start_test.go
+++ b/launcher/start_test.go
@@ -156,6 +156,25 @@ func TestCreateAttestClients_Behaviors(t *testing.T) {
 	}
 }
 
+func TestListenUnixSocket(t *testing.T) {
+	sockDir := t.TempDir()
+	sockPath := path.Join(sockDir, "test.sock")
+
+	nl, err := listenUnixSocket(sockPath)
+	if err != nil {
+		t.Fatalf("listenUnixSocket(%q) error = %v, want nil", sockPath, err)
+	}
+	defer nl.Close()
+
+	info, err := os.Stat(sockPath)
+	if err != nil {
+		t.Fatalf("os.Stat(%q) error = %v, want nil", sockPath, err)
+	}
+	if perm := info.Mode().Perm(); perm != 0777 {
+		t.Errorf("socket %s has permissions %04o, want 0777", sockPath, perm)
+	}
+}
+
 func TestVerifySocketPermissions(t *testing.T) {
 	tests := []struct {
 		name    string

--- a/launcher/teeserver/tee_server.go
+++ b/launcher/teeserver/tee_server.go
@@ -10,14 +10,12 @@ import (
 	"io"
 	"net"
 	"net/http"
-	"os"
 	"strings"
 
 	attestationpb "github.com/GoogleCloudPlatform/confidential-space/server/proto/gen/attestation"
 	"github.com/google/go-tpm-tools/agent"
 	wsd "github.com/google/go-tpm-tools/keymanager/workload_service"
 	"github.com/google/go-tpm-tools/launcher/internal/logging"
-	"github.com/google/go-tpm-tools/launcher/spec"
 	tspb "github.com/google/go-tpm-tools/launcher/teeserver/proto/gen/teeserver"
 	"github.com/google/go-tpm-tools/verifier"
 	"github.com/google/go-tpm-tools/verifier/models"
@@ -59,15 +57,15 @@ type AttestClients struct {
 }
 
 type attestHandler struct {
-	ctx         context.Context
-	attestAgent agent.AttestationAgent
-	// defaultTokenFile string
-	logger             logging.Logger
-	launchSpec         spec.LaunchSpec
-	clients            AttestClients
-	keyClaimsProvider  wsd.KeyClaimsProvider
-	kemAttester        KeyEndorsementAttester
-	bindingKeyAttester KeyEndorsementAttester
+	ctx                   context.Context
+	attestAgent           agent.AttestationAgent
+	logger                logging.Logger
+	bcMode                bool
+	enableHostAttestation bool
+	clients               AttestClients
+	keyClaimsProvider     wsd.KeyClaimsProvider
+	kemAttester           KeyEndorsementAttester
+	bindingKeyAttester    KeyEndorsementAttester
 }
 
 // TeeServer is a server that can be called from a container through a unix
@@ -79,50 +77,46 @@ type TeeServer struct {
 	bindingKeyAttester KeyEndorsementAttester
 }
 
-// New takes in a socket and start to listen to it, and create a server
-func New(ctx context.Context, unixSock string, a agent.AttestationAgent, logger logging.Logger, launchSpec spec.LaunchSpec, clients AttestClients, keyClaimsProvider wsd.KeyClaimsProvider) (*TeeServer, error) {
-	var err error
-	nl, err := net.Listen("unix", unixSock)
-	if err != nil {
-		return nil, fmt.Errorf("cannot listen to the socket [%s]: %v", unixSock, err)
-	}
-	if err := os.Chmod(unixSock, 0777); err != nil {
-		nl.Close()
-		return nil, fmt.Errorf("failed to chmod unix socket %s: %v", unixSock, err)
-	}
-
-	if launchSpec.Experiments.EnableKeyManager && keyClaimsProvider == nil {
-		return nil, fmt.Errorf("key claims provider cannot be nil when key manager is enabled")
-	}
-
-	kemAttester, err := initKEMAttester(launchSpec.Experiments.BcMode, keyClaimsProvider, a)
+// New creates a TeeServer with the given listener and dependencies.
+func New(
+	ctx context.Context,
+	nl net.Listener,
+	a agent.AttestationAgent,
+	logger logging.Logger,
+	bcMode bool,
+	enableHostAttestation bool,
+	clients AttestClients,
+	keyClaimsProvider wsd.KeyClaimsProvider,
+) (*TeeServer, error) {
+	kemAttester, err := initKEMAttester(bcMode, keyClaimsProvider, a)
 	if err != nil {
 		return nil, fmt.Errorf("failed to initialize KEM attester: %v", err)
 	}
 
-	bindingKeyAttester, err := initBindingKeyAttester(launchSpec.Experiments.BcMode, keyClaimsProvider, a)
+	bindingKeyAttester, err := initBindingKeyAttester(bcMode, keyClaimsProvider, a)
 	if err != nil {
+		_ = kemAttester.Close()
 		return nil, fmt.Errorf("failed to initialize binding key attester: %v", err)
 	}
 
-	teeServer := TeeServer{
+	return &TeeServer{
 		netListener:        nl,
 		kemAttester:        kemAttester,
 		bindingKeyAttester: bindingKeyAttester,
 		server: &http.Server{
 			Handler: (&attestHandler{
-				ctx:                ctx,
-				attestAgent:        a,
-				logger:             logger,
-				launchSpec:         launchSpec,
-				clients:            clients,
-				keyClaimsProvider:  keyClaimsProvider,
-				kemAttester:        kemAttester,
-				bindingKeyAttester: bindingKeyAttester,
+				ctx:                   ctx,
+				attestAgent:           a,
+				logger:                logger,
+				bcMode:                bcMode,
+				enableHostAttestation: enableHostAttestation,
+				clients:               clients,
+				keyClaimsProvider:     keyClaimsProvider,
+				kemAttester:           kemAttester,
+				bindingKeyAttester:    bindingKeyAttester,
 			}).Handler(),
 		},
-	}
-	return &teeServer, nil
+	}, nil
 }
 
 func initKEMAttester(bcMode bool, keyClaimsProvider wsd.KeyClaimsProvider, a agent.AttestationAgent) (KeyEndorsementAttester, error) {
@@ -338,7 +332,7 @@ func filterVMAttestationFields(att *attestationpb.VmAttestation, mask *fieldmask
 
 // getKeyEndorsement retrieves the attestation evidence with KEM and binding key claims.
 func (a *attestHandler) getKeyEndorsement(w http.ResponseWriter, r *http.Request) {
-	if !a.launchSpec.Experiments.EnableKeyManager && !a.launchSpec.Experiments.BcMode {
+	if a.keyClaimsProvider == nil && !a.bcMode {
 		a.logAndWriteHTTPError(w, http.StatusForbidden, fmt.Errorf("keymanager not enabled"))
 		return
 	}
@@ -479,7 +473,7 @@ func (a *attestHandler) attest(w http.ResponseWriter, r *http.Request, client ve
 }
 
 func (a *attestHandler) getHostAttestation(w http.ResponseWriter, r *http.Request) {
-	if !a.launchSpec.Experiments.EnableHostAttestation {
+	if !a.enableHostAttestation {
 		a.logAndWriteHTTPError(w, http.StatusForbidden, fmt.Errorf("host attestation not enabled"))
 		return
 	}
@@ -507,7 +501,7 @@ func (a *attestHandler) getHostAttestation(w http.ResponseWriter, r *http.Reques
 	}
 
 	evidence := &attestationpb.HostAttestation{}
-	if !a.launchSpec.Experiments.BcMode {
+	if !a.bcMode {
 		// vg has host attestation enabled and should use dummy implementation
 		evidence = dummyHostAttestation(req.Challenge)
 	} else {
@@ -549,7 +543,7 @@ func (s *TeeServer) Shutdown(ctx context.Context) error {
 	if err := s.server.Shutdown(ctx); err != nil {
 		errs = append(errs, err)
 	}
-	if err := s.netListener.Close(); err != nil {
+	if err := s.netListener.Close(); err != nil && !errors.Is(err, net.ErrClosed) {
 		errs = append(errs, err)
 	}
 	if s.kemAttester != nil {

--- a/launcher/teeserver/tee_server_test.go
+++ b/launcher/teeserver/tee_server_test.go
@@ -7,8 +7,10 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"net/http/httptest"
+	"path"
 	"strings"
 	"testing"
 
@@ -20,9 +22,7 @@ import (
 	"github.com/google/go-tpm-tools/agent"
 
 	keymanager "github.com/google/go-tpm-tools/keymanager/km_common/proto"
-	"github.com/google/go-tpm-tools/launcher/internal/experiments"
 	"github.com/google/go-tpm-tools/launcher/internal/logging"
-	"github.com/google/go-tpm-tools/launcher/spec"
 
 	tspb "github.com/google/go-tpm-tools/launcher/teeserver/proto/gen/teeserver"
 	"github.com/google/go-tpm-tools/verifier"
@@ -1044,6 +1044,7 @@ func TestGetKeyEndorsement(t *testing.T) {
 		name             string
 		reqBody          interface{}
 		enableKM         bool
+		bcMode           bool
 		claimsErr        error
 		kemAttestErr     error
 		bindingAttestErr error
@@ -1079,6 +1080,16 @@ func TestGetKeyEndorsement(t *testing.T) {
 			wantStatus: http.StatusForbidden,
 		},
 		{
+			name: "bc mode without key manager",
+			reqBody: map[string]interface{}{
+				"challenge":  testChallenge,
+				"key_handle": map[string]string{"handle": testHandle},
+			},
+			enableKM:   false,
+			bcMode:     true,
+			wantStatus: http.StatusOK,
+		},
+		{
 			name: "missing key handle",
 			reqBody: map[string]interface{}{
 				"challenge":  testChallenge,
@@ -1111,12 +1122,15 @@ func TestGetKeyEndorsement(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			mClaims := &mockClaimsProvider{
-				err: tt.claimsErr,
-				claims: map[keymanager.KeyType]*keymanager.KeyClaims{
-					keymanager.KeyType_KEY_TYPE_VM_PROTECTION_KEY:     {Claims: &keymanager.KeyClaims_VmKeyClaims{}},
-					keymanager.KeyType_KEY_TYPE_VM_PROTECTION_BINDING: {Claims: &keymanager.KeyClaims_VmBindingClaims{}},
-				},
+			var mClaims *mockClaimsProvider
+			if tt.enableKM {
+				mClaims = &mockClaimsProvider{
+					err: tt.claimsErr,
+					claims: map[keymanager.KeyType]*keymanager.KeyClaims{
+						keymanager.KeyType_KEY_TYPE_VM_PROTECTION_KEY:     {Claims: &keymanager.KeyClaims_VmKeyClaims{}},
+						keymanager.KeyType_KEY_TYPE_VM_PROTECTION_BINDING: {Claims: &keymanager.KeyClaims_VmBindingClaims{}},
+					},
+				}
 			}
 			mAgent := &fakeAttestationAgent{
 				attestationEvidenceFunc: func(_ context.Context, _, b2 []byte) (*attestationpb.VmAttestation, error) {
@@ -1155,15 +1169,15 @@ func TestGetKeyEndorsement(t *testing.T) {
 			}
 
 			handler := &attestHandler{
-				ctx:               context.Background(),
-				attestAgent:       mAgent,
-				keyClaimsProvider: mClaims,
-				logger:            logging.SimpleLogger(),
-				launchSpec: spec.LaunchSpec{
-					Experiments: experiments.Experiments{EnableKeyManager: tt.enableKM},
-				},
+				ctx:                context.Background(),
+				attestAgent:        mAgent,
+				logger:             logging.SimpleLogger(),
+				bcMode:             tt.bcMode,
 				kemAttester:        mKEM,
 				bindingKeyAttester: mBinding,
+			}
+			if tt.enableKM {
+				handler.keyClaimsProvider = mClaims
 			}
 			body, _ := json.Marshal(tt.reqBody)
 			req := httptest.NewRequest(http.MethodPost, endorsementEndpoint, bytes.NewBuffer(body))
@@ -1278,3 +1292,33 @@ func TestInitBindingKeyAttester(t *testing.T) {
 		})
 	}
 }
+
+func TestTeeServer_Shutdown(t *testing.T) {
+	sockDir := t.TempDir()
+	sockPath := path.Join(sockDir, "test_shutdown.sock")
+	nl, err := net.Listen("unix", sockPath)
+	if err != nil {
+		t.Fatalf("net.Listen() err = %v, want nil", err)
+	}
+
+	server, err := New(
+		t.Context(),
+		nl,
+		&fakeAttestationAgent{},
+		logging.SimpleLogger(),
+		false,
+		false,
+		AttestClients{},
+		nil,
+	)
+	if err != nil {
+		t.Fatalf("New() err = %v, want nil", err)
+	}
+
+	go func() { _ = server.Serve() }()
+
+	if err := server.Shutdown(t.Context()); err != nil {
+		t.Errorf("server.Shutdown() err = %v, want nil", err)
+	}
+}
+


### PR DESCRIPTION
## Overview

Extracts background server initialization (`TeeServer` and `KeyManager` server) and Unix socket permission validation out of `ContainerRunner.Run` and hoists them directly into `StartLauncher`. 

Additionally:
- Decouples `TeeServer` configuration from `spec.LaunchSpec` in favor of scoped `experiments.Experiments`.
- Simplifies `/v1/keyendorsement` access control by checking `keyClaimsProvider == nil && !experiments.BcMode` rather than relying on redundant boolean flags.
- Prevents spurious `net.ErrClosed` errors during graceful server shutdown.
- Adds comprehensive unit tests for host attestation, shutdown error aggregation, KeyManager integration, and BC-mode key endorsement.

```mermaid
sequenceDiagram
    autonumber
    participant Main as StartLauncher
    participant KM as KeyManager Server
    participant TEE as TeeServer
    participant CR as ContainerRunner

    opt EnableKeyManager is true
        Main->>KM: startKeyManagerServer()
        KM-->>Main: kmServer instance
    end

    Main->>TEE: startTeeServer(experiments, kmServer)
    TEE-->>Main: teeServer instance

    Main->>CR: NewRunner(...)
    Main->>CR: Run(ctx)
    CR-->>Main: workload exits

    Note over Main,KM: Strict LIFO Teardown
    Main->>CR: Close(ctx)
    Main->>TEE: Shutdown(ctx)
    opt EnableKeyManager was true
        Main->>KM: Shutdown(ctx)
    end
```

## Why

1. **Separation of Concerns**: Previously, `ContainerRunner` was burdened with managing daemon HTTP server lifecycles, requiring `AttestClients` and `WorkloadService` to be threaded through `RunnerConfig`. `ContainerRunner` is now solely responsible for container orchestration, execution, and event logging.
2. **Improved Shutdown Handling**: Elevating server lifecycle management to `StartLauncher` enables explicit, clean LIFO resource cleanup via standard `defer` semantics (`r.Close` $\rightarrow$ `teeServer.Shutdown` $\rightarrow$ `kmServer.Shutdown`), ensuring running container processes terminate before their backing Unix sockets are closed.
3. **Decoupled Architecture**: Removing `spec.LaunchSpec` dependencies from `teeserver` simplifies the constructor interface and clarifies dependencies across packages.
