### PR TITLE
test/privileged: make step dependencies explicit

### DIFF
--- a/launcher/image/test/test_privileged.yaml
+++ b/launcher/image/test/test_privileged.yaml
@@ -11,6 +11,7 @@ substitutions:
 steps:
 - name: 'gcr.io/cloud-builders/gcloud'
   id: CreateVMWithPrivileges
+  waitFor: ['-']
   entrypoint: 'bash'
   env:
   - 'BUILD_ID=$BUILD_ID'
@@ -23,6 +24,7 @@ steps:
         ]
 - name: 'gcr.io/cloud-builders/gcloud'
   id: CreateVMWithCgroupsDenied
+  waitFor: ['-']
   entrypoint: 'bash'
   env:
   - 'BUILD_ID=$BUILD_ID'
@@ -34,6 +36,7 @@ steps:
         ]
 - name: 'gcr.io/cloud-builders/gcloud'
   id: CreateVMWithCapsDenied
+  waitFor: ['-']
   entrypoint: 'bash'
   env:
   - 'BUILD_ID=$BUILD_ID'
@@ -45,6 +48,7 @@ steps:
         ]
 - name: 'gcr.io/cloud-builders/gcloud'
   id: CheckPrivilegesExist
+  waitFor: ['CreateVMWithPrivileges']
   env:
   - '_VM_NAME_PREFIX=$_VM_NAME_PREFIX'
   - 'BUILD_ID=$BUILD_ID'
@@ -74,6 +78,7 @@ steps:
     fi
 - name: 'gcr.io/cloud-builders/gcloud'
   id: CheckCgroupDenied
+  waitFor: ['CreateVMWithCgroupsDenied']
   env:
   - '_VM_NAME_PREFIX=$_VM_NAME_PREFIX'
   - 'BUILD_ID=$BUILD_ID'
@@ -95,6 +100,7 @@ steps:
     fi
 - name: 'gcr.io/cloud-builders/gcloud'
   id: CheckCapsDenied
+  waitFor: ['CreateVMWithCapsDenied']
   env:
   - '_VM_NAME_PREFIX=$_VM_NAME_PREFIX'
   - 'BUILD_ID=$BUILD_ID'
@@ -144,6 +150,10 @@ steps:
   env:
   - 'BUILD_ID=$BUILD_ID'
   args: ['check_failure.sh']
+  waitFor:
+  - CleanupPrivileged
+  - CleanupCgroupDenied
+  - CleanupCapsDenied
 
 options:
   pool:


### PR DESCRIPTION
test/privileged: make step dependencies explicit

In `launcher/image/test/test_privileged.yaml`, explicit `waitFor` fields were added to steps that previously omitted them. `CreateVMWithPrivileges`, `CreateVMWithCgroupsDenied`, and `CreateVMWithCapsDenied` now specify `waitFor: ['-']`. The verification steps `CheckPrivilegesExist`, `CheckCgroupDenied`, and `CheckCapsDenied` now explicitly wait for `CreateVMWithPrivileges`, `CreateVMWithCgroupsDenied`, and `CreateVMWithCapsDenied` respectively. Finally, `CheckFailure` now explicitly waits for `CleanupPrivileged`, `CleanupCgroupDenied`, and `CleanupCapsDenied`.

Previously, these steps omitted `waitFor`, causing Cloud Build to fall back to implicit serial execution where each step waited on all preceding steps in the file. Specifying explicit dependencies removes reliance on that implicit fallback: the VM creation steps execute immediately at build start, each check step waits only on its corresponding VM creation step, and `CheckFailure` explicitly waits for all cleanup steps to complete before evaluating test results.

#### Before (Implicit Serial Setup)
```mermaid
graph TD
  A1[CreateVMWithPrivileges] --> A2[CreateVMWithCgroupsDenied]
  A2 --> A3[CreateVMWithCapsDenied]
  A3 --> B1[CheckPrivilegesExist]
  B1 --> B2[CheckCgroupDenied]
  B2 --> B3[CheckCapsDenied]
  
  B1 --> C1[CleanupPrivileged]
  B2 --> C2[CleanupCgroupDenied]
  B3 --> C3[CleanupCapsDenied]

  B3 --> Barrier[CheckFailure]
  C1 -. waits on all prior .-> Barrier
  C2 -. waits on all prior .-> Barrier
  C3 -. waits on all prior .-> Barrier
```

#### After (Explicit DAG)
```mermaid
graph TD
  Start((Build Start)) --> A1[CreateVMWithPrivileges]
  Start --> A2[CreateVMWithCgroupsDenied]
  Start --> A3[CreateVMWithCapsDenied]

  A1 --> B1[CheckPrivilegesExist] --> C1[CleanupPrivileged]
  A2 --> B2[CheckCgroupDenied] --> C2[CleanupCgroupDenied]
  A3 --> B3[CheckCapsDenied] --> C3[CleanupCapsDenied]

  C1 --> Barrier[CheckFailure]
  C2 --> Barrier
  C3 --> Barrier
```
