### PR TITLE
launcher: hermetic image and signature tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,10 +76,6 @@ jobs:
         run: go build -v ./... ./agent/... ./cmd/... ./keymanager/... ./verifier/...
       - name: Build launcher module
         run: go build -v -ldflags="-extldflags=-Wl,-z,lazy" ./launcher/...
-      - name: Run specific tests under root permission
-        run: |
-          GO_EXECUTABLE_PATH=$(which go)
-          sudo $GO_EXECUTABLE_PATH test -v -ldflags="-extldflags=-Wl,-z,lazy" -run "TestFetchImageSignaturesDockerPublic" ./launcher
       - name: Run all tests in launcher to capture potential data race
         run: go test -v -ldflags="-extldflags=-Wl,-z,lazy" -race ./launcher/...
       - name: Test all modules
@@ -106,10 +102,6 @@ jobs:
         run: go build -v ./... ./agent/... ./cmd/... ./verifier/...
       - name: Build launcher module
         run: go build -v -ldflags="-extldflags=-Wl,-z,lazy" ./launcher/...
-      - name: Run specific tests under root permission
-        run: |
-          GO_EXECUTABLE_PATH=$(which go)
-          sudo $GO_EXECUTABLE_PATH test -v -ldflags="-extldflags=-Wl,-z,lazy" -run "TestFetchImageSignaturesDockerPublic" ./launcher
       - name: Test modules
         run: go test -v ./... ./agent/... ./cmd/... ./verifier/... -skip='TestCacheConcurrentSetGet|TestHwAttestationPass|TestHardwareAttestationPass'
 

--- a/launcher/container_runner_test.go
+++ b/launcher/container_runner_test.go
@@ -9,7 +9,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"net/http"
 	"os"
 	"path"
 	"strconv"
@@ -22,8 +21,6 @@ import (
 	"github.com/cenkalti/backoff/v4"
 	"github.com/containerd/containerd"
 	"github.com/containerd/containerd/content"
-	"github.com/containerd/containerd/defaults"
-	"github.com/containerd/containerd/namespaces"
 	"github.com/containerd/containerd/oci"
 	"github.com/golang-jwt/jwt/v4"
 	"github.com/google/go-cmp/cmp"
@@ -38,7 +35,6 @@ import (
 	"github.com/opencontainers/go-digest"
 	v1 "github.com/opencontainers/image-spec/specs-go/v1"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
-	"golang.org/x/oauth2"
 
 	attestationpb "github.com/GoogleCloudPlatform/confidential-space/server/proto/gen/attestation"
 )
@@ -705,33 +701,7 @@ func TestGetNextRefresh(t *testing.T) {
 	}
 }
 
-func TestInitImageDockerPublic(t *testing.T) {
-	// testing image fetching using a dummy token and a docker repo url
-	containerdClient, err := containerd.New(defaults.DefaultAddress)
-	if err != nil {
-		t.Skipf("test needs containerd daemon: %v", err)
-	}
 
-	ctx := namespaces.WithNamespace(context.Background(), "test")
-	// This is a "valid" token (formatwise)
-	validToken := oauth2.Token{AccessToken: "000000", Expiry: time.Now().Add(time.Hour)}
-	if _, err := initImage(ctx, containerdClient, spec.LaunchSpec{ImageRef: "docker.io/library/hello-world:latest"}, validToken, http.DefaultClient); err != nil {
-		t.Error(err)
-	} else {
-		if err := containerdClient.ImageService().Delete(ctx, "docker.io/library/hello-world:latest"); err != nil {
-			t.Error(err)
-		}
-	}
-
-	invalidToken := oauth2.Token{}
-	if _, err := initImage(ctx, containerdClient, spec.LaunchSpec{ImageRef: "docker.io/library/hello-world:latest"}, invalidToken, http.DefaultClient); err != nil {
-		t.Error(err)
-	} else {
-		if err := containerdClient.ImageService().Delete(ctx, "docker.io/library/hello-world:latest"); err != nil {
-			t.Error(err)
-		}
-	}
-}
 
 func TestMeasureCELEvents(t *testing.T) {
 	ctx := context.Background()

--- a/launcher/image_test.go
+++ b/launcher/image_test.go
@@ -2,10 +2,16 @@ package launcher
 
 import (
 	"errors"
+	"net/http"
+	"strings"
 	"testing"
+	"testing/synctest"
+	"time"
 
 	"github.com/cenkalti/backoff/v4"
 	"github.com/containerd/containerd"
+	"github.com/google/go-tpm-tools/launcher/spec"
+	"golang.org/x/oauth2"
 )
 
 func TestPullImageWithRetries(t *testing.T) {
@@ -15,9 +21,11 @@ func TestPullImageWithRetries(t *testing.T) {
 		wantPass    bool
 	}{
 		{
-			name:        "success with single attempt",
-			imagePuller: func(int) (containerd.Image, error) { return &fakeImage{}, nil },
-			wantPass:    true,
+			name: "success with single attempt",
+			imagePuller: func(int) (containerd.Image, error) {
+				return &fakeImage{}, nil
+			},
+			wantPass: true,
 		},
 		{
 			name: "failure then success",
@@ -40,21 +48,112 @@ func TestPullImageWithRetries(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			retryPolicy := func() backoff.BackOff {
-				b := backoff.NewExponentialBackOff()
-				return backoff.WithMaxRetries(b, 2)
-			}
+			synctest.Test(t, func(t *testing.T) {
+				retryPolicy := func() backoff.BackOff {
+					b := backoff.NewExponentialBackOff()
+					return backoff.WithMaxRetries(b, 2)
+				}
 
-			attempts := 0
-			_, err := pullImageWithRetries(
-				func() (containerd.Image, error) {
-					attempts++
-					return tc.imagePuller(attempts)
-				},
-				retryPolicy)
-			if gotPass := (err == nil); gotPass != tc.wantPass {
-				t.Errorf("pullImageWithRetries failed, got %v, but want %v", gotPass, tc.wantPass)
-			}
+				attempts := 0
+				_, err := pullImageWithRetries(
+					func() (containerd.Image, error) {
+						attempts++
+						return tc.imagePuller(attempts)
+					},
+					retryPolicy,
+				)
+				if gotPass := (err == nil); gotPass != tc.wantPass {
+					t.Errorf("pullImageWithRetries failed, got %v, but want %v", gotPass, tc.wantPass)
+				}
+			})
 		})
 	}
+}
+
+func TestInitImage_WithValidToken_Succeeds(t *testing.T) {
+	ctx := t.Context()
+	fakeCli := &fakeContainerdClient{
+		pullResult: &fakeImage{},
+	}
+	validToken := oauth2.Token{
+		AccessToken: "valid-token",
+		Expiry:      time.Now().Add(time.Hour),
+	}
+	launchSpec := spec.LaunchSpec{
+		ImageRef: "gcr.io/test/image:latest",
+	}
+
+	img, err := initImage(ctx, fakeCli, launchSpec, validToken, http.DefaultClient)
+	if err != nil {
+		t.Fatalf("initImage failed: %v", err)
+	}
+	if img == nil {
+		t.Error("initImage returned nil image, want non-nil")
+	}
+}
+
+func TestInitImage_WithNoToken_Succeeds(t *testing.T) {
+	ctx := t.Context()
+	fakeCli := &fakeContainerdClient{
+		pullResult: &fakeImage{},
+	}
+	emptyToken := oauth2.Token{}
+	launchSpec := spec.LaunchSpec{
+		ImageRef: "docker.io/library/hello-world:latest",
+	}
+
+	img, err := initImage(ctx, fakeCli, launchSpec, emptyToken, http.DefaultClient)
+	if err != nil {
+		t.Fatalf("initImage failed: %v", err)
+	}
+	if img == nil {
+		t.Error("initImage returned nil image, want non-nil")
+	}
+}
+
+func TestInitImage_WithToken_PropagatesAuthError(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		ctx := t.Context()
+		fakeCli := &fakeContainerdClient{
+			pullErr: errors.New("auth failure"),
+		}
+		validToken := oauth2.Token{
+			AccessToken: "valid-token",
+			Expiry:      time.Now().Add(time.Hour),
+		}
+		launchSpec := spec.LaunchSpec{
+			ImageRef: "gcr.io/test/image:latest",
+		}
+
+		_, err := initImage(ctx, fakeCli, launchSpec, validToken, http.DefaultClient)
+		if err == nil {
+			t.Fatal("initImage succeeded, want error")
+		}
+		wantErrSubstr := "cannot pull the image: failed to pull image with retries"
+		if !strings.Contains(err.Error(), wantErrSubstr) {
+			t.Errorf("initImage error = %q, want substring %q", err.Error(), wantErrSubstr)
+		}
+	})
+}
+
+func TestInitImage_NoToken_PropagatesPublicError(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		ctx := t.Context()
+		fakeCli := &fakeContainerdClient{
+			pullErr: errors.New("image not found"),
+		}
+		emptyToken := oauth2.Token{}
+		launchSpec := spec.LaunchSpec{
+			ImageRef: "docker.io/library/hello-world:latest",
+		}
+
+		_, err := initImage(ctx, fakeCli, launchSpec, emptyToken, http.DefaultClient)
+		if err == nil {
+			t.Fatal("initImage succeeded, want error")
+		}
+		wantErrSubstr := "cannot pull the image (no token, only works for a public image): failed to pull image with retries"
+		if !strings.Contains(err.Error(), wantErrSubstr) {
+			t.Errorf("initImage error = %q, want substring %q", err.Error(), wantErrSubstr)
+		}
+	})
 }

--- a/launcher/internal/signaturediscovery/client_test.go
+++ b/launcher/internal/signaturediscovery/client_test.go
@@ -1,17 +1,23 @@
 package signaturediscovery
 
 import (
+	"bytes"
 	"context"
-	"fmt"
+	"encoding/json"
+	"errors"
 	"net/http"
+	"strings"
 	"testing"
 
 	"github.com/containerd/containerd"
-	"github.com/containerd/containerd/defaults"
-	"github.com/containerd/containerd/namespaces"
+	"github.com/containerd/containerd/content"
+	"github.com/containerd/containerd/content/local"
 	"github.com/containerd/containerd/remotes"
+	"github.com/containerd/platforms"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-tpm-tools/launcher/registryauth"
+	"github.com/google/go-tpm-tools/verifier/oci/cosign"
+	"github.com/opencontainers/go-digest"
 	v1 "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
@@ -20,150 +26,369 @@ func TestFormatSigTag(t *testing.T) {
 		name       string
 		imageDesc  v1.Descriptor
 		wantSigTag string
-		wantPass   bool
 	}{
 		{
-			name:       "formatSigTag success",
-			imageDesc:  v1.Descriptor{Digest: "sha256:9ecc53c269509f63c69a266168e4a687c7eb8c0cfd753bd8bfcaa4f58a90876f"},
+			name: "sha256 digest formatted with sig suffix",
+			imageDesc: v1.Descriptor{
+				Digest: "sha256:9ecc53c269509f63c69a266168e4a687c7eb8c0cfd753bd8bfcaa4f58a90876f",
+			},
 			wantSigTag: "sha256-9ecc53c269509f63c69a266168e4a687c7eb8c0cfd753bd8bfcaa4f58a90876f.sig",
-			wantPass:   true,
 		},
 		{
-			name:       "formatSigTag failed with wrong image digest",
-			imageDesc:  v1.Descriptor{Digest: "sha256:9ecc53c269509f63c69a266168e4a687c7eb8c0cfd753bd8bfcaa4f58a90876f"},
+			name: "alternate sha256 digest formatted with sig suffix",
+			imageDesc: v1.Descriptor{
+				Digest: "sha256:18740b995b4eac1b5706392a96ff8c4f30cefac18772058a71449692f1581f0f",
+			},
 			wantSigTag: "sha256-18740b995b4eac1b5706392a96ff8c4f30cefac18772058a71449692f1581f0f.sig",
-			wantPass:   false,
-		},
-		{
-			name:       "formatSigTag failed with wrong tag format",
-			imageDesc:  v1.Descriptor{Digest: "sha256:9ecc53c269509f63c69a266168e4a687c7eb8c0cfd753bd8bfcaa4f58a90876f"},
-			wantSigTag: "sha256@9ecc53c269509f63c69a266168e4a687c7eb8c0cfd753bd8bfcaa4f58a90876f.sig",
-			wantPass:   false,
 		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			if got := formatSigTag(tc.imageDesc) == tc.wantSigTag; got != tc.wantPass {
-				t.Errorf("formatSigTag() failed for test case %v: got %v, wantPass %v", tc.name, got, tc.wantPass)
+			if got := formatSigTag(tc.imageDesc); got != tc.wantSigTag {
+				t.Errorf("formatSigTag(%v) = %q, want %q", tc.imageDesc.Digest, got, tc.wantSigTag)
 			}
 		})
 	}
 }
 
-func TestFetchSignedImageManifestDockerPublic(t *testing.T) {
-	ctx := namespaces.WithNamespace(context.Background(), "test")
-
-	targetRepository := "gcr.io/distroless/static"
-	originalImageDesc := v1.Descriptor{Digest: "sha256:9ecc53c269509f63c69a266168e4a687c7eb8c0cfd753bd8bfcaa4f58a90876f"}
-	client := createTestClient(t, originalImageDesc)
-	// testing image manifest fetching using a public docker repo url
-	if _, err := client.FetchSignedImageManifest(ctx, targetRepository); err != nil {
-		t.Errorf("failed to fetch signed image manifest from targetRepository [%s]: %v", targetRepository, err)
+func TestFetchSignedImageManifest_Success(t *testing.T) {
+	ctx := t.Context()
+	testImage, wantManifest := createTestImage(ctx, t, [][]byte{[]byte("layer-content")})
+	client := &Client{
+		OriginalImageDesc: v1.Descriptor{
+			Digest: "sha256:9ecc53c269509f63c69a266168e4a687c7eb8c0cfd753bd8bfcaa4f58a90876f",
+		},
+		imageFetcher: func(context.Context, string, ...containerd.RemoteOpt) (containerd.Image, error) {
+			return testImage, nil
+		},
 	}
-}
 
-func TestFetchImageSignaturesDockerPublic(t *testing.T) {
-	ctx := namespaces.WithNamespace(context.Background(), "test")
-	originalImageDesc := v1.Descriptor{Digest: "sha256:905a0f3b3d6d0fb37bfa448b9e78f833b73f0b19fc97fed821a09cf49e255df1"}
-	targetRepository := "us-docker.pkg.dev/vegas-codelab-5/cosign-test/base"
-
-	client := createTestClient(t, originalImageDesc)
-	signatures, err := client.FetchImageSignatures(ctx, targetRepository)
+	gotManifest, err := client.FetchSignedImageManifest(ctx, "gcr.io/test/repo")
 	if err != nil {
-		t.Errorf("failed to fetch image signatures from targetRepository [%s]: %v", targetRepository, err)
+		t.Fatalf("FetchSignedImageManifest failed: %v", err)
 	}
-	if len(signatures) == 0 {
-		t.Errorf("no image signatures found for the original image %v", originalImageDesc)
-	}
-	var gotBase64Sigs []string
-	for _, sig := range signatures {
-		if _, err := sig.Payload(); err != nil {
-			t.Errorf("Payload() failed: %v", err)
-		}
-		base64Sig, err := sig.Base64Encoded()
-		if err != nil {
-			t.Errorf("Base64Encoded() failed: %v", err)
-		}
-		gotBase64Sigs = append(gotBase64Sigs, base64Sig)
-	}
-
-	// Check signatures from the OCI image manifest at https://pantheon.corp.google.com/artifacts/docker/vegas-codelab-5/us/cosign-test/base/sha256:1febaa6ac3a5c095435d5276755fb8efcb7f029fefe85cd9bf3ec7de91685b9f;tab=manifest?project=vegas-codelab-5.
-	wantBase64Sigs := []string{"MEUCIQDgoiwMiVl1SAI1iePhH6Oeqztms3IwNtN+w0P92HTqQgIgKjJNcHEy0Ep4g4MH1Vd0gAHvbwH9ahD+jlnMP/rXSGE="}
-	if !cmp.Equal(gotBase64Sigs, wantBase64Sigs) {
-		t.Errorf("signatures did not return expected base64 signatures, got %v, want %v", gotBase64Sigs, wantBase64Sigs)
+	if diff := cmp.Diff(wantManifest, gotManifest); diff != "" {
+		t.Errorf("FetchSignedImageManifest mismatch (-want +got):\n%s", diff)
 	}
 }
 
-func TestPullSignatureImage(t *testing.T) {
-	imageFetcher := func(_ context.Context, _ string, opts ...containerd.RemoteOpt) (containerd.Image, error) {
-		if len(opts) >= 0 {
+func TestFetchSignedImageManifest_PullError(t *testing.T) {
+	ctx := t.Context()
+	wantErr := errors.New("pull failure")
+	client := &Client{
+		OriginalImageDesc: v1.Descriptor{
+			Digest: "sha256:9ecc53c269509f63c69a266168e4a687c7eb8c0cfd753bd8bfcaa4f58a90876f",
+		},
+		imageFetcher: func(context.Context, string, ...containerd.RemoteOpt) (containerd.Image, error) {
+			return nil, wantErr
+		},
+	}
+
+	if _, err := client.FetchSignedImageManifest(ctx, "gcr.io/test/repo"); !errors.Is(err, wantErr) {
+		t.Errorf("FetchSignedImageManifest got err %v, want %v", err, wantErr)
+	}
+}
+
+func TestFetchSignedImageManifest_CorruptManifest(t *testing.T) {
+	ctx := t.Context()
+	cs, err := local.NewStore(t.TempDir())
+	if err != nil {
+		t.Fatalf("local.NewStore failed: %v", err)
+	}
+	corruptDesc := writeBlob(ctx, t, cs, []byte("not-json"), v1.MediaTypeImageManifest)
+	testImage := &fakeImage{
+		target: corruptDesc,
+		store:  cs,
+	}
+	client := &Client{
+		OriginalImageDesc: v1.Descriptor{
+			Digest: "sha256:9ecc53c269509f63c69a266168e4a687c7eb8c0cfd753bd8bfcaa4f58a90876f",
+		},
+		imageFetcher: func(context.Context, string, ...containerd.RemoteOpt) (containerd.Image, error) {
+			return testImage, nil
+		},
+	}
+
+	if _, err := client.FetchSignedImageManifest(ctx, "gcr.io/test/repo"); err == nil {
+		t.Error("FetchSignedImageManifest succeeded for corrupt manifest, want error")
+	}
+}
+
+func TestFetchImageSignatures_Success(t *testing.T) {
+	ctx := t.Context()
+	layerPayload := []byte("cosign-signing-payload")
+	testImage, _ := createTestImage(ctx, t, [][]byte{layerPayload})
+	client := &Client{
+		OriginalImageDesc: v1.Descriptor{
+			Digest: "sha256:9ecc53c269509f63c69a266168e4a687c7eb8c0cfd753bd8bfcaa4f58a90876f",
+		},
+		imageFetcher: func(context.Context, string, ...containerd.RemoteOpt) (containerd.Image, error) {
+			return testImage, nil
+		},
+	}
+
+	targetRepo := "gcr.io/test/repo"
+	signatures, err := client.FetchImageSignatures(ctx, targetRepo)
+	if err != nil {
+		t.Fatalf("FetchImageSignatures failed: %v", err)
+	}
+	if len(signatures) != 1 {
+		t.Fatalf("FetchImageSignatures returned %d signatures, want 1", len(signatures))
+	}
+
+	sig := signatures[0]
+	gotPayload, err := sig.Payload()
+	if err != nil {
+		t.Fatalf("sig.Payload() failed: %v", err)
+	}
+	if diff := cmp.Diff(layerPayload, gotPayload); diff != "" {
+		t.Errorf("sig.Payload() mismatch (-want +got):\n%s", diff)
+	}
+
+	gotBase64, err := sig.Base64Encoded()
+	if err != nil {
+		t.Fatalf("sig.Base64Encoded() failed: %v", err)
+	}
+	if gotBase64 != fakeBase64Sig {
+		t.Errorf("sig.Base64Encoded() = %q, want %q", gotBase64, fakeBase64Sig)
+	}
+}
+
+func TestFetchImageSignatures_PullError(t *testing.T) {
+	ctx := t.Context()
+	wantErr := errors.New("pull failure")
+	client := &Client{
+		OriginalImageDesc: v1.Descriptor{
+			Digest: "sha256:9ecc53c269509f63c69a266168e4a687c7eb8c0cfd753bd8bfcaa4f58a90876f",
+		},
+		imageFetcher: func(context.Context, string, ...containerd.RemoteOpt) (containerd.Image, error) {
+			return nil, wantErr
+		},
+	}
+
+	if _, err := client.FetchImageSignatures(ctx, "gcr.io/test/repo"); !errors.Is(err, wantErr) {
+		t.Errorf("FetchImageSignatures got err %v, want %v", err, wantErr)
+	}
+}
+
+func TestFetchImageSignatures_ManifestReadError(t *testing.T) {
+	ctx := t.Context()
+	cs, err := local.NewStore(t.TempDir())
+	if err != nil {
+		t.Fatalf("local.NewStore failed: %v", err)
+	}
+	corruptDesc := writeBlob(ctx, t, cs, []byte("invalid-manifest"), v1.MediaTypeImageManifest)
+	testImage := &fakeImage{
+		target: corruptDesc,
+		store:  cs,
+	}
+	client := &Client{
+		OriginalImageDesc: v1.Descriptor{
+			Digest: "sha256:9ecc53c269509f63c69a266168e4a687c7eb8c0cfd753bd8bfcaa4f58a90876f",
+		},
+		imageFetcher: func(context.Context, string, ...containerd.RemoteOpt) (containerd.Image, error) {
+			return testImage, nil
+		},
+	}
+
+	if _, err := client.FetchImageSignatures(ctx, "gcr.io/test/repo"); err == nil {
+		t.Error("FetchImageSignatures succeeded for corrupt manifest, want error")
+	}
+}
+
+func TestFetchImageSignatures_LayerBlobMissing(t *testing.T) {
+	ctx := t.Context()
+	cs, err := local.NewStore(t.TempDir())
+	if err != nil {
+		t.Fatalf("local.NewStore failed: %v", err)
+	}
+
+	missingLayerDesc := v1.Descriptor{
+		MediaType: v1.MediaTypeImageLayer,
+		Digest:    digest.FromString("missing-layer"),
+		Size:      100,
+	}
+	configDesc := writeBlob(ctx, t, cs, []byte("{}"), v1.MediaTypeImageConfig)
+	manifest := v1.Manifest{
+		MediaType: v1.MediaTypeImageManifest,
+		Config:    configDesc,
+		Layers: []v1.Descriptor{
+			missingLayerDesc,
+		},
+	}
+	manifest.SchemaVersion = 2
+	manifestBytes, err := json.Marshal(manifest)
+	if err != nil {
+		t.Fatalf("json.Marshal failed: %v", err)
+	}
+	manifestDesc := writeBlob(ctx, t, cs, manifestBytes, v1.MediaTypeImageManifest)
+
+	testImage := &fakeImage{
+		target: manifestDesc,
+		store:  cs,
+	}
+	client := &Client{
+		OriginalImageDesc: v1.Descriptor{
+			Digest: "sha256:9ecc53c269509f63c69a266168e4a687c7eb8c0cfd753bd8bfcaa4f58a90876f",
+		},
+		imageFetcher: func(context.Context, string, ...containerd.RemoteOpt) (containerd.Image, error) {
+			return testImage, nil
+		},
+	}
+
+	if _, err := client.FetchImageSignatures(ctx, "gcr.io/test/repo"); err == nil {
+		t.Error("FetchImageSignatures succeeded when layer blob is missing, want error")
+	}
+}
+
+func TestPullSignatureImage_WithResolver_Succeeds(t *testing.T) {
+	ctx := t.Context()
+	var passedOpts []containerd.RemoteOpt
+	client := &Client{
+		OriginalImageDesc: v1.Descriptor{
+			Digest: "sha256:905a0f3b3d6d0fb37bfa448b9e78f833b73f0b19fc97fed821a09cf49e255df1",
+		},
+		refreshResolver: func(context.Context) (remotes.Resolver, error) {
+			return registryauth.Resolver("valid access", http.DefaultClient), nil
+		},
+		imageFetcher: func(_ context.Context, _ string, opts ...containerd.RemoteOpt) (containerd.Image, error) {
+			passedOpts = opts
 			return &fakeImage{}, nil
-		}
-		return nil, fmt.Errorf("unable to fetch image")
-	}
-
-	testCases := []struct {
-		name            string
-		resolverFetcher remoteResolverFetcher
-		wantErr         bool
-	}{
-		{
-			name: "valid resolver",
-			resolverFetcher: func(_ context.Context) (remotes.Resolver, error) {
-				return registryauth.Resolver("valid access", http.DefaultClient), nil
-			},
-			wantErr: false,
-		},
-		{
-			name: "invalid resolver",
-			resolverFetcher: func(_ context.Context) (remotes.Resolver, error) {
-				return nil, fmt.Errorf("invalid resolver")
-			},
-			wantErr: true,
-		},
-		{
-			name:            "nil resolver",
-			resolverFetcher: nil,
-			wantErr:         false,
 		},
 	}
 
-	for _, tc := range testCases {
-		c := &Client{
-			OriginalImageDesc: v1.Descriptor{Digest: "sha256:905a0f3b3d6d0fb37bfa448b9e78f833b73f0b19fc97fed821a09cf49e255df1"},
-			refreshResolver:   tc.resolverFetcher,
-			imageFetcher:      imageFetcher,
-		}
-		_, err := c.pullSignatureImage(context.Background(), "fake image repo")
-		if gotErr := err != nil; gotErr != tc.wantErr {
-			t.Errorf("failed to refresh resolver when pulling container image, gotErr: %v, but wantErr: %v", gotErr, tc.wantErr)
-		}
+	img, err := client.pullSignatureImage(ctx, "fake image repo")
+	if err != nil {
+		t.Fatalf("pullSignatureImage failed: %v", err)
+	}
+	if img == nil {
+		t.Error("pullSignatureImage returned nil image, want non-nil")
+	}
+	if len(passedOpts) == 0 {
+		t.Error("pullSignatureImage did not pass remote options to image fetcher")
 	}
 }
+
+func TestPullSignatureImage_NilResolver_Succeeds(t *testing.T) {
+	ctx := t.Context()
+	var passedOpts []containerd.RemoteOpt
+	client := &Client{
+		OriginalImageDesc: v1.Descriptor{
+			Digest: "sha256:905a0f3b3d6d0fb37bfa448b9e78f833b73f0b19fc97fed821a09cf49e255df1",
+		},
+		refreshResolver: nil,
+		imageFetcher: func(_ context.Context, _ string, opts ...containerd.RemoteOpt) (containerd.Image, error) {
+			passedOpts = opts
+			return &fakeImage{}, nil
+		},
+	}
+
+	img, err := client.pullSignatureImage(ctx, "fake image repo")
+	if err != nil {
+		t.Fatalf("pullSignatureImage failed: %v", err)
+	}
+	if img == nil {
+		t.Error("pullSignatureImage returned nil image, want non-nil")
+	}
+	if len(passedOpts) != 0 {
+		t.Errorf("pullSignatureImage passed %d opts for nil resolver, want 0", len(passedOpts))
+	}
+}
+
+func TestPullSignatureImage_ResolverError_Fails(t *testing.T) {
+	ctx := t.Context()
+	wantErr := errors.New("invalid resolver")
+	client := &Client{
+		OriginalImageDesc: v1.Descriptor{
+			Digest: "sha256:905a0f3b3d6d0fb37bfa448b9e78f833b73f0b19fc97fed821a09cf49e255df1",
+		},
+		refreshResolver: func(context.Context) (remotes.Resolver, error) {
+			return nil, wantErr
+		},
+		imageFetcher: func(context.Context, string, ...containerd.RemoteOpt) (containerd.Image, error) {
+			return &fakeImage{}, nil
+		},
+	}
+
+	_, err := client.pullSignatureImage(ctx, "fake image repo")
+	if err == nil {
+		t.Fatal("pullSignatureImage succeeded with failing resolver, want error")
+	}
+	wantErrSubstr := "failed to refresh remote resolver before pulling container image: invalid resolver"
+	if !strings.Contains(err.Error(), wantErrSubstr) {
+		t.Errorf("pullSignatureImage error = %q, want substring %q", err.Error(), wantErrSubstr)
+	}
+}
+
+const fakeBase64Sig = "MEUCIQDgoiwMiVl1SAI1iePhH6Oeqztms3IwNtN+w0P92HTqQgIgKjJNcHEy0Ep4g4MH1Vd0gAHvbwH9ahD+jlnMP/rXSGE="
 
 type fakeImage struct {
 	containerd.Image
+	target v1.Descriptor
+	store  content.Store
 }
 
-func createTestClient(t *testing.T, originalImageDesc v1.Descriptor) *Client {
+func (f *fakeImage) Target() v1.Descriptor {
+	return f.target
+}
+
+func (f *fakeImage) ContentStore() content.Store {
+	return f.store
+}
+
+func (f *fakeImage) Platform() platforms.MatchComparer {
+	return platforms.All
+}
+
+func writeBlob(ctx context.Context, t *testing.T, cs content.Store, data []byte, mediaType string) v1.Descriptor {
 	t.Helper()
+	d := digest.FromBytes(data)
+	desc := v1.Descriptor{
+		MediaType: mediaType,
+		Digest:    d,
+		Size:      int64(len(data)),
+	}
+	if err := content.WriteBlob(ctx, cs, string(d), bytes.NewReader(data), desc); err != nil {
+		t.Fatalf("failed to write blob: %v", err)
+	}
+	return desc
+}
 
-	containerdClient, err := containerd.New(defaults.DefaultAddress)
+func createTestImage(ctx context.Context, t *testing.T, layers [][]byte) (containerd.Image, v1.Manifest) {
+	t.Helper()
+	cs, err := local.NewStore(t.TempDir())
 	if err != nil {
-		t.Skipf("test needs containerd daemon: %v", err)
+		t.Fatalf("failed to create local store: %v", err)
 	}
-	t.Cleanup(func() { containerdClient.Close() })
 
-	resolverFetcher := func(_ context.Context) (remotes.Resolver, error) {
-		return registryauth.Resolver("valid token", http.DefaultClient), nil
+	var layerDescs []v1.Descriptor
+	for _, layerData := range layers {
+		desc := writeBlob(ctx, t, cs, layerData, v1.MediaTypeImageLayer)
+		desc.Annotations = map[string]string{
+			cosign.CosignSigKey: fakeBase64Sig,
+		}
+		layerDescs = append(layerDescs, desc)
 	}
-	imageFetcher := func(ctx context.Context, imageRef string, opts ...containerd.RemoteOpt) (containerd.Image, error) {
-		return containerdClient.Pull(ctx, imageRef, opts...)
+
+	configDesc := writeBlob(ctx, t, cs, []byte("{}"), v1.MediaTypeImageConfig)
+
+	manifest := v1.Manifest{
+		MediaType: v1.MediaTypeImageManifest,
+		Config:    configDesc,
+		Layers:    layerDescs,
 	}
-	return &Client{
-		OriginalImageDesc: originalImageDesc,
-		refreshResolver:   resolverFetcher,
-		imageFetcher:      imageFetcher,
+	manifest.SchemaVersion = 2
+
+	manifestBytes, err := json.Marshal(manifest)
+	if err != nil {
+		t.Fatalf("failed to marshal manifest: %v", err)
 	}
+
+	manifestDesc := writeBlob(ctx, t, cs, manifestBytes, v1.MediaTypeImageManifest)
+
+	return &fakeImage{
+		target: manifestDesc,
+		store:  cs,
+	}, manifest
 }


### PR DESCRIPTION
### Overview

Previously, image initialization and signature discovery unit tests attempted to connect to a local containerd daemon (`/run/containerd/containerd.sock`) to pull live container images from public registries.

This caused two problems:
1. Local Developer Latency: On developer machines where containerd is not running, each test blocked for containerd's default 10-second gRPC dial timeout before calling `t.Skipf`, adding ~30 seconds of dead time to `go test ./launcher/...`.
2. Untested Production Code in CI: In GitHub Actions CI runners, the containerd socket exists as a root-owned Unix domain socket. Standard test runs executed as user `runner` and immediately skipped due to permission errors. The explicit root workflow step introduced in #343 to run under `sudo` never actually ran the tests due to a directory targeting mismatch.

### Concrete Evidence: CI Logs & History

From GitHub Actions CI Run `33904062103` (Job `101124680204`, "Test Linux (amd64)"):

#### 1. The root step was a no-op that never executed tests
The workflow step `Run specific tests under root permission` executed:
```bash
sudo $GO_EXECUTABLE_PATH test -v -ldflags="-extldflags=-Wl,-z,lazy" -run "TestFetchImageSignaturesDockerPublic" ./launcher
```
Verbatim CI log output:
```
Test Linux (amd64)	Run specific tests under root permission	2026-09-04T18:11:25.3001075Z testing: warning: no tests to run
Test Linux (amd64)	Run specific tests under root permission	2026-09-04T18:11:25.3001305Z PASS
Test Linux (amd64)	Run specific tests under root permission	2026-09-04T18:11:25.3001601Z ok  	github.com/google/go-tpm-tools/launcher	0.011s [no tests to run]
```
Because the command targeted `./launcher` rather than `./launcher/internal/signaturediscovery`, the Go test runner found zero matching test functions and exited in 11ms. The test has never run under root in CI.

#### 2. Non-root CI test runs unconditionally skipped due to socket permissions
In the subsequent step `Run all tests in launcher to capture potential data race`, the runner executed as user `runner`:
```
Test Linux (amd64)	Run all tests in launcher to capture potential data race	2026-09-04T18:13:14.8595810Z === RUN   TestInitImageDockerPublic
Test Linux (amd64)	Run all tests in launcher to capture potential data race	2026-09-04T18:13:14.8596992Z     container_runner_test.go:712: test needs containerd daemon: failed to dial "/run/containerd/containerd.sock": connection error: desc = "transport: error while dialing: dial unix /run/containerd/containerd.sock: connect: permission denied"
Test Linux (amd64)	Run all tests in launcher to capture potential data race	2026-09-04T18:13:14.8597957Z --- SKIP: TestInitImageDockerPublic (0.00s)
...
Test Linux (amd64)	Run all tests in launcher to capture potential data race	2026-09-04T18:13:14.8718517Z === RUN   TestFetchSignedImageManifestDockerPublic
Test Linux (amd64)	Run all tests in launcher to capture potential data race	2026-09-04T18:13:14.8719692Z     client_test.go:59: test needs containerd daemon: failed to dial "/run/containerd/containerd.sock": connection error: desc = "transport: error while dialing: dial unix /run/containerd/containerd.sock: connect: permission denied"
Test Linux (amd64)	Run all tests in launcher to capture potential data race	2026-09-04T18:13:14.8720663Z --- SKIP: TestFetchSignedImageManifestDockerPublic (0.00s)
Test Linux (amd64)	Run all tests in launcher to capture potential data race	2026-09-04T18:13:14.8721044Z === RUN   TestFetchImageSignaturesDockerPublic
Test Linux (amd64)	Run all tests in launcher to capture potential data race	2026-09-04T18:13:14.8722185Z     client_test.go:71: test needs containerd daemon: failed to dial "/run/containerd/containerd.sock": connection error: desc = "transport: error while dialing: dial unix /run/containerd/containerd.sock: connect: permission denied"
Test Linux (amd64)	Run all tests in launcher to capture potential data race	2026-09-04T18:13:14.8723119Z --- SKIP: TestFetchImageSignaturesDockerPublic (0.00s)
```

The production code paths for image initialization, manifest fetching, and signature extraction have had 0% executed test coverage in CI.

### Solution

1. Hermetic Signature Discovery Tests: Replaced live daemon dials in `launcher/internal/signaturediscovery/client_test.go` with focused unit tests backed by temporary in-memory/tempdir OCI content stores (`containerd/content/local`). Tests cover valid manifest resolution, corrupt manifests, layer signature extraction, missing layer blobs, and pull errors in <10ms without dialing any daemon.
2. Hermetic Image Initialization Tests: Replaced live containerd calls in `launcher/image_test.go` with unit tests using `fakeContainerdClient`. Distinct behaviors for authenticated pulls, unauthenticated public pulls, and error propagation are tested in separate functions.
3. Instant Retry Backoffs: Wrapped retry loops under `testing/synctest` so exponential backoff sleeps advance synthetic time instantly.
4. Remove Obsolete CI Root Step: Removed `Run specific tests under root permission` from `.github/workflows/ci.yml`. All unit tests now execute hermetically in user space without requiring root privileges or external daemons.

### Performance Impact

- `launcher/internal/signaturediscovery`: 20.15s → 0.37s
- `launcher`: 12.69s → 1.27s
- Total latency reduction: ~31.2s
