### PR TITLE
launcher: parallelize build and test DAGs

### DIFF
--- a/launcher/cloudbuild.yaml
+++ b/launcher/cloudbuild.yaml
@@ -26,6 +26,7 @@ steps:
 # determine the base image
 - name: 'gcr.io/cloud-builders/gcloud'
   id: BaseImageIdent
+  waitFor: ['-']
   env:
   - 'BASE_IMAGE=$_BASE_IMAGE'
   - 'BASE_IMAGE_FAMILY=$_BASE_IMAGE_FAMILY'
@@ -46,6 +47,7 @@ steps:
 
 - name: 'us-docker.pkg.dev/confidential-space-images-dev/cs-tools/keymanager-builder@sha256:0283448a48bcc515f15d708d5dcf9e368ea2553c8f5a3bb0908019372a47dbfe'
   id: KeyManagerCompile
+  waitFor: ['-']
   entrypoint: /bin/bash
   args:
     - -c
@@ -78,6 +80,7 @@ steps:
 
 - name: 'gcr.io/cloud-builders/gcloud'
   id: DownloadExpBinary
+  waitFor: ['-']
   entrypoint: 'gcloud'
   args: ['storage',
           'cp',

--- a/launcher/image/test/test_debug_cloudbuild.yaml
+++ b/launcher/image/test/test_debug_cloudbuild.yaml
@@ -21,16 +21,19 @@ steps:
         ]
 - name: 'gcr.io/cloud-builders/gcloud'
   id: BasicWorkloadTest
+  waitFor: ['CreateVM']
   entrypoint: 'bash'
   args: ['scripts/test_launcher_workload.sh', '${_VM_NAME_PREFIX}-${BUILD_ID}', '${_ZONE}']
 - name: 'gcr.io/cloud-builders/gcloud'
   id: BasicWorkloadTestCloudLogging
+  waitFor: ['CreateVM']
   entrypoint: 'bash'
   env:
   - 'PROJECT_ID=$PROJECT_ID'
   args: ['scripts/test_launcher_workload_cloudlogging.sh', '${_VM_NAME_PREFIX}-${BUILD_ID}']
 - name: 'gcr.io/cloud-builders/gcloud'
   id: ChangeMDSVariables
+  waitFor: ['BasicWorkloadTest', 'BasicWorkloadTestCloudLogging']
   entrypoint: 'bash'
   args: ['util/change_metadata_vars.sh',
           '-n', '${_VM_NAME_PREFIX}-${BUILD_ID}',
@@ -39,10 +42,12 @@ steps:
         ]
 - name: 'gcr.io/cloud-builders/gcloud'
   id: ChangeMDSVariablesTest
+  waitFor: ['ChangeMDSVariables']
   entrypoint: 'bash'
   args: ['scripts/test_mds_var_change.sh', '${_VM_NAME_PREFIX}-${BUILD_ID}', '${_ZONE}']
 - name: 'gcr.io/cloud-builders/gcloud'
   id: CheckDebugVMAliveAfterLauncherExits
+  waitFor: ['ChangeMDSVariablesTest']
   script: |
     #!/usr/bin/env bash
     set -euo pipefail
@@ -64,6 +69,7 @@ steps:
   automapSubstitutions: true
 - name: 'gcr.io/cloud-builders/gcloud'
   id: CleanUp
+  waitFor: ['CheckDebugVMAliveAfterLauncherExits']
   entrypoint: 'bash'
   env:
   - 'CLEANUP=$_CLEANUP'

--- a/launcher/image/test/test_hardened_cloudbuild.yaml
+++ b/launcher/image/test/test_hardened_cloudbuild.yaml
@@ -26,16 +26,29 @@ steps:
         ]
 - name: 'gcr.io/cloud-builders/gcloud'
   id: BasicWorkloadTest
+  waitFor: ['CreateVM']
   entrypoint: 'bash'
   args: ['scripts/test_launcher_workload.sh', '${_VM_NAME_PREFIX}-${BUILD_ID}', '${_ZONE}']
 - name: 'gcr.io/cloud-builders/gcloud'
   id: BasicWorkloadTestCloudLogging
+  waitFor: ['CreateVM']
   entrypoint: 'bash'
   env:
   - 'PROJECT_ID=$PROJECT_ID'
   args: ['scripts/test_launcher_workload_cloudlogging.sh', '${_VM_NAME_PREFIX}-${BUILD_ID}']
 - name: 'gcr.io/cloud-builders/gcloud'
+  id: StartupScriptDisabledTest
+  waitFor: ['CreateVM']
+  entrypoint: 'bash'
+  args: ['scripts/test_startupscript_disabled.sh', '${_VM_NAME_PREFIX}-${BUILD_ID}', '${_ZONE}']
+- name: 'gcr.io/cloud-builders/gcloud'
+  id: CloudInitUserDataDisabledTest
+  waitFor: ['CreateVM']
+  entrypoint: 'bash'
+  args: ['scripts/test_cloud_init_userdata_disabled.sh', '${_VM_NAME_PREFIX}-${BUILD_ID}', '${_ZONE}']
+- name: 'gcr.io/cloud-builders/gcloud'
   id: ChangeMDSVariables
+  waitFor: ['BasicWorkloadTest', 'BasicWorkloadTestCloudLogging', 'StartupScriptDisabledTest', 'CloudInitUserDataDisabledTest']
   entrypoint: 'bash'
   args: ['util/change_metadata_vars.sh',
           '-n', '${_VM_NAME_PREFIX}-${BUILD_ID}',
@@ -44,24 +57,19 @@ steps:
         ]
 - name: 'gcr.io/cloud-builders/gcloud'
   id: ChangeMDSVariablesTest
+  waitFor: ['ChangeMDSVariables']
   entrypoint: 'bash'
   args: ['scripts/test_mds_var_change.sh', '${_VM_NAME_PREFIX}-${BUILD_ID}', '${_ZONE}']
 - name: 'gcr.io/cloud-builders/gcloud'
   id: MultiWriterPDTest
+  waitFor: ['-']
   entrypoint: 'bash'
   env:
   - 'BUILD_ID=$BUILD_ID'
   args: ['scripts/test_multiwriterpd_disabled.sh']
 - name: 'gcr.io/cloud-builders/gcloud'
-  id: StartupScriptDisabledTest
-  entrypoint: 'bash'
-  args: ['scripts/test_startupscript_disabled.sh', '${_VM_NAME_PREFIX}-${BUILD_ID}', '${_ZONE}']
-- name: 'gcr.io/cloud-builders/gcloud'
-  id: CloudInitUserDataDisabledTest
-  entrypoint: 'bash'
-  args: ['scripts/test_cloud_init_userdata_disabled.sh', '${_VM_NAME_PREFIX}-${BUILD_ID}', '${_ZONE}']
-- name: 'gcr.io/cloud-builders/gcloud'
   id: CleanUp
+  waitFor: ['ChangeMDSVariablesTest']
   entrypoint: 'bash'
   env:
   - 'CLEANUP=$_CLEANUP'

--- a/launcher/image/test/test_oda_with_signed_container.yaml
+++ b/launcher/image/test/test_oda_with_signed_container.yaml
@@ -23,10 +23,12 @@ steps:
         ]
 - name: 'gcr.io/cloud-builders/gcloud'
   id: TestCustomToken
+  waitFor: ['CreateVM']
   entrypoint: 'bash'
   args: ['scripts/test_custom_token.sh', "true", '${_VM_NAME_PREFIX}-${BUILD_ID}', '${_ZONE}']
 - name: 'gcr.io/cloud-builders/gcloud'
   id: BasicDiscoverSignaturesTest
+  waitFor: ['CreateVM']
   entrypoint: 'bash'
   # Check how many times container image signatures is being logged. 
   # Since signature logging will occur on refresh the default token, and on attest agent calling the `Attest` method, so the expected number should be 3.
@@ -34,6 +36,7 @@ steps:
   args: ['scripts/test_launcher_workload_discover_signatures.sh', '${_VM_NAME_PREFIX}-${BUILD_ID}', '${_ZONE}', '${_EXPECTED_SIG}', '3']
 - name: 'gcr.io/cloud-builders/gcloud'
   id: CleanUp
+  waitFor: ['TestCustomToken', 'BasicDiscoverSignaturesTest']
   entrypoint: 'bash'
   env:
   - 'CLEANUP=$_CLEANUP'

--- a/launcher/image/test/test_privileged.yaml
+++ b/launcher/image/test/test_privileged.yaml
@@ -11,6 +11,7 @@ substitutions:
 steps:
 - name: 'gcr.io/cloud-builders/gcloud'
   id: CreateVMWithPrivileges
+  waitFor: ['-']
   entrypoint: 'bash'
   env:
   - 'BUILD_ID=$BUILD_ID'
@@ -23,6 +24,7 @@ steps:
         ]
 - name: 'gcr.io/cloud-builders/gcloud'
   id: CreateVMWithCgroupsDenied
+  waitFor: ['-']
   entrypoint: 'bash'
   env:
   - 'BUILD_ID=$BUILD_ID'
@@ -34,6 +36,7 @@ steps:
         ]
 - name: 'gcr.io/cloud-builders/gcloud'
   id: CreateVMWithCapsDenied
+  waitFor: ['-']
   entrypoint: 'bash'
   env:
   - 'BUILD_ID=$BUILD_ID'
@@ -45,6 +48,7 @@ steps:
         ]
 - name: 'gcr.io/cloud-builders/gcloud'
   id: CheckPrivilegesExist
+  waitFor: ['CreateVMWithPrivileges']
   env:
   - '_VM_NAME_PREFIX=$_VM_NAME_PREFIX'
   - 'BUILD_ID=$BUILD_ID'
@@ -74,6 +78,7 @@ steps:
     fi
 - name: 'gcr.io/cloud-builders/gcloud'
   id: CheckCgroupDenied
+  waitFor: ['CreateVMWithCgroupsDenied']
   env:
   - '_VM_NAME_PREFIX=$_VM_NAME_PREFIX'
   - 'BUILD_ID=$BUILD_ID'
@@ -95,6 +100,7 @@ steps:
     fi
 - name: 'gcr.io/cloud-builders/gcloud'
   id: CheckCapsDenied
+  waitFor: ['CreateVMWithCapsDenied']
   env:
   - '_VM_NAME_PREFIX=$_VM_NAME_PREFIX'
   - 'BUILD_ID=$BUILD_ID'


### PR DESCRIPTION
## Overview

Declares explicit `waitFor` dependencies across Cloud Build configurations so independent setup tasks and VM test cases run concurrently instead of sequentially.

```mermaid
graph TD
  subgraph "Before: Serialized Execution"
    direction TB
    S1["Base Image / Root Setup"] --> S2["Compile KeyManager (Rust)"]
    S2 --> S3["Compile Launcher (Go)"]
    S3 --> S4["Download Experiments Binary"]
    S4 --> S5["Image Builds"]

    V1["Create VM 1 (Privileged)"] --> V2["Verify VM 1"]
    V2 --> V3["Cleanup VM 1"]
    V3 --> V4["Create VM 2 (Cgroups Denied)"]
    V4 --> V5["Verify VM 2"]
    V5 --> V6["Cleanup VM 2"]
    V6 --> V7["Create VM 3 (Caps Denied)"]
    V7 --> V8["Verify VM 3"]
    V8 --> V9["Cleanup VM 3"]
    V9 --> V10["CheckFailure"]
  end
```

```mermaid
graph TD
  subgraph "After: Concurrent DAG Execution"
    direction TB
    Start_Setup((Build Start)) --> S_Roots["Download Google Roots"]
    Start_Setup --> S_Base["Identify Base Image"]
    Start_Setup --> S_KM["Compile KeyManager (Rust)"]
    Start_Setup --> S_Exp["Download Experiments Binary"]

    S_Base --> S_GPU["Download GPU Drivers"]
    S_KM --> S_Launcher["Compile Launcher (Go)"]

    S_Roots --> S_Builds["Image Builds"]
    S_Base --> S_Builds
    S_Launcher --> S_Builds
    S_Exp --> S_Builds
    S_GPU --> S_Builds

    Start_VM((Test Start)) --> V_Priv["VM 1: Privileged"]
    Start_VM --> V_Cgroup["VM 2: Cgroups Denied"]
    Start_VM --> V_Caps["VM 3: Caps Denied"]

    V_Priv --> V1_Run["Verify & Cleanup VM 1"]
    V_Cgroup --> V2_Run["Verify & Cleanup VM 2"]
    V_Caps --> V3_Run["Verify & Cleanup VM 3"]

    V1_Run --> V_Barrier["CheckFailure (Join Barrier)"]
    V2_Run --> V_Barrier
    V3_Run --> V_Barrier
  end
```

## What Changed

Configured explicit `waitFor` DAG dependencies across the image build and integration test configurations:
* Runs independent setup tasks immediately at build start: Rust KeyManager compilation, base image resolution, and experiments binary download now start immediately with `waitFor: ['-']` alongside Google roots download.
* Runs independent test VMs concurrently: In tests with multiple VM configurations (like privilege and capability checks), each VM is created, tested, and cleaned up in parallel branches.
* Decouples independent API checks: Standalone disk creation checks start immediately at build start rather than waiting for test VM execution.
* Runs read-only assertions concurrently: Serial console scraping and Cloud Logging checks run in parallel on booted instances before running metadata mutation steps.

## Why

Cloud Build steps without `waitFor` run sequentially after all preceding steps. Several integration test configurations and setup phases accumulated steps without explicit dependencies, resulting in serial execution of independent work:
* Multi-VM test suites provisioned and cleaned up each VM sequentially. Because each VM is isolated with unique names, running their lifecycles in parallel reduces suite runtime to the duration of a single VM.
* In setup, Rust KeyManager compilation takes approximately 2 minutes. Starting it immediately overlaps it with base image discovery and artifact fetching before launcher compilation starts.
* In single-VM tests, read-only serial console and Cloud Logging verifications ran sequentially even though both inspect the same initial boot.

Declaring explicit `waitFor` DAGs allows Cloud Build to schedule independent work concurrently without changing test behavior or adding dependencies.
