### PR TITLE
test/debug: make step dependencies explicit

### DIFF
--- a/launcher/image/test/test_debug_cloudbuild.yaml
+++ b/launcher/image/test/test_debug_cloudbuild.yaml
@@ -9,6 +9,7 @@ substitutions:
 steps:
 - name: 'gcr.io/cloud-builders/gcloud'
   id: CreateVM
+  waitFor: ['-']
   entrypoint: 'bash'
   env:
   - 'BUILD_ID=$BUILD_ID'
@@ -21,16 +22,19 @@ steps:
         ]
 - name: 'gcr.io/cloud-builders/gcloud'
   id: BasicWorkloadTest
+  waitFor: ['CreateVM']
   entrypoint: 'bash'
   args: ['scripts/test_launcher_workload.sh', '${_VM_NAME_PREFIX}-${BUILD_ID}', '${_ZONE}']
 - name: 'gcr.io/cloud-builders/gcloud'
   id: BasicWorkloadTestCloudLogging
+  waitFor: ['CreateVM']
   entrypoint: 'bash'
   env:
   - 'PROJECT_ID=$PROJECT_ID'
   args: ['scripts/test_launcher_workload_cloudlogging.sh', '${_VM_NAME_PREFIX}-${BUILD_ID}']
 - name: 'gcr.io/cloud-builders/gcloud'
   id: ChangeMDSVariables
+  waitFor: ['BasicWorkloadTest']
   entrypoint: 'bash'
   args: ['util/change_metadata_vars.sh',
           '-n', '${_VM_NAME_PREFIX}-${BUILD_ID}',
@@ -39,10 +43,12 @@ steps:
         ]
 - name: 'gcr.io/cloud-builders/gcloud'
   id: ChangeMDSVariablesTest
+  waitFor: ['ChangeMDSVariables']
   entrypoint: 'bash'
   args: ['scripts/test_mds_var_change.sh', '${_VM_NAME_PREFIX}-${BUILD_ID}', '${_ZONE}']
 - name: 'gcr.io/cloud-builders/gcloud'
   id: CheckDebugVMAliveAfterLauncherExits
+  waitFor: ['BasicWorkloadTest']
   script: |
     #!/usr/bin/env bash
     set -euo pipefail
@@ -64,6 +70,7 @@ steps:
   automapSubstitutions: true
 - name: 'gcr.io/cloud-builders/gcloud'
   id: CleanUp
+  waitFor: ['BasicWorkloadTestCloudLogging', 'ChangeMDSVariablesTest', 'CheckDebugVMAliveAfterLauncherExits']
   entrypoint: 'bash'
   env:
   - 'CLEANUP=$_CLEANUP'
@@ -71,6 +78,7 @@ steps:
 # Must come after cleanup.
 - name: 'gcr.io/cloud-builders/gcloud'
   id: CheckFailure
+  waitFor: ['CleanUp']
   entrypoint: 'bash'
   env:
   - 'BUILD_ID=$BUILD_ID'


### PR DESCRIPTION
test/debug: make step dependencies explicit

In `launcher/image/test/test_debug_cloudbuild.yaml`, steps previously omitted the `waitFor` field. When `waitFor` is omitted, Cloud Build defaults to implicit serial execution, causing each step to wait for all preceding steps in the file rather than declaring its actual requirements.

This change adds explicit `waitFor` dependencies to each step in the workflow:
- `CreateVM` sets `waitFor: ['-']` to begin immediately at build start.
- `BasicWorkloadTest` and `BasicWorkloadTestCloudLogging` explicitly wait for `CreateVM`.
- `ChangeMDSVariables` explicitly waits for `BasicWorkloadTest`, and `ChangeMDSVariablesTest` waits for `ChangeMDSVariables`.
- `CheckDebugVMAliveAfterLauncherExits` explicitly waits for `BasicWorkloadTest`.
- `CleanUp` explicitly waits for all test tracks (`BasicWorkloadTestCloudLogging`, `ChangeMDSVariablesTest`, and `CheckDebugVMAliveAfterLauncherExits`) to ensure the instance is preserved until all tests finish.
- `CheckFailure` explicitly waits for `CleanUp` before verifying build results.

Declaring these dependencies directly removes reliance on Cloud Build's implicit serial execution fallback and ensures step prerequisites and teardown barriers are explicitly defined.

#### Before (Implicit Serial Execution)
```mermaid
graph TD
  S0[CreateVM] --> S1[BasicWorkloadTest]
  S1 --> S2[BasicWorkloadTestCloudLogging]
  S2 --> S3[ChangeMDSVariables]
  S3 --> S4[ChangeMDSVariablesTest]
  S4 --> S5[CheckDebugVMAliveAfterLauncherExits]
  S5 --> S6[CleanUp]
  S6 --> S7[CheckFailure]
```

#### After (Explicit DAG)
```mermaid
graph TD
  Start((Build Start)) --> VM[CreateVM]
  VM --> BW[BasicWorkloadTest]
  VM --> CL[BasicWorkloadTestCloudLogging]

  BW --> CM[ChangeMDSVariables] --> CMT[ChangeMDSVariablesTest]
  BW --> CD[CheckDebugVMAliveAfterLauncherExits]

  CL --> Clean[CleanUp]
  CMT --> Clean
  CD --> Clean

  Clean --> Barrier[CheckFailure]
```
