### PR TITLE
ci: decompose lint matrix and centralize constants

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,23 +27,27 @@ on:
 permissions:
   contents: read
 
+env:
+  GO_VERSION: '1.26.x'
+  GOLANGCI_LINT_VERSION: 'v2.12.2'
+  PROTOC_VERSION: '3.20.1'
+  PROTOC_GEN_GO_VERSION: 'v1.28.0'
+  KEEP_SORTED_VERSION: 'v0.9.1'
+
 jobs:
   build:
     timeout-minutes: 12
     strategy:
       matrix:
-        go-version: [1.26.x]
         # TODO: Get this working on windows-latest
         os: [ubuntu-latest]
         architecture: [x32, x64]
         include:
           - os: macos-latest
             architecture: arm64
-            go-version: 1.26.x
           - os: macos-14-large
             architecture: x64
-            go-version: 1.26.x
-    name: Generate/Build/Test (${{ matrix.os }}, ${{ matrix.architecture }}, Go ${{ matrix.go-version }})
+    name: Generate/Build/Test (${{ matrix.os }}, ${{ matrix.architecture }})
     runs-on: ${{ matrix.os }}
     steps:
       # Pinned to commit SHA to satisfy blanket security policy (zizmor)
@@ -53,16 +57,16 @@ jobs:
           persist-credentials: false
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
-          go-version: ${{ matrix.go-version }}
+          go-version: ${{ env.GO_VERSION }}
           architecture: ${{ matrix.architecture }}
           cache: false
       - name: Install Protoc
         uses: arduino/setup-protoc@149f6c87b92550901b26acd1632e11c3662e381f # v1.3.0
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-          version: "3.20.1"
+          version: ${{ env.PROTOC_VERSION }}
       - name: Install protoc-gen-go
-        run: go install google.golang.org/protobuf/cmd/protoc-gen-go@v1.28.0
+        run: go install google.golang.org/protobuf/cmd/protoc-gen-go@${{ env.PROTOC_GEN_GO_VERSION }}
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
         with:
@@ -124,14 +128,9 @@ jobs:
         if: runner.os == 'Linux' && matrix.architecture == 'x64'
 
   lint:
-    timeout-minutes: 10
-    strategy:
-      matrix:
-        go-version: [1.26.x]
-        os: [ubuntu-latest]
-        dir: ["./", "./agent", "./cmd", "./launcher", "./keymanager"]
-    name: Lint ${{ matrix.dir }} (${{ matrix.os }}, Go ${{ matrix.go-version }})
-    runs-on: ${{ matrix.os }}
+    timeout-minutes: 5
+    name: Lint Go
+    runs-on: ubuntu-latest
     steps:
       # Pinned to commit SHA to satisfy blanket security policy (zizmor)
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -140,7 +139,35 @@ jobs:
           persist-credentials: false
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
-          go-version: ${{ matrix.go-version }}
+          go-version: ${{ env.GO_VERSION }}
+          cache: false
+      # Pinned to commit SHA to satisfy blanket security policy (zizmor)
+      - name: Run golangci-lint
+        uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v9.3.0
+        with:
+          version: ${{ env.GOLANGCI_LINT_VERSION }}
+          args: >
+            -D errcheck
+            -E misspell
+            -E revive
+            --max-same-issues=0
+            --max-issues-per-linter=0
+            --timeout 5m
+            ./... ./agent/... ./cmd/... ./launcher/...
+
+  lint-keymanager:
+    timeout-minutes: 8
+    name: Lint KeyManager
+    runs-on: ubuntu-latest
+    steps:
+      # Pinned to commit SHA to satisfy blanket security policy (zizmor)
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          submodules: recursive
+          persist-credentials: false
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version: ${{ env.GO_VERSION }}
           cache: false
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
@@ -158,8 +185,8 @@ jobs:
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v9.3.0
         with:
-          version: v2.12.2
-          working-directory: ${{ matrix.dir }}
+          version: ${{ env.GOLANGCI_LINT_VERSION }}
+          working-directory: ./keymanager
           args: >
             -D errcheck
             -E misspell
@@ -170,12 +197,8 @@ jobs:
 
   lintc:
     timeout-minutes: 8
-    strategy:
-      matrix:
-        go-version: [1.26.x]
-        os: [ubuntu-latest]
-    name: Lint CGO (${{ matrix.os }}, Go ${{ matrix.go-version }})
-    runs-on: ${{ matrix.os }}
+    name: Lint CGO (ubuntu-latest)
+    runs-on: ubuntu-latest
     steps:
       # Pinned to commit SHA to satisfy blanket security policy (zizmor)
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -184,7 +207,7 @@ jobs:
           persist-credentials: false
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
-          go-version: ${{ matrix.go-version }}
+          go-version: ${{ env.GO_VERSION }}
           cache: false
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
@@ -214,10 +237,10 @@ jobs:
           persist-credentials: false
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
-          go-version: '1.26.x'
+          go-version: ${{ env.GO_VERSION }}
           cache: false
       - name: Install keep-sorted
-        run: go install github.com/google/keep-sorted@v0.9.1
+        run: go install github.com/google/keep-sorted@${{ env.KEEP_SORTED_VERSION }}
       - name: Check keep-sorted
         run: |
           if [ -n "${GITHUB_BASE_REF}" ]; then
@@ -236,13 +259,14 @@ jobs:
   ci-status:
     name: CI Status
     runs-on: ubuntu-latest
-    needs: [build, lint, lintc, keep-sorted]
+    needs: [build, lint, lint-keymanager, lintc, keep-sorted]
     if: always()
     steps:
       - name: Check Status
         run: |
           if [[ "${{ needs.build.result }}" != "success" || \
                 "${{ needs.lint.result }}" != "success" || \
+                "${{ needs.lint-keymanager.result }}" != "success" || \
                 "${{ needs.lintc.result }}" != "success" || \
                 "${{ needs.keep-sorted.result }}" != "success" ]]; then
             echo "CI checks failed"


### PR DESCRIPTION
## Overview

Decompose the multi-module linter into separate jobs for pure Go code and CGO/Rust dependencies, and centralize language and toolchain versions into workflow constants.

The previous CI configuration executed a 5-way matrix across all repository submodules. Every runner unconditionally installed the Rust toolchain, fetched apt build dependencies, and compiled `bindgen-cli` from source—even when linting standard Go packages with no CGO or Rust code. This added ~8–10 runner-minutes of redundant compilation to every PR.

Isolating KeyManager's CGO and Rust prerequisites to a dedicated job allows pure Go modules to lint cleanly in a single step without external toolchain overhead. Centralizing language and tool versions prevents toolchain drift across jobs and ensures future version bumps are single-line updates.