### PR TITLE
launcher: make setup step dependencies explicit

### DIFF
--- a/launcher/cloudbuild.yaml
+++ b/launcher/cloudbuild.yaml
@@ -21,11 +21,13 @@ substitutions:
 steps:
 - name: 'gcr.io/cloud-builders/curl'
   id: DownloadGoogleRoots
+  waitFor: ['-']
   args: ['-sSL', 'https://pki.goog/roots.pem', '-o', 'launcher/image/google_roots.pem']
 
 # determine the base image
 - name: 'gcr.io/cloud-builders/gcloud'
   id: BaseImageIdent
+  waitFor: ['-']
   env:
   - 'BASE_IMAGE=$_BASE_IMAGE'
   - 'BASE_IMAGE_FAMILY=$_BASE_IMAGE_FAMILY'
@@ -46,6 +48,7 @@ steps:
 
 - name: 'us-docker.pkg.dev/confidential-space-images-dev/cs-tools/keymanager-builder@sha256:0283448a48bcc515f15d708d5dcf9e368ea2553c8f5a3bb0908019372a47dbfe'
   id: KeyManagerCompile
+  waitFor: ['-']
   entrypoint: /bin/bash
   args:
     - -c
@@ -78,6 +81,7 @@ steps:
 
 - name: 'gcr.io/cloud-builders/gcloud'
   id: DownloadExpBinary
+  waitFor: ['-']
   entrypoint: 'gcloud'
   args: ['storage',
           'cp',


### PR DESCRIPTION
launcher: make setup step dependencies explicit

In `launcher/cloudbuild.yaml`, four setup steps—`DownloadGoogleRoots`, `BaseImageIdent`, `KeyManagerCompile`, and `DownloadExpBinary`—previously omitted the `waitFor` field. In Cloud Build, steps that omit `waitFor` default to waiting for all preceding steps in the configuration file to complete. Because of this implicit serial fallback, `BaseImageIdent` and `KeyManagerCompile` implicitly waited on earlier steps in the configuration, and `DownloadExpBinary` waited on all preceding steps (including `LauncherCompile`) purely because of its placement in the file.

This change adds `waitFor: ['-']` to `DownloadGoogleRoots`, `BaseImageIdent`, `KeyManagerCompile`, and `DownloadExpBinary`. These steps have no prerequisites on other tasks in the configuration and can run immediately when the build starts. Making their dependencies explicit removes reliance on Cloud Build's implicit serial ordering and ensures each step's prerequisites are declared transparently rather than governed by configuration file sequence.

#### Before (Implicit Serial Ordering for Unset Steps)
```mermaid
graph TD
  S0[DownloadGoogleRoots] --> S1[BaseImageIdent]
  S1 --> S2[KeyManagerCompile]
  S2 --> S3[LauncherCompile]
  S3 --> S4[DownloadExpBinary]
  S1 -. existing explicit waitFor .-> S5[DownloadGpuDrivers]
```

#### After (Explicit DAG)
```mermaid
graph TD
  Start((Build Start)) --> S0[DownloadGoogleRoots]
  Start --> S1[BaseImageIdent]
  Start --> S2[KeyManagerCompile]
  Start --> S4[DownloadExpBinary]

  S1 --> S5[DownloadGpuDrivers]
  S2 --> S3[LauncherCompile]
```
