### PR TITLE
ci: decompose build matrix into explicit jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,20 +35,10 @@ env:
   KEEP_SORTED_VERSION: 'v0.9.1'
 
 jobs:
-  build:
+  test-linux-amd64:
     timeout-minutes: 12
-    strategy:
-      matrix:
-        # TODO: Get this working on windows-latest
-        os: [ubuntu-latest]
-        architecture: [x32, x64]
-        include:
-          - os: macos-latest
-            architecture: arm64
-          - os: macos-14-large
-            architecture: x64
-    name: Generate/Build/Test (${{ matrix.os }}, ${{ matrix.architecture }})
-    runs-on: ${{ matrix.os }}
+    name: Test Linux (amd64)
+    runs-on: ubuntu-latest
     steps:
       # Pinned to commit SHA to satisfy blanket security policy (zizmor)
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -58,7 +48,6 @@ jobs:
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version: ${{ env.GO_VERSION }}
-          architecture: ${{ matrix.architecture }}
           cache: false
       - name: Install Protoc
         uses: arduino/setup-protoc@149f6c87b92550901b26acd1632e11c3662e381f # v1.3.0
@@ -73,59 +62,80 @@ jobs:
           toolchain: stable
       - name: Install Build Dependencies (Linux)
         run: sudo DEBIAN_FRONTEND=noninteractive apt-get update -o Acquire::Retries=3 -o Acquire::http::Timeout="30" && sudo DEBIAN_FRONTEND=noninteractive apt-get install -y -o Acquire::Retries=3 -o Acquire::http::Timeout="30" cmake clang pkg-config libssl-dev
-        if: runner.os == 'Linux' && matrix.architecture == 'x64'
       - name: Install bindgen-cli
         run: cargo install bindgen-cli
-        if: runner.os == 'Linux' && matrix.architecture == 'x64'
       - name: Build KeyManager Rust library
         run: |
           cd keymanager
           cargo build --release
-        if: runner.os == 'Linux' && matrix.architecture == 'x64'
       - name: Check Protobuf Generation
         run: |
           go generate ./... ./agent/... ./cmd/... ./launcher/... ./verifier/...
           git diff -G'^[^/]' --exit-code
-      - name: Install Linux 64-bit packages
-        run: sudo DEBIAN_FRONTEND=noninteractive apt-get install -y -o Acquire::Retries=3 -o Acquire::http::Timeout="30" libssl-dev
-        if: runner.os == 'Linux' && matrix.architecture == 'x64'
-      - name: Install Linux 32-bit packages
-        run: sudo dpkg --add-architecture i386; sudo DEBIAN_FRONTEND=noninteractive apt-get update -o Acquire::Retries=3 -o Acquire::http::Timeout="30"; sudo DEBIAN_FRONTEND=noninteractive apt-get install -y -o Acquire::Retries=3 -o Acquire::http::Timeout="30" libssl-dev:i386 libgcc-s1:i386 gcc-multilib
-        if: runner.os == 'Linux' && matrix.architecture == 'x32'
-      - name: Install Mac packages
-        run: |
-          brew install openssl
-        if: runner.os == 'macOS'
-      - name: Install Windows packages
-        run: choco install openssl
-        if: runner.os == 'Windows'
-      - name: Build all modules except agent, launcher, and keymanager
-        run: go build -v ./... ./cmd/... ./verifier/...
-      - name: Build agent module
-        run: go build -v ./agent/...
-        if: runner.os == 'Linux'
-      - name: Build keymanager module
-        run: go build -v ./keymanager/...
-        if: runner.os == 'Linux' && matrix.architecture == 'x64'
+      - name: Build all modules
+        run: go build -v ./... ./agent/... ./cmd/... ./keymanager/... ./verifier/...
       - name: Build launcher module
         run: go build -v -ldflags="-extldflags=-Wl,-z,lazy" ./launcher/...
-        if: runner.os == 'Linux'
       - name: Run specific tests under root permission
         run: |
           GO_EXECUTABLE_PATH=$(which go)
           sudo $GO_EXECUTABLE_PATH test -v -ldflags="-extldflags=-Wl,-z,lazy" -run "TestFetchImageSignaturesDockerPublic" ./launcher
-        if: runner.os == 'Linux'
       - name: Run all tests in launcher to capture potential data race
         run: go test -v -ldflags="-extldflags=-Wl,-z,lazy" -race ./launcher/...
-        if: (runner.os == 'Linux') && matrix.architecture == 'x64'
-      - name: Test all modules except agent, launcher, and keymanager
+      - name: Test all modules
+        run: go test -v ./... ./agent/... ./cmd/... ./keymanager/... ./verifier/... -skip='TestCacheConcurrentSetGet|TestHwAttestationPass|TestHardwareAttestationPass'
+
+  test-linux-386:
+    timeout-minutes: 12
+    name: Test Linux (386)
+    runs-on: ubuntu-latest
+    steps:
+      # Pinned to commit SHA to satisfy blanket security policy (zizmor)
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          submodules: recursive
+          persist-credentials: false
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version: ${{ env.GO_VERSION }}
+          architecture: x32
+          cache: false
+      - name: Install Linux 32-bit packages
+        run: sudo dpkg --add-architecture i386; sudo DEBIAN_FRONTEND=noninteractive apt-get update -o Acquire::Retries=3 -o Acquire::http::Timeout="30"; sudo DEBIAN_FRONTEND=noninteractive apt-get install -y -o Acquire::Retries=3 -o Acquire::http::Timeout="30" libssl-dev:i386 libgcc-s1:i386 gcc-multilib
+      - name: Build modules
+        run: go build -v ./... ./agent/... ./cmd/... ./verifier/...
+      - name: Build launcher module
+        run: go build -v -ldflags="-extldflags=-Wl,-z,lazy" ./launcher/...
+      - name: Run specific tests under root permission
+        run: |
+          GO_EXECUTABLE_PATH=$(which go)
+          sudo $GO_EXECUTABLE_PATH test -v -ldflags="-extldflags=-Wl,-z,lazy" -run "TestFetchImageSignaturesDockerPublic" ./launcher
+      - name: Test modules
+        run: go test -v ./... ./agent/... ./cmd/... ./verifier/... -skip='TestCacheConcurrentSetGet|TestHwAttestationPass|TestHardwareAttestationPass'
+
+  test-macos:
+    timeout-minutes: 12
+    strategy:
+      matrix:
+        os: [macos-latest, macos-14-large]
+    name: Test macOS (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    steps:
+      # Pinned to commit SHA to satisfy blanket security policy (zizmor)
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          submodules: recursive
+          persist-credentials: false
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version: ${{ env.GO_VERSION }}
+          cache: false
+      - name: Install Mac packages
+        run: brew install openssl
+      - name: Build modules
+        run: go build -v ./... ./cmd/... ./verifier/...
+      - name: Test modules
         run: go test -v ./... ./cmd/... ./verifier/... -skip='TestCacheConcurrentSetGet|TestHwAttestationPass|TestHardwareAttestationPass'
-      - name: Test agent module
-        run: go test -v ./agent/...
-        if: runner.os == 'Linux'
-      - name: Test keymanager module
-        run: go test -v ./keymanager/...
-        if: runner.os == 'Linux' && matrix.architecture == 'x64'
 
   lint:
     timeout-minutes: 5
@@ -259,12 +269,14 @@ jobs:
   ci-status:
     name: CI Status
     runs-on: ubuntu-latest
-    needs: [build, lint, lint-keymanager, lintc, keep-sorted]
+    needs: [test-linux-amd64, test-linux-386, test-macos, lint, lint-keymanager, lintc, keep-sorted]
     if: always()
     steps:
       - name: Check Status
         run: |
-          if [[ "${{ needs.build.result }}" != "success" || \
+          if [[ "${{ needs.test-linux-amd64.result }}" != "success" || \
+                "${{ needs.test-linux-386.result }}" != "success" || \
+                "${{ needs.test-macos.result }}" != "success" || \
                 "${{ needs.lint.result }}" != "success" || \
                 "${{ needs.lint-keymanager.result }}" != "success" || \
                 "${{ needs.lintc.result }}" != "success" || \


### PR DESCRIPTION
## Overview

Decomposes the monolithic `build` matrix job in `ci.yml` into three dedicated platform test jobs (`test-linux-amd64`, `test-linux-386`, and `test-macos`), removing all step-level conditionals.

## What Changed

The single multi-target matrix is replaced by three explicit platform workflows, eliminating redundant toolchains and unused steps from 32-bit and macOS runners:

```mermaid
graph TD
    subgraph L64["test-linux-amd64 (Ubuntu x64)"]
        direction TB
        A1["actions/checkout"] --> B1["setup-go (amd64)"]
        B1 --> C1["setup-protoc & protoc-gen-go"]
        C1 --> D1["Setup Rust & apt dependencies"]
        D1 --> E1["Install bindgen-cli & build KeyManager"]
        E1 --> F1["Check Protobuf Generation"]
        F1 --> G1["Build all modules (incl. Agent, Launcher, KeyManager)"]
        G1 --> H1["Root & race test launcher"]
        H1 --> I1["Test all modules"]
    end

    subgraph L32["test-linux-386 (Ubuntu x32)"]
        direction TB
        A2["actions/checkout"] --> B2["setup-go (x32)"]
        B2 --> C2["Install 32-bit multilib packages"]
        C2 --> D2["Build non-CGO modules & launcher"]
        D2 --> E2["Root test launcher"]
        E2 --> F2["Test modules"]
        
        DEL1["❌ ELIMINATED: Rust Toolchain & Bindgen"]
        DEL2["❌ ELIMINATED: Protoc & Proto Generation"]
        DEL3["❌ ELIMINATED: KeyManager & CGO Builds"]
    end

    subgraph MAC["test-macos (arm64 & x64)"]
        direction TB
        A3["actions/checkout"] --> B3["setup-go"]
        B3 --> C3["Install OpenSSL (brew)"]
        C3 --> D3["Build core modules (., cmd, verifier)"]
        D3 --> E3["Test core modules"]
        
        DEL4["❌ ELIMINATED: Rust Toolchain Setup"]
        DEL5["❌ ELIMINATED: Protoc Toolchain Setup"]
        DEL6["❌ ELIMINATED: Linux Root & Race Tests"]
    end

    L64 --> S["ci-status"]
    L32 --> S
    MAC --> S

    classDef activeStep fill:#1e293b,stroke:#475569,stroke-width:1px,color:#f8fafc;
    classDef eliminatedStep fill:#2d1215,stroke:#ef4444,stroke-width:1px,stroke-dasharray: 4 4,color:#fca5a5;
    classDef statusBox fill:#0f766e,stroke:#14b8a6,stroke-width:2px,color:#f8fafc;

    class A1,B1,C1,D1,E1,F1,G1,H1,I1,A2,B2,C2,D2,E2,F2,A3,B3,C3,D3,E3 activeStep;
    class DEL1,DEL2,DEL3,DEL4,DEL5,DEL6 eliminatedStep;
    class S statusBox;
```

* Updated `ci-status` aggregation job dependencies to require `test-linux-amd64`, `test-linux-386`, and `test-macos`.

## Why

The previous matrix required 14 step-level conditionals to navigate differing platform capabilities. Because KeyManager and Linux Agent require specific CGO and Rust dependencies unavailable on other platforms, non-Linux and 32-bit runners were downloading and installing `dtolnay/rust-toolchain` and `protoc` without using them.

Decomposing the matrix removes these unnecessary toolchain installations and eliminates all step-level conditionals from the build pipeline.