### PR TITLE
launcher: move BC socket setup to startup

### DIFF
--- a/launcher/container_runner.go
+++ b/launcher/container_runner.go
@@ -55,8 +55,6 @@ type ContainerRunner struct {
 
 const tokenFileTmp = ".token.tmp"
 
-const keyManagerGrpcSocket = "kmaserver-grpc.sock"
-
 // Since we only allow one container on a VM, using a deterministic id is probably fine
 const (
 	containerID = "tee-container"
@@ -638,28 +636,6 @@ func (r *ContainerRunner) Run(ctx context.Context) error {
 	exitStatusC, err := task.Wait(ctx)
 	if err != nil {
 		r.logger.Error(err.Error())
-	}
-
-	// Update and verify socket permissions if in bc mode.
-	if r.launchSpec.Experiments.BcMode {
-		kmaServerSocketPath := path.Join(launcherfile.HostTmpPath, keyManagerSocket)
-		kmaServerGrpcSocketPath := path.Join(launcherfile.HostTmpPath, keyManagerGrpcSocket)
-
-		err := os.Chmod(kmaServerSocketPath, 0777)
-		if err != nil {
-			r.logger.Error("failed to chmod file %s: %v\n", kmaServerSocketPath, err)
-		}
-		err = os.Chmod(kmaServerGrpcSocketPath, 0777)
-		if err != nil {
-			r.logger.Error("failed to chmod file %s: %v\n", kmaServerGrpcSocketPath, err)
-		}
-
-		if err := verifySocketPermissions(kmaServerSocketPath); err != nil {
-			r.logger.Error("failed to verify kmaserver socket permissions: %v", err)
-		}
-		if err := verifySocketPermissions(kmaServerGrpcSocketPath); err != nil {
-			r.logger.Error("failed to verify kmaserver-grpc socket permissions: %v", err)
-		}
 	}
 
 	// Start timer for workload execution.

--- a/launcher/start.go
+++ b/launcher/start.go
@@ -35,8 +35,9 @@ import (
 )
 
 const (
-	teeServerSocket  = "teeserver.sock"
-	keyManagerSocket = "kmaserver.sock"
+	teeServerSocket      = "teeserver.sock"
+	keyManagerSocket     = "kmaserver.sock"
+	keyManagerGrpcSocket = "kmaserver-grpc.sock"
 )
 
 var expectedTPMDAParams = TPMDAParams{
@@ -183,6 +184,10 @@ func StartLauncher(ctx context.Context, launchSpec spec.LaunchSpec, logger loggi
 		teeSocket.Close()
 		return fmt.Errorf("failed to create TEE server: %w", err)
 	}
+	if launchSpec.Experiments.BcMode {
+		setupBCSocketPermissions(logger)
+	}
+
 	go func() { _ = teeServer.Serve() }()
 	defer teeServer.Shutdown(ctx)
 
@@ -312,3 +317,23 @@ func verifySocketPermissions(socketPath string) error {
 	}
 	return nil
 }
+
+func setupBCSocketPermissions(logger logging.Logger) {
+	kmaServerSocketPath := path.Join(launcherfile.HostTmpPath, keyManagerSocket)
+	kmaServerGrpcSocketPath := path.Join(launcherfile.HostTmpPath, keyManagerGrpcSocket)
+
+	if err := os.Chmod(kmaServerSocketPath, 0777); err != nil {
+		logger.Error("failed to chmod file %s: %v\n", kmaServerSocketPath, err)
+	}
+	if err := os.Chmod(kmaServerGrpcSocketPath, 0777); err != nil {
+		logger.Error("failed to chmod file %s: %v\n", kmaServerGrpcSocketPath, err)
+	}
+
+	if err := verifySocketPermissions(kmaServerSocketPath); err != nil {
+		logger.Error("failed to verify kmaserver socket permissions: %v", err)
+	}
+	if err := verifySocketPermissions(kmaServerGrpcSocketPath); err != nil {
+		logger.Error("failed to verify kmaserver-grpc socket permissions: %v", err)
+	}
+}
+

--- a/launcher/start_test.go
+++ b/launcher/start_test.go
@@ -211,3 +211,10 @@ func TestVerifySocketPermissions(t *testing.T) {
 		})
 	}
 }
+
+func TestSetupBCSocketPermissions(_ *testing.T) {
+	logger := &fakeLogger{}
+	// Verify that setupBCSocketPermissions executes without panicking even when host sockets do not exist.
+	setupBCSocketPermissions(logger)
+}
+


### PR DESCRIPTION
## Overview

Moves BC mode KeyManager Unix domain socket permissions adjustment and verification out of the container runner and into host daemon initialization during startup.

## What Changed

* Extracted KeyManager Unix domain socket permission configuration out of container execution.
* Relocated socket permission setup to host server startup so socket permissions are established alongside daemon initialization.

## Why

In BC mode, the KeyManager Unix domain sockets require world-accessible permissions so container workloads can communicate with the host daemon.

Previously, socket permission mutations occurred inside the container runner immediately before starting the container task. Performing host socket manipulations inside the runner tightly coupled container orchestration to host filesystem state and blocked isolated unit testing of the runner.

Configuring all socket permissions during host daemon initialization ensures the host environment is fully established before the runner is invoked, keeping the container runner decoupled from host sockets and ready for isolated unit tests.
