### PR TITLE
[GB300] Add experiment and agent shell

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -803,7 +803,7 @@ func convertToTPMQuote(v *pb.Attestation) *attestationpb.TpmQuote {
 }
 func (a *gb300ccaAgent) Attest(_ context.Context, _ AttestAgentOpts) ([]byte, error) {
 	a.logger.Info("GB300 CC mode: Skipping Attest (Hardware attestation not implemented)")
-	return []byte("dummy-token"), nil
+	return []byte("eyJhbGciOiJub25lIn0.eyJleHAiOjMyNTAzNjgwMDAwfQ."), nil
 }
 
 func (a *gb300ccaAgent) Refresh(_ context.Context) error {
@@ -818,5 +818,5 @@ func (a *gb300ccaAgent) MeasureEvent(_ gecel.Content) error {
 
 func (a *gb300ccaAgent) AttestWithClient(_ context.Context, _ AttestAgentOpts, _ verifier.Client) ([]byte, error) {
 	a.logger.Info("GB300 CC mode: Skipping AttestWithClient (Hardware attestation not implemented)")
-	return []byte("dummy-token"), nil
+	return []byte("eyJhbGciOiJub25lIn0.eyJleHAiOjMyNTAzNjgwMDAwfQ."), nil
 }

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -801,22 +801,22 @@ func convertToTPMQuote(v *pb.Attestation) *attestationpb.TpmQuote {
 		},
 	}
 }
-func (a *gb300ccaAgent) Attest(ctx context.Context, opts AttestAgentOpts) ([]byte, error) {
+func (a *gb300ccaAgent) Attest(_ context.Context, _ AttestAgentOpts) ([]byte, error) {
 	a.logger.Info("GB300 CC mode: Skipping Attest (Hardware attestation not implemented)")
 	return []byte("dummy-token"), nil
 }
 
-func (a *gb300ccaAgent) Refresh(ctx context.Context) error {
+func (a *gb300ccaAgent) Refresh(_ context.Context) error {
 	a.logger.Info("GB300 CC mode: Skipping Refresh")
 	return nil
 }
 
-func (a *gb300ccaAgent) MeasureEvent(event gecel.Content) error {
+func (a *gb300ccaAgent) MeasureEvent(_ gecel.Content) error {
 	a.logger.Info("GB300 CC mode: Skipping MeasureEvent")
 	return nil
 }
 
-func (a *gb300ccaAgent) AttestWithClient(ctx context.Context, opts AttestAgentOpts, client verifier.Client) ([]byte, error) {
+func (a *gb300ccaAgent) AttestWithClient(_ context.Context, _ AttestAgentOpts, _ verifier.Client) ([]byte, error) {
 	a.logger.Info("GB300 CC mode: Skipping AttestWithClient (Hardware attestation not implemented)")
 	return []byte("dummy-token"), nil
 }

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -117,6 +117,8 @@ type Experiments struct {
 	EnableAttestationEvidence bool
 	// BcMode enables baremetal execution mode.
 	BcMode bool
+	// GB300CCMode enables the GB300 Confidential Computing mode.
+	GB300CCMode bool
 }
 
 type agent struct {
@@ -137,6 +139,10 @@ type bcAgent struct {
 	*agent
 }
 
+type gb300ccaAgent struct {
+	*agent
+}
+
 // CreateAttestationAgent returns an agent capable of performing remote
 // attestation using the machine's (v)TPM to GCE's Attestation Service.
 // - tpm is a handle to the TPM on the instance
@@ -147,6 +153,9 @@ type bcAgent struct {
 func CreateAttestationAgent(tpm io.ReadWriteCloser, akFetcher util.TpmKeyFetcher, verifierClient verifier.Client, principalFetcher principalIDTokenFetcher, sigsFetcher SignatureFetcher, exps Experiments, logger Logger, deviceROTManager *device.ROTManager, signedImageRepos []string) (AttestationAgent, error) {
 	if exps.BcMode {
 		return createBCAgent(principalFetcher, sigsFetcher, exps, logger, deviceROTManager, signedImageRepos)
+	}
+	if exps.GB300CCMode {
+		return createGB300CCAgent(principalFetcher, sigsFetcher, exps, logger, deviceROTManager, signedImageRepos)
 	}
 
 	// Fetched the AK and save it, so the agent doesn't need to create a new key everytime
@@ -231,6 +240,24 @@ func createBCAgent(principalFetcher principalIDTokenFetcher, sigsFetcher Signatu
 
 	baseAgent.deviceROTManager = deviceROTManager
 	return &bcAgent{agent: baseAgent}, nil
+}
+
+func createGB300CCAgent(principalFetcher principalIDTokenFetcher, sigsFetcher SignatureFetcher, exps Experiments, logger Logger, deviceROTManager *device.ROTManager, signedImageRepos []string) (AttestationAgent, error) {
+	logger.Info("Initializing GB300 CC agent placeholder. Hardware attestation (ARM CCA) is not yet implemented.")
+
+	baseAgent := &agent{
+		principalFetcher: principalFetcher,
+		sigsFetcher:      sigsFetcher,
+		experiments:      exps,
+		logger:           logger,
+		sigsCache:        &sigsCache{},
+		signedImageRepos: signedImageRepos,
+		deviceROTManager: deviceROTManager,
+	}
+
+	// TODO: Add details and implementations
+
+	return &gb300ccaAgent{agent: baseAgent}, nil
 }
 
 func (a *agent) addTDXAttestRoot() (bool, error) {
@@ -773,4 +800,23 @@ func convertToTPMQuote(v *pb.Attestation) *attestationpb.TpmQuote {
 			},
 		},
 	}
+}
+func (a *gb300ccaAgent) Attest(ctx context.Context, opts AttestAgentOpts) ([]byte, error) {
+	a.logger.Info("GB300 CC mode: Skipping Attest (Hardware attestation not implemented)")
+	return []byte("dummy-token"), nil
+}
+
+func (a *gb300ccaAgent) Refresh(ctx context.Context) error {
+	a.logger.Info("GB300 CC mode: Skipping Refresh")
+	return nil
+}
+
+func (a *gb300ccaAgent) MeasureEvent(event gecel.Content) error {
+	a.logger.Info("GB300 CC mode: Skipping MeasureEvent")
+	return nil
+}
+
+func (a *gb300ccaAgent) AttestWithClient(ctx context.Context, opts AttestAgentOpts, client verifier.Client) ([]byte, error) {
+	a.logger.Info("GB300 CC mode: Skipping AttestWithClient (Hardware attestation not implemented)")
+	return []byte("dummy-token"), nil
 }

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -139,7 +139,7 @@ type bcAgent struct {
 	*agent
 }
 
-type gb300ccaAgent struct {
+type gb300ccAgent struct {
 	*agent
 }
 
@@ -243,7 +243,7 @@ func createBCAgent(principalFetcher principalIDTokenFetcher, sigsFetcher Signatu
 }
 
 func createGB300CCAgent(principalFetcher principalIDTokenFetcher, sigsFetcher SignatureFetcher, exps Experiments, logger Logger, deviceROTManager *device.ROTManager, signedImageRepos []string) (AttestationAgent, error) {
-	logger.Info("Initializing GB300 CC agent placeholder. Hardware attestation (ARM CCA) is not yet implemented.")
+	logger.Info("Initializing GB300 CC agent placeholder. Not yet implemented.")
 
 	baseAgent := &agent{
 		principalFetcher: principalFetcher,
@@ -257,7 +257,7 @@ func createGB300CCAgent(principalFetcher principalIDTokenFetcher, sigsFetcher Si
 
 	// TODO: Add details and implementations
 
-	return &gb300ccaAgent{agent: baseAgent}, nil
+	return &gb300ccAgent{agent: baseAgent}, nil
 }
 
 func (a *agent) addTDXAttestRoot() (bool, error) {
@@ -801,22 +801,22 @@ func convertToTPMQuote(v *pb.Attestation) *attestationpb.TpmQuote {
 		},
 	}
 }
-func (a *gb300ccaAgent) Attest(_ context.Context, _ AttestAgentOpts) ([]byte, error) {
+func (a *gb300ccAgent) Attest(_ context.Context, _ AttestAgentOpts) ([]byte, error) {
 	a.logger.Info("GB300 CC mode: Skipping Attest (Hardware attestation not implemented)")
 	return []byte("eyJhbGciOiJub25lIn0.eyJleHAiOjMyNTAzNjgwMDAwfQ."), nil
 }
 
-func (a *gb300ccaAgent) Refresh(_ context.Context) error {
+func (a *gb300ccAgent) Refresh(_ context.Context) error {
 	a.logger.Info("GB300 CC mode: Skipping Refresh")
 	return nil
 }
 
-func (a *gb300ccaAgent) MeasureEvent(_ gecel.Content) error {
+func (a *gb300ccAgent) MeasureEvent(_ gecel.Content) error {
 	a.logger.Info("GB300 CC mode: Skipping MeasureEvent")
 	return nil
 }
 
-func (a *gb300ccaAgent) AttestWithClient(_ context.Context, _ AttestAgentOpts, _ verifier.Client) ([]byte, error) {
+func (a *gb300ccAgent) AttestWithClient(_ context.Context, _ AttestAgentOpts, _ verifier.Client) ([]byte, error) {
 	a.logger.Info("GB300 CC mode: Skipping AttestWithClient (Hardware attestation not implemented)")
 	return []byte("eyJhbGciOiJub25lIn0.eyJleHAiOjMyNTAzNjgwMDAwfQ."), nil
 }

--- a/launcher/internal/experiments/experiments.go
+++ b/launcher/internal/experiments/experiments.go
@@ -22,6 +22,7 @@ type Experiments struct {
 	EnableGpuItaSupport          bool
 	EnableHostAttestation        bool
 	BcMode                       bool
+	GB300CCMode                  bool
 }
 
 // New takes a filepath, opens the file, and calls ReadJsonInput with the contents

--- a/launcher/launcher/main.go
+++ b/launcher/launcher/main.go
@@ -132,17 +132,22 @@ func main() {
 	logger.Info(fmt.Sprintf("Launch Spec: %+v", launchSpec.LogFriendly()))
 
 	verifier := osMountVerifier{}
-	if err := verifyDiskIntegrity(verifier); err != nil {
-		logger.Error(fmt.Sprintf("failed to verify disk integrity: %v\n", err))
-		exitCode = rebootRC
-		logger.Error(exitMessage, "exit_code", exitCode, "exit_msg", rcMessage[exitCode])
-		return
-	}
-	if err := verifyMounts(launchSpec, verifier); err != nil {
-		logger.Error(fmt.Sprintf("failed to verify mounts: %v\n", err))
-		exitCode = rebootRC
-		logger.Error(exitMessage, "exit_code", exitCode, "exit_msg", rcMessage[exitCode])
-		return
+	if launchSpec.GB300CCMode {
+		// TODO: we need to implement integrity and mount verifications for GB300 CC mode.
+		logger.Info("Running in GB300 CC mode. Skipping disk integrity and mount verifications. [Temporary while WIP]")
+	} else {
+		if err := verifyDiskIntegrity(verifier); err != nil {
+			logger.Error(fmt.Sprintf("failed to verify disk integrity: %v\n", err))
+			exitCode = rebootRC
+			logger.Error(exitMessage, "exit_code", exitCode, "exit_msg", rcMessage[exitCode])
+			return
+		}
+		if err := verifyMounts(launchSpec, verifier); err != nil {
+			logger.Error(fmt.Sprintf("failed to verify mounts: %v\n", err))
+			exitCode = rebootRC
+			logger.Error(exitMessage, "exit_code", exitCode, "exit_msg", rcMessage[exitCode])
+			return
+		}
 	}
 
 	defer func() {

--- a/launcher/launcher/main.go
+++ b/launcher/launcher/main.go
@@ -132,7 +132,7 @@ func main() {
 	logger.Info(fmt.Sprintf("Launch Spec: %+v", launchSpec.LogFriendly()))
 
 	verifier := osMountVerifier{}
-	if launchSpec.GB300CCMode {
+	if launchSpec.Experiments.GB300CCMode {
 		// TODO: we need to implement integrity and mount verifications for GB300 CC mode.
 		logger.Info("Running in GB300 CC mode. Skipping disk integrity and mount verifications. [Temporary while WIP]")
 	} else {

--- a/launcher/start.go
+++ b/launcher/start.go
@@ -182,8 +182,8 @@ func StartLauncher(ctx context.Context, launchSpec spec.LaunchSpec, logger loggi
 }
 
 func initTPM(launchSpec spec.LaunchSpec, logger logging.Logger) (io.ReadWriteCloser, error) {
-	if launchSpec.Experiments.BcMode {
-		logger.Info("Running in BC mode, bypassing TPM initialization and checks.")
+	if launchSpec.Experiments.BcMode || launchSpec.Experiments.GB300CCMode {
+		logger.Info("Running in BC or GB300 CC mode, bypassing TPM initialization and checks.")
 		return nil, nil
 	}
 

--- a/launcher/start.go
+++ b/launcher/start.go
@@ -139,6 +139,7 @@ func StartLauncher(ctx context.Context, launchSpec spec.LaunchSpec, logger loggi
 		EnableGpuGcaSupport:       launchSpec.Experiments.EnableGpuGcaSupport,
 		EnableGpuItaSupport:       launchSpec.Experiments.EnableGpuItaSupport,
 		BcMode:                    launchSpec.Experiments.BcMode,
+		GB300CCMode:               launchSpec.Experiments.GB300CCMode,
 	}
 	attestAgent, err := agent.CreateAttestationAgent(tpm, client.GceAttestationKeyECC, verifierClient, principalFetcherWithImpersonate, sdClient, exps, logger, deviceROTManager, launchSpec.SignedImageRepos)
 	if err != nil {


### PR DESCRIPTION
Add the GB300CCMode experiment and create an initial GB300CCMode attestation agent. 

Most of the logic remains unimplemented, but this sets up the framework for easier follow-ups and enables us to create a test image that is usable. 

Follow up PRs will:
- Add the  GB300CCMode attestation agent implementation
- Add the necessary disk integrity and mount checks to the launcher for GB300CCMode