### PR TITLE
test/discover-signatures: parallelize test DAG

### DIFF
--- a/launcher/image/test/test_discover_signatures.yaml
+++ b/launcher/image/test/test_discover_signatures.yaml
@@ -10,6 +10,7 @@ substitutions:
 steps:
 - name: 'gcr.io/projectsigstore/cosign:v2.2.0'
   id: SignContainer
+  waitFor: ['-']
   entrypoint: 'sh'
   env:
   - 'BUILD_ID=$BUILD_ID'
@@ -24,6 +25,7 @@ steps:
     cosign sign --key gcpkms://projects/confidential-space-images-dev/locations/global/keyRings/cosign-test/cryptoKeys/ecdsa/cryptoKeyVersions/1 ${_WORKLOAD_IMAGE} -a dev.cosignproject.cosign/sigalg=ECDSA_P256_SHA256 -a dev.cosignproject.cosign/pub=$pub
 - name: 'gcr.io/cloud-builders/gcloud'
   id: CreateVM
+  waitFor: ['-']
   entrypoint: 'bash'
   env:
   - 'BUILD_ID=$BUILD_ID'
@@ -35,16 +37,19 @@ steps:
         ]
 - name: 'gcr.io/cloud-builders/gcloud'
   id: BasicDiscoverSignaturesTest
+  waitFor: ['SignContainer', 'CreateVM']
   entrypoint: 'bash'
   args: ['scripts/test_launcher_workload_discover_signatures.sh', '${_VM_NAME_PREFIX}-${BUILD_ID}', '${_ZONE}', 'Found container image signatures', '1']
 - name: 'gcr.io/cloud-builders/gcloud'
   id: CleanUp
+  waitFor: ['BasicDiscoverSignaturesTest']
   entrypoint: 'bash'
   env:
   - 'CLEANUP=$_CLEANUP'
   args: ['cleanup.sh', '${_VM_NAME_PREFIX}-${BUILD_ID}', '${_ZONE}']
 - name: 'gcr.io/cloud-builders/gcloud'
   id: DeleteContainerSignatures
+  waitFor: ['BasicDiscoverSignaturesTest']
   env:
   - 'BUILD_ID=$BUILD_ID'
   entrypoint: 'bash'
@@ -59,6 +64,7 @@ steps:
 # Must come after cleanup.
 - name: 'gcr.io/cloud-builders/gcloud'
   id: CheckFailure
+  waitFor: ['CleanUp', 'DeleteContainerSignatures']
   entrypoint: 'bash'
   env:
   - 'BUILD_ID=$BUILD_ID'


### PR DESCRIPTION
# test/discover-signatures: parallelize test DAG

## Overview

In `launcher/image/test/test_discover_signatures.yaml`, the integration test validates container signature discovery using `cosign`.

### Before

```mermaid
graph TD
  S1[SignContainer] --> S2[CreateVM]
  S2 --> S3[BasicDiscoverSignaturesTest]
  S3 --> S4[CleanUp]
  S4 --> S5[DeleteContainerSignatures]
  S5 --> S6[CheckFailure]
```

### After

```mermaid
graph TD
  S1[SignContainer] --> S3[BasicDiscoverSignaturesTest]
  S2[CreateVM] --> S3

  S3 --> S4[CleanUp]
  S3 --> S5[DeleteContainerSignatures]

  S4 --> S6[CheckFailure]
  S5 --> S6
```

## What Changed

- **Concurrent Initialization**: Added `waitFor: ['-']` to both `SignContainer` and `CreateVM` so that VM provisioning (~60–90s) and container signing with Cloud KMS (~10–15s) begin immediately at $t=0$.
- **Joined Assertion**: Configured `BasicDiscoverSignaturesTest` to wait on both `SignContainer` and `CreateVM`.
- **Parallel Teardown**: Re-parented `DeleteContainerSignatures` to wait directly on `BasicDiscoverSignaturesTest`, allowing registry signature deletion to execute concurrently with VM deletion (`CleanUp`).
- **Failure Barrier**: Updated `CheckFailure` to wait on both `CleanUp` and `DeleteContainerSignatures` before evaluating test status.

## Why

Cloud Build defaults to sequential step execution whenever `waitFor` is omitted, making task dependencies implicit and fragile. Explicitly declaring what every action waits on makes the execution DAG fully declarative and deterministic:
- `SignContainer` and `CreateVM` explicitly declare `waitFor: ['-']`, beginning immediately at $t=0$ and overlapping container signing with VM boot latency.
- `BasicDiscoverSignaturesTest` explicitly declares its prerequisites (`['SignContainer', 'CreateVM']`).
- Teardown steps (`CleanUp` and `DeleteContainerSignatures`) explicitly trigger upon test completion, allowing registry signature cleanup to proceed concurrently with VM deletion.
- `CheckFailure` forms an explicit synchronization barrier joining all teardown steps before evaluating test outcome.

This removes reliance on implicit pipeline ordering and eliminates ~30–45 seconds of idle serialization per run without altering test behavior.
