### PR TITLE
test/oda: make test step dependencies explicit

### DIFF
--- a/launcher/image/test/test_oda_with_signed_container.yaml
+++ b/launcher/image/test/test_oda_with_signed_container.yaml
@@ -12,6 +12,7 @@ substitutions:
 steps:
 - name: 'gcr.io/cloud-builders/gcloud'
   id: CreateVM
+  waitFor: ['-']
   entrypoint: 'bash'
   env:
   - 'BUILD_ID=$BUILD_ID'
@@ -23,10 +24,12 @@ steps:
         ]
 - name: 'gcr.io/cloud-builders/gcloud'
   id: TestCustomToken
+  waitFor: ['CreateVM']
   entrypoint: 'bash'
   args: ['scripts/test_custom_token.sh', "true", '${_VM_NAME_PREFIX}-${BUILD_ID}', '${_ZONE}']
 - name: 'gcr.io/cloud-builders/gcloud'
   id: BasicDiscoverSignaturesTest
+  waitFor: ['CreateVM']
   entrypoint: 'bash'
   # Check how many times container image signatures is being logged. 
   # Since signature logging will occur on refresh the default token, and on attest agent calling the `Attest` method, so the expected number should be 3.
@@ -34,6 +37,7 @@ steps:
   args: ['scripts/test_launcher_workload_discover_signatures.sh', '${_VM_NAME_PREFIX}-${BUILD_ID}', '${_ZONE}', '${_EXPECTED_SIG}', '3']
 - name: 'gcr.io/cloud-builders/gcloud'
   id: CleanUp
+  waitFor: ['TestCustomToken', 'BasicDiscoverSignaturesTest']
   entrypoint: 'bash'
   env:
   - 'CLEANUP=$_CLEANUP'
@@ -41,6 +45,7 @@ steps:
 # Must come after cleanup.
 - name: 'gcr.io/cloud-builders/gcloud'
   id: CheckFailure
+  waitFor: ['CleanUp']
   entrypoint: 'bash'
   env:
   - 'BUILD_ID=$BUILD_ID'


### PR DESCRIPTION
test/oda: make test step dependencies explicit

In `launcher/image/test/test_oda_with_signed_container.yaml`, explicit `waitFor` dependencies are added to every step in the pipeline. `CreateVM` is configured with `waitFor: ['-']` to execute immediately at build start. Both `TestCustomToken` and `BasicDiscoverSignaturesTest` explicitly declare `CreateVM` as their prerequisite. `CleanUp` explicitly waits on both `TestCustomToken` and `BasicDiscoverSignaturesTest`, and `CheckFailure` explicitly waits on `CleanUp`.

Previously, all steps in this file omitted `waitFor`. In Cloud Build, steps that omit `waitFor` default to waiting for all preceding steps in the configuration, creating implicit serial dependencies based on file order. Adding explicit `waitFor` fields removes reliance on this implicit fallback and clearly declares the exact prerequisites and synchronization points across the test lifecycle.

#### Before (Implicit Serial Execution)
```mermaid
graph TD
  S0[CreateVM] --> S1[TestCustomToken]
  S1 --> S2[BasicDiscoverSignaturesTest]
  S2 --> S3[CleanUp]
  S3 --> S4[CheckFailure]
```

#### After (Explicit DAG)
```mermaid
graph TD
  Start((Build Start)) --> VM[CreateVM]
  VM --> T1[TestCustomToken]
  VM --> T2[BasicDiscoverSignaturesTest]
  T1 --> Clean[CleanUp]
  T2 --> Clean
  Clean --> Barrier[CheckFailure]
```
