### PR TITLE
launcher: eliminate token refresh test delays

### DIFF
--- a/launcher/container_runner.go
+++ b/launcher/container_runner.go
@@ -510,7 +510,7 @@ func (r *ContainerRunner) fetchAndWriteTokenWithRetry(ctx context.Context,
 						duration, err = r.refreshToken(ctx)
 						return err
 					},
-					retry(),
+					backoff.WithContext(retry(), ctx),
 					func(err error, t time.Duration) {
 						r.logger.Error(fmt.Sprintf("failed to refresh attestation service token at time %v: %v", t, err))
 					})

--- a/launcher/container_runner_test.go
+++ b/launcher/container_runner_test.go
@@ -16,6 +16,7 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	clogging "cloud.google.com/go/logging"
@@ -490,6 +491,10 @@ func TestFetchAndWriteTokenSucceeds(t *testing.T) {
 }
 
 func TestTokenIsNotChangedIfRefreshFails(t *testing.T) {
+	synctest.Test(t, testTokenIsNotChangedIfRefreshFails)
+}
+
+func testTokenIsNotChangedIfRefreshFails(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
@@ -529,6 +534,7 @@ func TestTokenIsNotChangedIfRefreshFails(t *testing.T) {
 	}
 
 	time.Sleep(ttl)
+	synctest.Wait()
 
 	data, err = os.ReadFile(filepath)
 	if err != nil {
@@ -553,14 +559,20 @@ func testRetryPolicyThreeTimes() *backoff.ExponentialBackOff {
 }
 
 func TestTokenRefreshRetryPolicyFail(t *testing.T) {
-	testRetryPolicyWithNTries(t, 4 /*numTries*/, false /*expectRefresh*/)
+	synctest.Test(t, func(t *testing.T) {
+		testRetryPolicyWithNTries(t, 4 /*numTries*/, false /*expectRefresh*/)
+	})
 }
 
 func TestTokenRefreshRetryPolicy(t *testing.T) {
 	// Test retry policy tries 3 times.
 	for numTries := 1; numTries <= 3; numTries++ {
 		t.Run("RetryPolicyWith"+strconv.Itoa(numTries)+"Tries",
-			func(t *testing.T) { testRetryPolicyWithNTries(t, numTries /*numTries*/, true /*expectRefresh*/) })
+			func(t *testing.T) {
+				synctest.Test(t, func(t *testing.T) {
+					testRetryPolicyWithNTries(t, numTries /*numTries*/, true /*expectRefresh*/)
+				})
+			})
 	}
 }
 
@@ -605,6 +617,7 @@ func testRetryPolicyWithNTries(t *testing.T, numTries int, expectRefresh bool) {
 		t.Errorf("initial token written to file does not match expected token: got ID %v, want ID %v", gotClaims.ID, wantClaims.ID)
 	}
 	time.Sleep(ttl)
+	synctest.Wait()
 
 	data, err = os.ReadFile(filepath)
 	if err != nil {
@@ -627,6 +640,10 @@ func testRetryPolicyWithNTries(t *testing.T, numTries int, expectRefresh bool) {
 }
 
 func TestFetchAndWriteTokenWithTokenRefresh(t *testing.T) {
+	synctest.Test(t, testFetchAndWriteTokenWithTokenRefresh)
+}
+
+func testFetchAndWriteTokenWithTokenRefresh(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
@@ -677,6 +694,7 @@ func TestFetchAndWriteTokenWithTokenRefresh(t *testing.T) {
 	}
 
 	time.Sleep(ttl)
+	synctest.Wait()
 
 	// Check that token has changed.
 	data, err = os.ReadFile(filepath)


### PR DESCRIPTION
launcher: eliminate token refresh test delays

Token refresh unit tests previously relied on wall-clock sleeps for expiration and backoff retry cycles, adding over forty seconds of latency to CI runs. The refresher retry loop also ignored context cancellation, leaking background goroutines after test completion.

Running the tests under synctest advances timers instantaneously when goroutines block, eliminating idle waiting while preserving exact retry behavior. Propagating context to the retry policy aborts retries immediately on shutdown so background workers terminate cleanly.