### PR TITLE
launcher: parallelize bc image build DAG

### DIFF
--- a/launcher/image/bc_cloudbuild.yaml
+++ b/launcher/image/bc_cloudbuild.yaml
@@ -11,6 +11,7 @@ substitutions:
 steps:
   - name: 'gcr.io/google.com/cloudsdktool/cloud-sdk'
     id: 'ExportBaseImage'
+    waitFor: ['-']
     args:
       - 'gcloud'
       - 'compute'
@@ -22,6 +23,7 @@ steps:
       - '--zone=us-west1-a'
   - name: 'gcr.io/cloud-builders/gcloud'
     id: 'DownloadImageFromGCS'
+    waitFor: ['ExportBaseImage']
     entrypoint: 'gcloud'
     args: ['storage',
            'cp',
@@ -29,6 +31,7 @@ steps:
            './src_image.tar.gz']
   - name: 'gcr.io/cloud-builders/docker'
     id: 'SaveWSDContainerImage'
+    waitFor: ['-']
     entrypoint: 'bash'
     args:
       - '-c'
@@ -40,9 +43,11 @@ steps:
         docker rm "$${container_id}"
   - name: 'alpine'
     id: 'ExtractRawImage'
+    waitFor: ['DownloadImageFromGCS']
     args: ['tar', '-xf', './src_image.tar.gz']
   - name: 'alpine'
     id: 'PrepareOEMInstallDir'
+    waitFor: ['SaveWSDContainerImage']
     entrypoint: 'sh'
     args:
       - -c
@@ -116,6 +121,7 @@ steps:
 
   - name: 'gcr.io/cloud-builders/gcloud'
     id: 'DownloadVmlinux'
+    waitFor: ['-']
     entrypoint: 'bash'
     env:
       - 'BASE_IMAGE=${_BASE_IMAGE}'
@@ -139,6 +145,7 @@ steps:
         gcloud storage cp "gs://cos-tools/$${VERSION}/$${TARGET}/vmlinux" ./vmlinux
   - name: 'gcr.io/cos-cloud/oem-preloader:v20260529'
     id: 'RunOEMPreloader'
+    waitFor: ['ExtractRawImage', 'PrepareOEMInstallDir', 'DownloadVmlinux']
     env:
       - 'IMAGE_ENV=${_IMAGE_ENV}'
     entrypoint: 'bash'
@@ -215,9 +222,11 @@ steps:
         "$${CMD[@]}"
   - name: 'alpine'
     id: 'RenameOutputImage'
+    waitFor: ['RunOEMPreloader']
     args: ['mv', 'output.bin', 'disk.raw']
   - name: 'us-docker.pkg.dev/confidential-space-images-dev/cs-tools/measure@sha256:dae4766caef4a93c52736feb829bf2c505b7d48ce44d0ecb33e77d61bb4be888'
     id: 'MeasureImage'
+    waitFor: ['RenameOutputImage']
     env:
       - 'IMAGE_ENV=${_IMAGE_ENV}'
       - 'OUTPUT_IMAGE_NAME=${_OUTPUT_IMAGE_NAME}'
@@ -234,9 +243,11 @@ steps:
         gcloud storage cp measure_output_bc_$${IMAGE_ENV}_sha384.json gs://${PROJECT_ID}-rims/bc/$${OUTPUT_IMAGE_NAME}_sha384.json
   - name: 'alpine'
     id: 'TarOutputImage'
+    waitFor: ['RenameOutputImage']
     args: ['tar', '-zcf', './out_image.tar.gz', 'disk.raw']
   - name: 'gcr.io/cloud-builders/gcloud'
     id: 'UploadToGCS'
+    waitFor: ['TarOutputImage']
     entrypoint: 'gcloud'
     args: ['storage',
            'cp',
@@ -244,6 +255,7 @@ steps:
            'gs://${_BUCKET_NAME}/oem-preloader-${BUILD_ID}/${_OUTPUT_IMAGE_NAME}.tar.gz']
   - name: 'golang:1.26-bookworm'
     id: 'ExtractWorkloadLicenses'
+    waitFor: ['-']
     entrypoint: 'bash'
     args:
       - '-c'
@@ -255,6 +267,7 @@ steps:
         tar -czf /workspace/workload-licenses.tar.gz -C /workspace/license_out go-tpm-tools
   - name: 'gcr.io/cloud-builders/gcloud'
     id: 'UploadWorkloadLicensesToGCS'
+    waitFor: ['ExtractWorkloadLicenses']
     entrypoint: 'gcloud'
     args: ['storage',
            'cp',
@@ -262,6 +275,7 @@ steps:
            'gs://${_BUCKET_NAME}/oem-preloader-${BUILD_ID}/${_OUTPUT_IMAGE_NAME}_licenses.tar.gz']
   - name: 'gcr.io/google.com/cloudsdktool/cloud-sdk'
     id: 'FetchBaseImageFeatures'
+    waitFor: ['-']
     entrypoint: 'sh'
     args:
       - '-c'
@@ -273,6 +287,7 @@ steps:
         sed -i 's/^,//; s/,$//' /workspace/features.txt
   - name: 'gcr.io/google.com/cloudsdktool/cloud-sdk'
     id: 'CreateGCEImage'
+    waitFor: ['UploadToGCS', 'FetchBaseImageFeatures']
     entrypoint: 'sh'
     args:
       - '-c'
@@ -291,6 +306,7 @@ steps:
           --guest-os-features="$$FEATURES"
   - name: 'gcr.io/google.com/cloudsdktool/cloud-sdk'
     id: 'CopyImageToACOSBucket'
+    waitFor: ['TarOutputImage']
     entrypoint: 'sh'
     args:
       - '-c'


### PR DESCRIPTION
## Overview

This PR parallelizes the execution DAG in `launcher/image/bc_cloudbuild.yaml`. Previously, all 16 build steps ran in strict serial order because no explicit `waitFor` dependencies were declared.

## What Changed

- Declared `waitFor: ['-']` on steps that only require repository contents or public artifacts: `SaveWSDContainerImage`, `DownloadVmlinux`, `ExtractWorkloadLicenses`, and `FetchBaseImageFeatures`, allowing them to execute immediately at build start concurrently with the ~3.5-minute `ExportBaseImage` step.
- Routed `PrepareOEMInstallDir` to depend directly on `SaveWSDContainerImage` (`waitFor: ['SaveWSDContainerImage']`) since it only unpacks `wsd_rootfs.tar` and stages OEM files without touching the base image disk.
- Made `RunOEMPreloader` explicitly wait on its exact prerequisites: `ExtractRawImage`, `PrepareOEMInstallDir`, and `DownloadVmlinux`.
- Parallelized downstream packaging and verification: `MeasureImage` and `TarOutputImage` now execute concurrently once `RenameOutputImage` completes.
- Made `CopyImageToACOSBucket` execute in parallel with `CreateGCEImage` as soon as `TarOutputImage` completes.

```mermaid
flowchart TD
  subgraph ConcurrentSetup["Concurrent Setup (starts at T=0)"]
    Export["ExportBaseImage<br/>(gcloud compute images export, ~3.5m)"]
    WSD["SaveWSDContainerImage<br/>(docker pull & export, ~10s)"]
    Vmlinux["DownloadVmlinux<br/>(gcloud storage cp, ~5s)"]
    Licenses["ExtractWorkloadLicenses<br/>(inspects repo root, ~35s)"]
    Features["FetchBaseImageFeatures<br/>(gcloud compute describe, ~5s)"]
  end

  Export --> Download["DownloadImageFromGCS (~10s)"] --> Extract["ExtractRawImage (~70s)"]
  Licenses --> UploadLicenses["UploadWorkloadLicensesToGCS (~5s)"]

  Extract & WSD & Vmlinux --> OEMDir["PrepareOEMInstallDir (~2s)"]
  OEMDir --> Preloader["RunOEMPreloader (~7.5m)"]
  Preloader --> Rename["RenameOutputImage (~2s)"]

  subgraph ConcurrentPackaging["Concurrent Packaging & Measurement"]
    Rename --> Measure["MeasureImage (~40s)"]
    Rename --> Tar["TarOutputImage (~3.9m)"]
  end

  Tar --> UploadGCS["UploadToGCS (~5s)"]
  UploadGCS & Features --> CreateGCE["CreateGCEImage (~3.2m)"]
  UploadGCS --> CopyACOS["CopyImageToACOSBucket (~10s)"]
```

## Why

Cloud Build defaults to strictly sequential step execution when `waitFor` is omitted. The base image export (`ExportBaseImage`) takes ~3.5 minutes on GCE, during which independent tasks like pulling the WSD container image, fetching `vmlinux`, scanning licenses, and querying guest OS features sat idle. Furthermore, disk hashing (`MeasureImage`) was queued sequentially before image compression (`TarOutputImage`).

By declaring explicit DAG dependencies:
- ~55 seconds of setup tasks are overlapped with `ExportBaseImage`.
- ~40 seconds of `MeasureImage` execution are overlapped with `TarOutputImage`.
- Total savings: ~1.5 to 2 minutes off both `HardenedBcImageBuildAndExport` and `DebugBcImageBuildAndExport` with zero changes to dependencies or build images.
