### PR TITLE
test/hardened: make step dependencies explicit

### DIFF
--- a/launcher/image/test/test_hardened_cloudbuild.yaml
+++ b/launcher/image/test/test_hardened_cloudbuild.yaml
@@ -13,6 +13,7 @@ substitutions:
 steps:
 - name: 'gcr.io/cloud-builders/gcloud'
   id: CreateVM
+  waitFor: ['-']
   entrypoint: 'bash'
   env:
   - 'BUILD_ID=$BUILD_ID'
@@ -26,16 +27,19 @@ steps:
         ]
 - name: 'gcr.io/cloud-builders/gcloud'
   id: BasicWorkloadTest
+  waitFor: ['CreateVM']
   entrypoint: 'bash'
   args: ['scripts/test_launcher_workload.sh', '${_VM_NAME_PREFIX}-${BUILD_ID}', '${_ZONE}']
 - name: 'gcr.io/cloud-builders/gcloud'
   id: BasicWorkloadTestCloudLogging
+  waitFor: ['CreateVM']
   entrypoint: 'bash'
   env:
   - 'PROJECT_ID=$PROJECT_ID'
   args: ['scripts/test_launcher_workload_cloudlogging.sh', '${_VM_NAME_PREFIX}-${BUILD_ID}']
 - name: 'gcr.io/cloud-builders/gcloud'
   id: ChangeMDSVariables
+  waitFor: ['BasicWorkloadTest']
   entrypoint: 'bash'
   args: ['util/change_metadata_vars.sh',
           '-n', '${_VM_NAME_PREFIX}-${BUILD_ID}',
@@ -44,24 +48,29 @@ steps:
         ]
 - name: 'gcr.io/cloud-builders/gcloud'
   id: ChangeMDSVariablesTest
+  waitFor: ['ChangeMDSVariables']
   entrypoint: 'bash'
   args: ['scripts/test_mds_var_change.sh', '${_VM_NAME_PREFIX}-${BUILD_ID}', '${_ZONE}']
 - name: 'gcr.io/cloud-builders/gcloud'
   id: MultiWriterPDTest
+  waitFor: ['-']
   entrypoint: 'bash'
   env:
   - 'BUILD_ID=$BUILD_ID'
   args: ['scripts/test_multiwriterpd_disabled.sh']
 - name: 'gcr.io/cloud-builders/gcloud'
   id: StartupScriptDisabledTest
+  waitFor: ['CreateVM']
   entrypoint: 'bash'
   args: ['scripts/test_startupscript_disabled.sh', '${_VM_NAME_PREFIX}-${BUILD_ID}', '${_ZONE}']
 - name: 'gcr.io/cloud-builders/gcloud'
   id: CloudInitUserDataDisabledTest
+  waitFor: ['CreateVM']
   entrypoint: 'bash'
   args: ['scripts/test_cloud_init_userdata_disabled.sh', '${_VM_NAME_PREFIX}-${BUILD_ID}', '${_ZONE}']
 - name: 'gcr.io/cloud-builders/gcloud'
   id: CleanUp
+  waitFor: ['ChangeMDSVariablesTest', 'StartupScriptDisabledTest', 'CloudInitUserDataDisabledTest']
   entrypoint: 'bash'
   env:
   - 'CLEANUP=$_CLEANUP'
@@ -69,6 +78,7 @@ steps:
 # Must come after cleanup.
 - name: 'gcr.io/cloud-builders/gcloud'
   id: CheckFailure
+  waitFor: ['CleanUp', 'BasicWorkloadTestCloudLogging', 'MultiWriterPDTest']
   entrypoint: 'bash'
   env:
   - 'BUILD_ID=$BUILD_ID'


### PR DESCRIPTION
test/hardened: make step dependencies explicit

In Cloud Build, omitting `waitFor` causes a step to wait for all preceding steps in the build configuration. Previously, every step in `launcher/image/test/test_hardened_cloudbuild.yaml` omitted `waitFor`, relying entirely on this implicit serial execution fallback. This imposed arbitrary ordering constraints: `MultiWriterPDTest` does not use the test VM but implicitly waited on preceding VM tests due to its position in the list, while `StartupScriptDisabledTest` and `CloudInitUserDataDisabledTest` depend only on the initial VM creation but were sequenced behind the metadata mutation steps.

This change adds explicit `waitFor` declarations to each step in the workflow to clearly define true dependencies:
- `CreateVM` and `MultiWriterPDTest` specify `waitFor: ['-']` to explicitly start at build initialization.
- `BasicWorkloadTest`, `BasicWorkloadTestCloudLogging`, `StartupScriptDisabledTest`, and `CloudInitUserDataDisabledTest` explicitly declare `waitFor: ['CreateVM']`.
- `ChangeMDSVariables` explicitly declares `waitFor: ['BasicWorkloadTest']`, and `ChangeMDSVariablesTest` explicitly declares `waitFor: ['ChangeMDSVariables']`.
- `CleanUp` explicitly declares `waitFor: ['ChangeMDSVariablesTest', 'StartupScriptDisabledTest', 'CloudInitUserDataDisabledTest']` so it only tears down the VM once all tests targeting that VM have finished.
- `CheckFailure` serves as an explicit terminal synchronization barrier with `waitFor: ['CleanUp', 'BasicWorkloadTestCloudLogging', 'MultiWriterPDTest']`, ensuring all test paths and cleanup complete before checking build failure status.

#### Before (Implicit Serial Execution)
```mermaid
graph TD
  S0[CreateVM] --> S1[BasicWorkloadTest]
  S1 --> S2[BasicWorkloadTestCloudLogging]
  S2 --> S3[ChangeMDSVariables]
  S3 --> S4[ChangeMDSVariablesTest]
  S4 --> S5[MultiWriterPDTest]
  S5 --> S6[StartupScriptDisabledTest]
  S6 --> S7[CloudInitUserDataDisabledTest]
  S7 --> S8[CleanUp]
  S8 --> S9[CheckFailure]
```

#### After (Explicit DAG)
```mermaid
graph TD
  Start((Build Start)) --> VM[CreateVM]
  Start --> MW[MultiWriterPDTest]

  VM --> BW[BasicWorkloadTest]
  VM --> CL[BasicWorkloadTestCloudLogging]
  VM --> SS[StartupScriptDisabledTest]
  VM --> CI[CloudInitUserDataDisabledTest]

  BW --> CM[ChangeMDSVariables] --> CMT[ChangeMDSVariablesTest]

  CMT --> Clean[CleanUp]
  SS --> Clean
  CI --> Clean

  Clean --> Barrier[CheckFailure]
  CL --> Barrier
  MW --> Barrier
```
