### PR TITLE
Download Go modules before checking protobuf generation

### DIFF
--- a/proto/gen_attest.sh
+++ b/proto/gen_attest.sh
@@ -1,5 +1,10 @@
 #!/bin/bash
 
+# Only download the specific modules we need include paths for
+go mod download github.com/google/go-sev-guest \
+                github.com/google/go-tdx-guest \
+                github.com/google/go-eventlog \
+                github.com/GoogleCloudPlatform/confidential-space/server
 protoc -I. \
   -I$(go list -m -f "{{.Dir}}" github.com/google/go-sev-guest) \
   -I$(go list -m -f "{{.Dir}}" github.com/google/go-tdx-guest) \


### PR DESCRIPTION
Populate the Go module cache before running `go generate` so `go list` can resolve imported `.proto` paths in `gen_attest.sh`.