### PR TITLE
test/gpu: make step dependencies explicit

### DIFF
--- a/launcher/image/test/test_gpu_driver_installation_cloudbuild.yaml
+++ b/launcher/image/test/test_gpu_driver_installation_cloudbuild.yaml
@@ -8,6 +8,7 @@ substitutions:
 steps:
 - name: 'gcr.io/cloud-builders/gcloud'
   id: CreateShieldedVMWithUnsupportedGPU
+  waitFor: ['-']
   entrypoint: 'bash'
   env:
   - 'BUILD_ID=$BUILD_ID'
@@ -22,6 +23,7 @@ steps:
         ]
 - name: 'gcr.io/cloud-builders/gcloud'
   id: CreateSEVCVMWithNoGPU
+  waitFor: ['-']
   entrypoint: 'bash'
   env:
   - 'BUILD_ID=$BUILD_ID'
@@ -33,6 +35,7 @@ steps:
         ]
 - name: 'gcr.io/cloud-builders/gcloud'
   id: CreateTDXCVMWithCGPUNoDriverInstallationFlag
+  waitFor: ['-']
   entrypoint: 'bash'
   env:
   - 'BUILD_ID=$BUILD_ID'
@@ -48,6 +51,7 @@ steps:
         ]
 - name: 'gcr.io/cloud-builders/gcloud'
   id: CreateTDXCVMWithConfidentialGPU
+  waitFor: ['-']
   entrypoint: 'bash'
   env:
   - 'BUILD_ID=$BUILD_ID'
@@ -63,48 +67,61 @@ steps:
         ]
 - name: 'gcr.io/cloud-builders/gcloud'
   id: UnsupportedGpuWorkloadTest
+  waitFor: ['CreateShieldedVMWithUnsupportedGPU']
   entrypoint: 'bash'
   args: ['scripts/gpu/test_gpu_unsupported_gputype.sh', '${_VM_NAME_PREFIX}-${BUILD_ID}-unsup', '${_ZONE}']
 - name: 'gcr.io/cloud-builders/gcloud'
   id: NoGpuWorkloadTest
+  waitFor: ['CreateSEVCVMWithNoGPU']
   entrypoint: 'bash'
   args: ['scripts/gpu/test_gpu_nogpu.sh', '${_VM_NAME_PREFIX}-${BUILD_ID}-nogpu', '${_ZONE}']
 - name: 'gcr.io/cloud-builders/gcloud'
   id: NoGpuDriverInstallationTest
+  waitFor: ['CreateTDXCVMWithCGPUNoDriverInstallationFlag']
   entrypoint: 'bash'
   args: ['scripts/gpu/test_gpu_nodriver.sh', '${_VM_NAME_PREFIX}-${BUILD_ID}-nodriver', 'us-east5-a']
 - name: 'gcr.io/cloud-builders/gcloud'
   id: ConfidentialGpuWorkloadTest
+  waitFor: ['CreateTDXCVMWithConfidentialGPU']
   entrypoint: 'bash'
   args: ['scripts/gpu/test_gpu_workload.sh', '${_VM_NAME_PREFIX}-${BUILD_ID}-tdxcvm-cgpu', 'us-east5-a']
 - name: 'gcr.io/cloud-builders/gcloud'
   id: NoGpuDriverInstallationCleanUp
+  waitFor: ['NoGpuDriverInstallationTest']
   entrypoint: 'bash'
   env:
   - 'CLEANUP=$_CLEANUP'
   args: ['cleanup.sh', '${_VM_NAME_PREFIX}-${BUILD_ID}-nodriver', 'us-east5-a']
 - name: 'gcr.io/cloud-builders/gcloud'
   id: UnsupportedGpuVmCleanUp
+  waitFor: ['UnsupportedGpuWorkloadTest']
   entrypoint: 'bash'
   env:
   - 'CLEANUP=$_CLEANUP'
   args: ['cleanup.sh', '${_VM_NAME_PREFIX}-${BUILD_ID}-unsup', '${_ZONE}']
 - name: 'gcr.io/cloud-builders/gcloud'
   id: NoGpuVmCleanUp
+  waitFor: ['NoGpuWorkloadTest']
   entrypoint: 'bash'
   env:
   - 'CLEANUP=$_CLEANUP'
   args: ['cleanup.sh', '${_VM_NAME_PREFIX}-${BUILD_ID}-nogpu', '${_ZONE}']
 - name: 'gcr.io/cloud-builders/gcloud'
   id: ConfidentialGpuVmCleanUp
+  waitFor: ['ConfidentialGpuWorkloadTest']
   entrypoint: 'bash'
   env:
   - 'CLEANUP=$_CLEANUP'
   args: ['cleanup.sh', '${_VM_NAME_PREFIX}-${BUILD_ID}-tdxcvm-cgpu', 'us-east5-a']
 # Must come after cleanup.
 - name: 'gcr.io/cloud-builders/gcloud'
-  id: NoGpuVmCheckFailure
+  id: CheckFailure
   entrypoint: 'bash'
   env:
   - 'BUILD_ID=$BUILD_ID'
   args: ['check_failure.sh']
+  waitFor:
+  - UnsupportedGpuVmCleanUp
+  - NoGpuVmCleanUp
+  - NoGpuDriverInstallationCleanUp
+  - ConfidentialGpuVmCleanUp


### PR DESCRIPTION
test/gpu: make step dependencies explicit

This change adds explicit `waitFor` dependencies to each step in `launcher/image/test/test_gpu_driver_installation_cloudbuild.yaml` and renames the final step to `CheckFailure`. The four VM creation steps (`CreateShieldedVMWithUnsupportedGPU`, `CreateSEVCVMWithNoGPU`, `CreateTDXCVMWithCGPUNoDriverInstallationFlag`, and `CreateTDXCVMWithConfidentialGPU`) now set `waitFor: ['-']` to execute immediately when the build starts. Each workload test step (`UnsupportedGpuWorkloadTest`, `NoGpuWorkloadTest`, `NoGpuDriverInstallationTest`, and `ConfidentialGpuWorkloadTest`) explicitly waits on its corresponding VM creation step, and each cleanup step explicitly waits on its respective test step. Lastly, `NoGpuVmCheckFailure` is renamed to `CheckFailure` and explicitly waits on all four cleanup steps.

Previously, none of the steps defined `waitFor`. In Cloud Build, omitting `waitFor` defaults to waiting for all preceding steps in the configuration, causing them to execute in an implicit serial order dictated by their position in the file. This coupled independent VM test lifecycles to an arbitrary sequential order rather than their true functional prerequisites. Declaring explicit dependencies removes the reliance on this implicit serial fallback, directly links each test and cleanup to its prerequisite VM, and establishes an explicit join barrier requiring all cleanups to complete before evaluating failures.

#### Before (Implicit Serial Execution)
```mermaid
graph TD
  A1[CreateShieldedVMWithUnsupportedGPU] --> A2[CreateSEVCVMWithNoGPU]
  A2 --> A3[CreateTDXCVMWithCGPUNoDriverInstallationFlag]
  A3 --> A4[CreateTDXCVMWithConfidentialGPU]
  A4 --> B1[UnsupportedGpuWorkloadTest]
  B1 --> B2[NoGpuWorkloadTest]
  B2 --> B3[NoGpuDriverInstallationTest]
  B3 --> B4[ConfidentialGpuWorkloadTest]
  B4 --> C3[CleanupCGPUNoDriverInstallation]
  C3 --> C1[CleanupUnsupportedGPU]
  C1 --> C2[CleanupNoGPU]
  C2 --> C4[CleanupConfidentialGPU]
  C4 --> Barrier[NoGpuVmCheckFailure]
```

#### After (Explicit DAG)
```mermaid
graph TD
  Start((Build Start)) --> A1[CreateShieldedVMWithUnsupportedGPU]
  Start --> A2[CreateSEVCVMWithNoGPU]
  Start --> A3[CreateTDXCVMWithCGPUNoDriverInstallationFlag]
  Start --> A4[CreateTDXCVMWithConfidentialGPU]

  A1 --> B1[UnsupportedGpuWorkloadTest] --> C1[CleanupUnsupportedGPU]
  A2 --> B2[NoGpuWorkloadTest] --> C2[CleanupNoGPU]
  A3 --> B3[NoGpuDriverInstallationTest] --> C3[CleanupCGPUNoDriverInstallation]
  A4 --> B4[ConfidentialGpuWorkloadTest] --> C4[CleanupConfidentialGPU]

  C1 --> Barrier[CheckFailure]
  C2 --> Barrier
  C3 --> Barrier
  C4 --> Barrier
```
