### PR TITLE
ci: update rust toolchain action pin

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,7 @@ jobs:
       - name: Install protoc-gen-go
         run: go install google.golang.org/protobuf/cmd/protoc-gen-go@${{ env.PROTOC_GEN_GO_VERSION }}
       - name: Setup Rust
-        uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
+        uses: dtolnay/rust-toolchain@6bed0761d98439e5a578e2877258200ad565ba87 # stable
         with:
           toolchain: stable
       - name: Install Build Dependencies (Linux)
@@ -180,7 +180,7 @@ jobs:
           go-version: ${{ env.GO_VERSION }}
           cache: false
       - name: Setup Rust
-        uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
+        uses: dtolnay/rust-toolchain@6bed0761d98439e5a578e2877258200ad565ba87 # stable
         with:
           toolchain: stable
       - name: Install Build Dependencies (Linux)
@@ -220,7 +220,7 @@ jobs:
           go-version: ${{ env.GO_VERSION }}
           cache: false
       - name: Setup Rust
-        uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
+        uses: dtolnay/rust-toolchain@6bed0761d98439e5a578e2877258200ad565ba87 # stable
         with:
           toolchain: stable
       - name: Install Build Dependencies (Linux)

--- a/.github/workflows/releaser.yaml
+++ b/.github/workflows/releaser.yaml
@@ -52,7 +52,7 @@ jobs:
         run: sudo DEBIAN_FRONTEND=noninteractive apt-get update -o Acquire::Retries=3 -o Acquire::http::Timeout="30" && sudo DEBIAN_FRONTEND=noninteractive apt-get install -y -o Acquire::Retries=3 -o Acquire::http::Timeout="30" libssl-dev cmake clang pkg-config
         if: runner.os == 'Linux'
       - name: Setup Rust
-        uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
+        uses: dtolnay/rust-toolchain@6bed0761d98439e5a578e2877258200ad565ba87 # stable
       - name: Install bindgen-cli
         run: cargo install bindgen-cli
         if: runner.os == 'Linux'


### PR DESCRIPTION
Upstream rebased its stable branch, causing the previously pinned commit SHA to become unreachable from any reference in the remote repository. Automated workflow security scanners flagged the orphaned commit as an impostor commit with no history in the referenced repository.

This updates the action pin across workflow configurations to the current reachable commit on the stable branch.
